### PR TITLE
Fix uinput ACL conflict with brltty

### DIFF
--- a/contrib/99-whisrs.rules
+++ b/contrib/99-whisrs.rules
@@ -1,4 +1,10 @@
 # Allow members of the "input" group to access /dev/uinput
 # Install: sudo cp 99-whisrs.rules /etc/udev/rules.d/
 # Reload: sudo udevadm control --reload-rules && sudo udevadm trigger
+#
+# Note: MODE/GROUP alone are not enough if another udev rule (e.g. brltty)
+# sets an ACL on /dev/uinput, because ACLs override traditional Unix group
+# permissions. The setfacl call below ensures the input group always has
+# read-write access regardless of ACL state.
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", TAG+="uaccess"
+KERNEL=="uinput", SUBSYSTEM=="misc", TEST=="/usr/bin/setfacl", RUN+="/usr/bin/setfacl -m g:input:rw /dev/$name"

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -622,7 +622,7 @@ fn setup_uinput_permissions() {
                         }
                     } else {
                         // Write the rule inline if contrib file not found.
-                        let rule = "KERNEL==\"uinput\", SUBSYSTEM==\"misc\", MODE=\"0660\", GROUP=\"input\", TAG+=\"uaccess\"";
+                        let rule = "KERNEL==\"uinput\", SUBSYSTEM==\"misc\", MODE=\"0660\", GROUP=\"input\", TAG+=\"uaccess\"\nKERNEL==\"uinput\", SUBSYSTEM==\"misc\", TEST==\"/usr/bin/setfacl\", RUN+=\"/usr/bin/setfacl -m g:input:rw /dev/$name\"";
                         let status = std::process::Command::new("sudo")
                             .args([
                                 "bash",


### PR DESCRIPTION
## Summary
- brltty's udev rule sets ACLs on `/dev/uinput`, which override traditional Unix group permissions and block the `input` group
- Added explicit `setfacl -m g:input:rw` to `contrib/99-whisrs.rules` so permissions survive ACL interference
- Updated the inline fallback in `setup.rs` to include the same fix

## Test plan
- [x] Verified `/dev/uinput` was denied due to ACL `group::---` overriding `MODE=0660`
- [x] Applied updated udev rule, confirmed daemon can write to uinput again
- [x] All 125 tests pass, clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)