### PR TITLE
Fix panic on Cyrillic/non-ASCII text in notifications

### DIFF
--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -433,6 +433,21 @@ fn get_model_for_backend(config: &Config) -> String {
     }
 }
 
+/// Truncate a string to at most `max_bytes` bytes, respecting UTF-8 char
+/// boundaries. Appends "..." if truncated.
+fn truncate_preview(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let end = text
+        .char_indices()
+        .map(|(i, _)| i)
+        .take_while(|&i| i <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    format!("{}...", &text[..end])
+}
+
 fn send_notification(summary: &str, body: &str) {
     let summary = summary.to_string();
     let body = body.to_string();
@@ -819,11 +834,7 @@ async fn handle_toggle(
                                         );
                                     }
                                     if context.notify {
-                                        let preview = if text.len() > 80 {
-                                            format!("{}...", &text[..77])
-                                        } else {
-                                            text.clone()
-                                        };
+                                        let preview = truncate_preview(&text, 77);
                                         send_notification("whisrs", &format!("Done: {preview}"));
                                     }
                                     Response::Ok { state: new_state }
@@ -1048,11 +1059,7 @@ async fn run_streaming_pipeline(
             feedback::play_done(audio_feedback_volume);
         }
         if notify {
-            let preview = if full_text.len() > 80 {
-                format!("{}...", &full_text[..77])
-            } else {
-                full_text.clone()
-            };
+            let preview = truncate_preview(&full_text, 77);
             if !preview.is_empty() {
                 send_notification("whisrs", &format!("Done: {preview}"));
             }
@@ -1836,5 +1843,92 @@ async fn handle_cancel(
         Err(e) => Response::Error {
             message: e.to_string(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_ascii_short() {
+        assert_eq!(truncate_preview("hello", 77), "hello");
+    }
+
+    #[test]
+    fn truncate_ascii_exact() {
+        let text = "a".repeat(77);
+        assert_eq!(truncate_preview(&text, 77), text);
+    }
+
+    #[test]
+    fn truncate_ascii_long() {
+        let text = "a".repeat(100);
+        let expected = format!("{}...", "a".repeat(77));
+        assert_eq!(truncate_preview(&text, 77), expected);
+    }
+
+    #[test]
+    fn truncate_cyrillic() {
+        // Cyrillic chars are 2 bytes each. 40 Cyrillic chars = 80 bytes > 77.
+        let text = "а".repeat(40); // 80 bytes
+        let preview = truncate_preview(&text, 77);
+        assert!(preview.ends_with("..."));
+        // Should truncate to 38 chars (76 bytes) + "..." since 39 chars = 78 bytes > 77.
+        assert_eq!(preview, format!("{}...", "а".repeat(38)));
+    }
+
+    #[test]
+    fn truncate_cyrillic_issue_repro() {
+        // Exact text from issue #4.
+        let text = "Вот это рутина, блять, вы дешевые щели, блять.";
+        let preview = truncate_preview(text, 77);
+        // Must not panic and must be valid UTF-8.
+        assert!(preview.is_char_boundary(0));
+        assert!(!preview.is_empty());
+    }
+
+    #[test]
+    fn truncate_cjk() {
+        // CJK chars are 3 bytes each. 27 CJK chars = 81 bytes > 77.
+        let text = "字".repeat(27);
+        let preview = truncate_preview(&text, 77);
+        assert!(preview.ends_with("..."));
+        // 25 chars = 75 bytes (fits), 26 chars = 78 bytes (too big).
+        assert_eq!(preview, format!("{}...", "字".repeat(25)));
+    }
+
+    #[test]
+    fn truncate_arabic() {
+        // Arabic chars are 2 bytes each. 40 Arabic chars = 80 bytes > 77.
+        let text = "ش".repeat(40);
+        let preview = truncate_preview(&text, 77);
+        assert!(preview.ends_with("..."));
+        assert_eq!(preview, format!("{}...", "ش".repeat(38)));
+    }
+
+    #[test]
+    fn truncate_emoji() {
+        // Emoji are 4 bytes each. 20 emoji = 80 bytes > 77.
+        let text = "😀".repeat(20);
+        let preview = truncate_preview(&text, 77);
+        assert!(preview.ends_with("..."));
+        // 19 emoji = 76 bytes (fits).
+        assert_eq!(preview, format!("{}...", "😀".repeat(19)));
+    }
+
+    #[test]
+    fn truncate_mixed_scripts() {
+        // Mix of ASCII (1 byte), Cyrillic (2 bytes), CJK (3 bytes).
+        let text = "Hello Мир 世界! This is a test of mixed script truncation that is long enough";
+        let preview = truncate_preview(text, 77);
+        assert!(preview.ends_with("..."));
+        // Verify it doesn't panic and produces valid UTF-8.
+        assert!(preview.len() <= 80); // 77 + "..."
+    }
+
+    #[test]
+    fn truncate_empty() {
+        assert_eq!(truncate_preview("", 77), "");
     }
 }

--- a/src/post_processing/filler.rs
+++ b/src/post_processing/filler.rs
@@ -228,4 +228,72 @@ mod tests {
     fn filler_with_comma() {
         assert_eq!(remove_filler_words("like, it was good", &[]), "it was good");
     }
+
+    // --- Non-ASCII language tests ---
+
+    #[test]
+    fn cyrillic_no_fillers() {
+        let text = "Привет мир, как дела?";
+        assert_eq!(remove_filler_words(text, &[]), text);
+    }
+
+    #[test]
+    fn cyrillic_with_english_filler() {
+        // Transcription APIs sometimes mix English fillers into non-English text.
+        assert_eq!(remove_filler_words("um Привет мир", &[]), "Привет мир");
+    }
+
+    #[test]
+    fn cyrillic_stutter_removal() {
+        assert_eq!(remove_filler_words("я я пошёл домой", &[]), "я пошёл домой");
+    }
+
+    #[test]
+    fn arabic_no_fillers() {
+        let text = "مرحبا بالعالم";
+        assert_eq!(remove_filler_words(text, &[]), text);
+    }
+
+    #[test]
+    fn arabic_stutter_removal() {
+        assert_eq!(remove_filler_words("هذا هذا اختبار", &[]), "هذا اختبار");
+    }
+
+    #[test]
+    fn cjk_no_fillers() {
+        let text = "你好世界";
+        assert_eq!(remove_filler_words(text, &[]), text);
+    }
+
+    #[test]
+    fn japanese_no_fillers() {
+        let text = "こんにちは世界";
+        assert_eq!(remove_filler_words(text, &[]), text);
+    }
+
+    #[test]
+    fn korean_no_fillers() {
+        let text = "안녕하세요 세계";
+        assert_eq!(remove_filler_words(text, &[]), text);
+    }
+
+    #[test]
+    fn mixed_script_with_filler() {
+        assert_eq!(
+            remove_filler_words("basically Привет, 世界 uh okay", &[]),
+            "Привет, 世界 okay"
+        );
+    }
+
+    #[test]
+    fn custom_cyrillic_filler() {
+        let custom = vec!["ну".to_string(), "типа".to_string()];
+        assert_eq!(remove_filler_words("ну типа я пошёл", &custom), "я пошёл");
+    }
+
+    #[test]
+    fn emoji_in_text() {
+        let text = "um 😀 that was basically 🎉 great";
+        assert_eq!(remove_filler_words(text, &[]), "😀 that was 🎉 great");
+    }
 }


### PR DESCRIPTION
## Summary
- Notification preview truncation used byte-index slicing (`&text[..77]`) which panics on multi-byte UTF-8 characters (Cyrillic, CJK, Arabic, emoji)
- Replaced with a `truncate_preview()` helper that walks `char_indices()` to find the nearest valid char boundary
- Added 10 truncation tests covering Cyrillic, CJK, Arabic, emoji, and mixed scripts
- Added 11 filler removal tests for non-ASCII languages to ensure regex processing is safe

Closes #4

## Test plan
- [ ] Dictate in Russian with `remove_filler_words = true` and notifications enabled
- [ ] Dictate in Arabic / CJK / mixed-language text longer than 80 bytes
- [ ] Verify notification previews show correctly truncated text without panic
- [ ] Run `cargo test` — all 146 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)