### PR TITLE
Fix command mode and hotkeys not working on boot

### DIFF
--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixListener;
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use whisrs::audio::capture::AudioCaptureHandle;
 use whisrs::audio::feedback;
@@ -164,6 +165,98 @@ fn load_config() -> (Config, Option<String>) {
         },
         None,
     )
+}
+
+/// Maximum number of attempts to detect compositor environment.
+const COMPOSITOR_ENV_MAX_RETRIES: u32 = 10;
+
+/// Initial retry delay for compositor env detection (doubles each attempt, capped at 10 s).
+const COMPOSITOR_ENV_INITIAL_DELAY: Duration = Duration::from_secs(1);
+
+/// Compositor environment variables to import from systemd.
+const COMPOSITOR_ENV_VARS: &[&str] = &[
+    "WAYLAND_DISPLAY",
+    "DISPLAY",
+    "HYPRLAND_INSTANCE_SIGNATURE",
+    "SWAYSOCK",
+    "XDG_CURRENT_DESKTOP",
+];
+
+/// Wait for compositor environment variables to become available.
+///
+/// When the daemon starts via systemd on boot, it may launch before the
+/// compositor sets session environment variables (WAYLAND_DISPLAY, etc.).
+/// Without these, clipboard operations (wl-paste) and window tracking fail.
+///
+/// Polls `systemctl --user show-environment` with exponential backoff until
+/// a display server variable is found, then imports all compositor-related
+/// vars into the process environment.
+async fn import_compositor_env() {
+    // Already have a display server — nothing to do.
+    if std::env::var("WAYLAND_DISPLAY").is_ok() || std::env::var("DISPLAY").is_ok() {
+        debug!("compositor environment already available");
+        return;
+    }
+
+    info!("compositor env vars not set — polling systemd user environment");
+
+    let mut delay = COMPOSITOR_ENV_INITIAL_DELAY;
+
+    for attempt in 1..=COMPOSITOR_ENV_MAX_RETRIES {
+        if let Some(imported) = try_import_from_systemd() {
+            info!("imported compositor environment from systemd (attempt {attempt}): {imported}");
+            return;
+        }
+
+        if attempt == COMPOSITOR_ENV_MAX_RETRIES {
+            warn!(
+                "compositor environment not available after {COMPOSITOR_ENV_MAX_RETRIES} attempts \
+                 — clipboard and window tracking may not work"
+            );
+            return;
+        }
+
+        info!(
+            "compositor env not available (attempt {attempt}/{COMPOSITOR_ENV_MAX_RETRIES}) \
+             — retrying in {delay:?}"
+        );
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(Duration::from_secs(10));
+    }
+}
+
+/// Try to read compositor env vars from systemd's user environment.
+///
+/// Returns a summary string of imported vars on success, or None if no
+/// display server variable was found.
+fn try_import_from_systemd() -> Option<String> {
+    let output = std::process::Command::new("systemctl")
+        .args(["--user", "show-environment"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut imported = Vec::new();
+
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            if COMPOSITOR_ENV_VARS.contains(&key) && std::env::var(key).is_err() {
+                std::env::set_var(key, value);
+                imported.push(key.to_string());
+            }
+        }
+    }
+
+    // Only succeed if we found a display server.
+    if std::env::var("WAYLAND_DISPLAY").is_ok() || std::env::var("DISPLAY").is_ok() {
+        Some(imported.join(", "))
+    } else {
+        None
+    }
 }
 
 fn check_uinput_access() {
@@ -383,6 +476,10 @@ async fn main() -> Result<()> {
     }
 
     let backend = create_backend(&config);
+
+    // Wait for compositor environment on boot (WAYLAND_DISPLAY, etc.).
+    // Must run before window tracker detection and any clipboard operations.
+    import_compositor_env().await;
 
     let window_tracker: Arc<dyn WindowTracker> = Arc::from(window::detect_tracker());
     info!(

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -434,14 +434,16 @@ async fn main() -> Result<()> {
     });
 
     // Start global hotkey listener if configured.
+    // Spawned as a background task so retries don't block the IPC server.
     if let Some(ref hk_config) = context.config.hotkeys {
-        let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::channel::<Command>(16);
-        whisrs::hotkey::start_hotkey_listener(hk_config, hotkey_tx).await;
-
-        // Process hotkey commands in the background.
+        let hk_config = hk_config.clone();
         let hk_state = Arc::clone(&daemon_state);
         let hk_ctx = Arc::clone(&context);
         tokio::spawn(async move {
+            let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::channel::<Command>(16);
+            whisrs::hotkey::start_hotkey_listener(&hk_config, hotkey_tx).await;
+
+            // Process hotkey commands.
             while let Some(cmd) = hotkey_rx.recv().await {
                 info!("hotkey command: {cmd:?}");
                 let _response =

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -89,10 +89,7 @@ pub async fn start_hotkey_listener(config: &HotkeyConfig, cmd_tx: mpsc::Sender<C
         match enumerate_keyboards() {
             Ok(d) if !d.is_empty() => {
                 if attempt > 1 {
-                    info!(
-                        "found {} keyboard device(s) (attempt {attempt})",
-                        d.len()
-                    );
+                    info!("found {} keyboard device(s) (attempt {attempt})", d.len());
                 }
                 devices = d;
                 break;

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -7,6 +7,7 @@ mod parse;
 
 use std::collections::HashSet;
 use std::path::Path;
+use std::time::Duration;
 
 use evdev::{Device, EventType, InputEventKind, Key};
 use tokio::sync::mpsc;
@@ -14,6 +15,12 @@ use tracing::{debug, info, warn};
 
 use crate::{Command, HotkeyConfig};
 pub use parse::{parse_hotkey, HotkeyBinding};
+
+/// Maximum number of attempts to find keyboard input devices.
+const HOTKEY_MAX_RETRIES: u32 = 10;
+
+/// Initial retry delay (doubles each attempt, capped at 10 s).
+const HOTKEY_INITIAL_DELAY: Duration = Duration::from_secs(1);
 
 /// A configured hotkey action.
 struct HotkeyAction {
@@ -24,7 +31,9 @@ struct HotkeyAction {
 /// Start the global hotkey listener.
 ///
 /// Enumerates keyboard input devices, listens for key events, and sends
-/// matching commands through the provided channel. Runs until dropped.
+/// matching commands through the provided channel. Retries with exponential
+/// backoff if no keyboards are found yet (common on boot when the daemon
+/// starts before input devices are fully initialized). Runs until dropped.
 pub async fn start_hotkey_listener(config: &HotkeyConfig, cmd_tx: mpsc::Sender<Command>) {
     let mut actions = Vec::new();
 
@@ -72,18 +81,48 @@ pub async fn start_hotkey_listener(config: &HotkeyConfig, cmd_tx: mpsc::Sender<C
         return;
     }
 
-    // Find all keyboard input devices.
-    let devices = match enumerate_keyboards() {
-        Ok(d) if d.is_empty() => {
-            warn!("no keyboard input devices found — hotkeys disabled");
-            return;
+    // Find keyboard input devices, retrying with backoff on boot.
+    let mut delay = HOTKEY_INITIAL_DELAY;
+    let mut devices = Vec::new();
+
+    for attempt in 1..=HOTKEY_MAX_RETRIES {
+        match enumerate_keyboards() {
+            Ok(d) if !d.is_empty() => {
+                if attempt > 1 {
+                    info!(
+                        "found {} keyboard device(s) (attempt {attempt})",
+                        d.len()
+                    );
+                }
+                devices = d;
+                break;
+            }
+            Ok(_) => {
+                if attempt == HOTKEY_MAX_RETRIES {
+                    warn!(
+                        "no keyboard input devices found after {HOTKEY_MAX_RETRIES} attempts — hotkeys disabled"
+                    );
+                    return;
+                }
+                info!(
+                    "no keyboard devices found (attempt {attempt}/{HOTKEY_MAX_RETRIES}) — retrying in {delay:?}"
+                );
+            }
+            Err(e) => {
+                if attempt == HOTKEY_MAX_RETRIES {
+                    warn!(
+                        "failed to enumerate input devices after {HOTKEY_MAX_RETRIES} attempts: {e} — hotkeys disabled"
+                    );
+                    return;
+                }
+                info!(
+                    "failed to enumerate input devices (attempt {attempt}/{HOTKEY_MAX_RETRIES}): {e} — retrying in {delay:?}"
+                );
+            }
         }
-        Ok(d) => d,
-        Err(e) => {
-            warn!("failed to enumerate input devices: {e} — hotkeys disabled");
-            return;
-        }
-    };
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(Duration::from_secs(10));
+    }
 
     info!(
         "hotkey listener monitoring {} keyboard device(s)",


### PR DESCRIPTION
## Summary
- **Root cause**: When the daemon starts via systemd on boot, compositor env vars (`WAYLAND_DISPLAY`, `HYPRLAND_INSTANCE_SIGNATURE`) aren't in the process environment yet. This causes clipboard ops to fall back to X11/arboard which hangs indefinitely on Wayland-only systems, completely breaking command mode. Window tracker also falls back to noop.
- **Fix**: Poll `systemctl --user show-environment` with exponential backoff at daemon startup to import compositor env vars once the session is ready. Also added retry with backoff to the built-in hotkey listener's keyboard enumeration for the same boot-timing reason.

## Test plan
- [ ] Boot machine with `whisrs.service` enabled, verify command mode works without restarting the daemon
- [ ] Check `journalctl --user -u whisrs` for "imported compositor environment from systemd" log on boot
- [ ] Verify window tracker detects Hyprland (not noop) after env import
- [ ] Verify no delay when starting the daemon manually (env vars already present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)