### PR TITLE
Add Deepgram transcription backend (REST + streaming)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **Linux-first voice-to-text dictation tool, written in Rust.**
 
-Speech-to-text for Wayland, X11, Hyprland, Sway, GNOME, and KDE. Press a hotkey, speak, and your words appear at the cursor. Works with any app, any window manager, any desktop environment. Supports cloud transcription (Groq, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source.
+Speech-to-text for Wayland, X11, Hyprland, Sway, GNOME, and KDE. Press a hotkey, speak, and your words appear at the cursor. Works with any app, any window manager, any desktop environment. Supports cloud transcription (Groq, Deepgram, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source.
 
 ---
 
@@ -127,11 +127,15 @@ bindsym $mod+w exec whisrs toggle
 | Backend | Type | Streaming | Cost | Best for |
 |---|---|---|---|---|
 | **Groq** | Cloud | Batch | Free tier available | Getting started, budget use |
+| **Deepgram Streaming** | Cloud (WebSocket) | True streaming | $200 free credit | Streaming with free credits |
+| **Deepgram REST** | Cloud | Batch | $200 free credit | Simple, 60+ languages |
 | **OpenAI Realtime** | Cloud (WebSocket) | True streaming | Paid | Best UX, text as you speak |
 | **OpenAI REST** | Cloud | Batch | Paid | Simple fallback |
 | **Local whisper.cpp** | Local (CPU/GPU) | Sliding window | Free | Privacy, offline use |
 
 Groq is the default. Fast, free tier, good accuracy with `whisper-large-v3-turbo`.
+
+Deepgram offers $200 in free credits on signup (no credit card required) and supports 60+ languages with the Nova-3 model. The streaming backend provides true real-time transcription over WebSocket.
 
 OpenAI Realtime is the premium option: true streaming over WebSocket means text appears at your cursor while you're still speaking.
 
@@ -157,7 +161,7 @@ Config file: `~/.config/whisrs/config.toml`
 
 ```toml
 [general]
-backend = "groq"            # groq | openai-realtime | openai | local-whisper
+backend = "groq"            # groq | deepgram-streaming | deepgram | openai-realtime | openai | local-whisper
 language = "en"             # ISO 639-1 or "auto"
 silence_timeout_ms = 2000   # auto-stop after silence (streaming only)
 notify = true               # desktop notifications
@@ -174,6 +178,10 @@ device = "default"
 [groq]
 api_key = "gsk_..."
 model = "whisper-large-v3-turbo"
+
+[deepgram]
+api_key = "..."
+model = "nova-3"
 
 [openai]
 api_key = "sk-..."
@@ -195,7 +203,7 @@ cancel = "Super+Shift+D"
 command = "Super+Shift+G"
 ```
 
-Environment variable overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_OPENAI_API_KEY`
+Environment variable overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, `WHISRS_OPENAI_API_KEY`
 
 ---
 
@@ -236,7 +244,7 @@ whisrs is functional and usable for daily dictation. The core features work:
 
 - [x] Daemon + CLI architecture
 - [x] Audio capture and WAV encoding
-- [x] Groq, OpenAI REST, and OpenAI Realtime backends
+- [x] Groq, Deepgram (REST + streaming), OpenAI REST, and OpenAI Realtime backends
 - [x] Local whisper.cpp backend (sliding window, prompt conditioning, model download)
 - [x] Layout-aware keyboard injection (uinput + XKB)
 - [x] Wayland/X11 clipboard with save/restore

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -12,7 +12,10 @@ use anyhow::{Context, Result};
 use dialoguer::{Confirm, Input, Password, Select};
 
 use crate::llm::LlmConfig;
-use crate::{AudioConfig, Config, GeneralConfig, GroqConfig, LocalWhisperConfig, OpenAiConfig};
+use crate::{
+    AudioConfig, Config, DeepgramConfig, GeneralConfig, GroqConfig, LocalWhisperConfig,
+    OpenAiConfig,
+};
 
 // ANSI color codes.
 const GREEN: &str = "\x1b[32m";
@@ -24,14 +27,23 @@ const RESET: &str = "\x1b[0m";
 
 /// Backend choices presented to the user.
 const BACKEND_CHOICES: &[&str] = &[
-    "Groq            (free, fast, cloud)",
-    "OpenAI Realtime (best streaming, cloud)",
-    "OpenAI REST     (simple, cloud)",
-    "Local           (offline, no API key needed)",
+    "Groq               (free, fast, cloud)",
+    "Deepgram Streaming (free credits, true streaming, cloud)",
+    "Deepgram REST      (free credits, simple, cloud)",
+    "OpenAI Realtime    (best streaming, cloud)",
+    "OpenAI REST        (simple, cloud)",
+    "Local              (offline, no API key needed)",
 ];
 
 /// Map selection index to backend string used in config.
-const BACKEND_VALUES: &[&str] = &["groq", "openai-realtime", "openai", "local"];
+const BACKEND_VALUES: &[&str] = &[
+    "groq",
+    "deepgram-streaming",
+    "deepgram",
+    "openai-realtime",
+    "openai",
+    "local",
+];
 
 /// Whisper model choices (name, file size, description).
 const WHISPER_MODEL_CHOICES: &[&str] = &[
@@ -90,7 +102,8 @@ pub fn run_setup() -> Result<()> {
     let backend = select_backend(None)?;
 
     // 2. Configure backend (API key or model download).
-    let (groq_config, openai_config, local_whisper_config) = configure_backend(&backend, None)?;
+    let (deepgram_config, groq_config, openai_config, local_whisper_config) =
+        configure_backend(&backend, None)?;
 
     // 3. Language.
     let language = select_language(None)?;
@@ -121,6 +134,7 @@ pub fn run_setup() -> Result<()> {
         audio: AudioConfig {
             device: "default".to_string(),
         },
+        deepgram: deepgram_config,
         groq: groq_config,
         openai: openai_config,
         local_whisper: local_whisper_config,
@@ -159,9 +173,11 @@ fn select_backend(existing: Option<&Config>) -> Result<String> {
             let b = cfg.general.backend.as_str();
             match b {
                 "groq" => 0,
-                "openai-realtime" => 1,
-                "openai" => 2,
-                _ if b.starts_with("local") => 3,
+                "deepgram-streaming" => 1,
+                "deepgram" => 2,
+                "openai-realtime" => 3,
+                "openai" => 4,
+                _ if b.starts_with("local") => 5,
                 _ => 0,
             }
         })
@@ -217,15 +233,32 @@ fn select_local_engine() -> Result<String> {
 }
 
 /// Configure the selected backend (API key or model path).
+#[allow(clippy::type_complexity)]
 fn configure_backend(
     backend: &str,
     existing: Option<&Config>,
 ) -> Result<(
+    Option<DeepgramConfig>,
     Option<GroqConfig>,
     Option<OpenAiConfig>,
     Option<LocalWhisperConfig>,
 )> {
     match backend {
+        "deepgram" | "deepgram-streaming" => {
+            let existing_key = existing
+                .and_then(|c| c.deepgram.as_ref())
+                .map(|d| &d.api_key);
+            let api_key = prompt_api_key_with_existing(
+                "Deepgram API key",
+                "Get one free ($200 credit) at https://console.deepgram.com/signup",
+                existing_key,
+            )?;
+            let model = existing
+                .and_then(|c| c.deepgram.as_ref())
+                .map(|d| d.model.clone())
+                .unwrap_or_else(|| "nova-3".to_string());
+            Ok((Some(DeepgramConfig { api_key, model }), None, None, None))
+        }
         "groq" => {
             let existing_key = existing.and_then(|c| c.groq.as_ref()).map(|g| &g.api_key);
             let api_key = prompt_api_key_with_existing(
@@ -237,7 +270,7 @@ fn configure_backend(
                 .and_then(|c| c.groq.as_ref())
                 .map(|g| g.model.clone())
                 .unwrap_or_else(|| "whisper-large-v3-turbo".to_string());
-            Ok((Some(GroqConfig { api_key, model }), None, None))
+            Ok((None, Some(GroqConfig { api_key, model }), None, None))
         }
         "openai-realtime" | "openai" => {
             let existing_key = existing.and_then(|c| c.openai.as_ref()).map(|o| &o.api_key);
@@ -266,7 +299,7 @@ fn configure_backend(
                 }
                 .to_string()
             };
-            Ok((None, Some(OpenAiConfig { api_key, model }), None))
+            Ok((None, None, Some(OpenAiConfig { api_key, model }), None))
         }
         "local-whisper" => {
             // Select model size.
@@ -306,9 +339,9 @@ fn configure_backend(
             }
 
             let model_path = dest.to_string_lossy().to_string();
-            Ok((None, None, Some(LocalWhisperConfig { model_path })))
+            Ok((None, None, None, Some(LocalWhisperConfig { model_path })))
         }
-        _ => Ok((None, None, None)),
+        _ => Ok((None, None, None, None)),
     }
 }
 

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -16,6 +16,7 @@ use whisrs::input::ClipboardHandler;
 use whisrs::llm;
 use whisrs::post_processing::filler::remove_filler_words;
 use whisrs::state::{Action, StateMachine};
+use whisrs::transcription::deepgram::{DeepgramRestBackend, DeepgramStreamingBackend};
 use whisrs::transcription::groq::GroqBackend;
 use whisrs::transcription::local_parakeet::ParakeetBackend;
 use whisrs::transcription::local_vosk::VoskBackend;
@@ -111,6 +112,7 @@ fn load_config() -> (Config, Option<String>) {
                         Config {
                             general: Default::default(),
                             audio: Default::default(),
+                            deepgram: None,
                             groq: None,
                             openai: None,
                             local_whisper: None,
@@ -133,6 +135,7 @@ fn load_config() -> (Config, Option<String>) {
                     Config {
                         general: Default::default(),
                         audio: Default::default(),
+                        deepgram: None,
                         groq: None,
                         openai: None,
                         local_whisper: None,
@@ -155,6 +158,7 @@ fn load_config() -> (Config, Option<String>) {
         Config {
             general: Default::default(),
             audio: Default::default(),
+            deepgram: None,
             groq: None,
             openai: None,
             local_whisper: None,
@@ -335,8 +339,33 @@ fn resolve_openai_api_key(config: &Config) -> Option<String> {
     config.openai.as_ref().map(|o| o.api_key.clone())
 }
 
+fn resolve_deepgram_api_key(config: &Config) -> Option<String> {
+    if let Ok(key) = std::env::var("WHISRS_DEEPGRAM_API_KEY") {
+        if !key.is_empty() {
+            return Some(key);
+        }
+    }
+    config.deepgram.as_ref().map(|d| d.api_key.clone())
+}
+
 fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
     match config.general.backend.as_str() {
+        "deepgram" => {
+            let api_key = resolve_deepgram_api_key(config).unwrap_or_default();
+            if api_key.is_empty() {
+                warn!("no Deepgram API key configured");
+            }
+            info!("using Deepgram REST transcription backend");
+            Arc::new(DeepgramRestBackend::new(api_key))
+        }
+        "deepgram-streaming" => {
+            let api_key = resolve_deepgram_api_key(config).unwrap_or_default();
+            if api_key.is_empty() {
+                warn!("no Deepgram API key configured");
+            }
+            info!("using Deepgram streaming transcription backend");
+            Arc::new(DeepgramStreamingBackend::new(api_key))
+        }
         "groq" => {
             let api_key = resolve_groq_api_key(config).unwrap_or_default();
             if api_key.is_empty() {
@@ -416,6 +445,11 @@ fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
 
 fn get_model_for_backend(config: &Config) -> String {
     match config.general.backend.as_str() {
+        "deepgram" | "deepgram-streaming" => config
+            .deepgram
+            .as_ref()
+            .map(|d| d.model.clone())
+            .unwrap_or_else(|| "nova-3".to_string()),
         "groq" => config
             .groq
             .as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,8 @@ pub struct Config {
     #[serde(default)]
     pub audio: AudioConfig,
     #[serde(default)]
+    pub deepgram: Option<DeepgramConfig>,
+    #[serde(default)]
     pub groq: Option<GroqConfig>,
     #[serde(default)]
     pub openai: Option<OpenAiConfig>,
@@ -174,6 +176,13 @@ impl Default for AudioConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeepgramConfig {
+    pub api_key: String,
+    #[serde(default = "default_deepgram_model")]
+    pub model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroqConfig {
     pub api_key: String,
     #[serde(default = "default_groq_model")]
@@ -219,6 +228,9 @@ fn default_device() -> String {
 }
 fn default_audio_feedback_volume() -> f32 {
     0.5
+}
+fn default_deepgram_model() -> String {
+    "nova-3".to_string()
 }
 fn default_groq_model() -> String {
     "whisper-large-v3-turbo".to_string()
@@ -278,6 +290,24 @@ impl Config {
         let backend = self.general.backend.as_str();
 
         match backend {
+            "deepgram" | "deepgram-streaming" => {
+                let has_config_key = self
+                    .deepgram
+                    .as_ref()
+                    .map(|d| !d.api_key.is_empty())
+                    .unwrap_or(false);
+                let has_env_key = std::env::var("WHISRS_DEEPGRAM_API_KEY")
+                    .map(|k| !k.is_empty())
+                    .unwrap_or(false);
+                if !has_config_key && !has_env_key {
+                    return Err(WhisrsError::Config(
+                        "Deepgram backend selected but no API key configured.\n\
+                         Set WHISRS_DEEPGRAM_API_KEY or add [deepgram] api_key to config.toml.\n\
+                         Run 'whisrs setup' to get started."
+                            .to_string(),
+                    ));
+                }
+            }
             "groq" => {
                 let has_config_key = self
                     .groq
@@ -365,8 +395,8 @@ impl Config {
             }
             other => {
                 return Err(WhisrsError::Config(format!(
-                    "Unknown backend '{other}'. Valid options: groq, openai, openai-realtime, \
-                     local-whisper, local-vosk, local-parakeet"
+                    "Unknown backend '{other}'. Valid options: deepgram, deepgram-streaming, \
+                     groq, openai, openai-realtime, local-whisper, local-vosk, local-parakeet"
                 )));
             }
         }
@@ -382,6 +412,15 @@ impl Config {
 
     /// Check if any transcription backend has an API key configured.
     pub fn has_any_backend_configured(&self) -> bool {
+        let has_deepgram = self
+            .deepgram
+            .as_ref()
+            .map(|d| !d.api_key.is_empty())
+            .unwrap_or(false)
+            || std::env::var("WHISRS_DEEPGRAM_API_KEY")
+                .map(|k| !k.is_empty())
+                .unwrap_or(false);
+
         let has_groq = self
             .groq
             .as_ref()
@@ -404,7 +443,7 @@ impl Config {
             || self.local_vosk.is_some()
             || self.local_parakeet.is_some();
 
-        has_groq || has_openai || has_local
+        has_deepgram || has_groq || has_openai || has_local
     }
 }
 
@@ -595,6 +634,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            deepgram: None,
             groq: None,
             openai: None,
             local_whisper: None,
@@ -617,6 +657,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            deepgram: None,
             groq: None,
             openai: None,
             local_whisper: None,
@@ -637,6 +678,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            deepgram: None,
             groq: Some(GroqConfig {
                 api_key: "test-key".to_string(),
                 model: "whisper-large-v3-turbo".to_string(),
@@ -661,6 +703,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            deepgram: None,
             groq: Some(GroqConfig {
                 api_key: "test-key".to_string(),
                 model: "whisper-large-v3-turbo".to_string(),

--- a/src/transcription/deepgram.rs
+++ b/src/transcription/deepgram.rs
@@ -1,0 +1,552 @@
+//! Deepgram transcription backend (REST + streaming WebSocket).
+//!
+//! Supports two modes:
+//! - **REST**: POST WAV audio to `/v1/listen` (non-streaming, simple).
+//! - **Streaming**: WebSocket to `wss://api.deepgram.com/v1/listen` with raw
+//!   PCM binary frames and real-time transcription results.
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite;
+use tracing::{debug, error, info, warn};
+
+use crate::audio::AudioChunk;
+
+use super::{TranscriptionBackend, TranscriptionConfig};
+
+/// Deepgram REST API endpoint for pre-recorded audio.
+const DEEPGRAM_REST_URL: &str = "https://api.deepgram.com/v1/listen";
+
+/// Deepgram WebSocket endpoint for live streaming.
+const DEEPGRAM_WS_URL: &str = "wss://api.deepgram.com/v1/listen";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve the API key from the struct field or `WHISRS_DEEPGRAM_API_KEY`.
+fn resolve_api_key(api_key: &str) -> anyhow::Result<String> {
+    if !api_key.is_empty() {
+        return Ok(api_key.to_string());
+    }
+    std::env::var("WHISRS_DEEPGRAM_API_KEY").map_err(|_| {
+        anyhow::anyhow!(
+            "no Deepgram API key configured — set WHISRS_DEEPGRAM_API_KEY or add [deepgram] to config.toml"
+        )
+    })
+}
+
+/// Map whisrs language codes to Deepgram's `language` query parameter.
+/// "auto" maps to "multi" (Deepgram's auto-detect / code-switching mode).
+fn map_language(language: &str) -> &str {
+    if language == "auto" {
+        "multi"
+    } else {
+        language
+    }
+}
+
+/// Build common query parameters for Deepgram requests.
+fn build_query_params<'a>(
+    config: &'a TranscriptionConfig,
+    extra: &[(&'a str, &'a str)],
+) -> Vec<(&'a str, &'a str)> {
+    let mut params = vec![
+        ("model", config.model.as_str()),
+        ("language", map_language(&config.language)),
+        ("smart_format", "true"),
+    ];
+    params.extend_from_slice(extra);
+    params
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+/// Top-level response from Deepgram's pre-recorded API.
+#[derive(Debug, Deserialize)]
+struct DeepgramResponse {
+    results: DeepgramResults,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepgramResults {
+    channels: Vec<DeepgramChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepgramChannel {
+    alternatives: Vec<DeepgramAlternative>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepgramAlternative {
+    transcript: String,
+}
+
+/// Error response from the Deepgram API.
+#[derive(Debug, Deserialize)]
+struct DeepgramErrorResponse {
+    #[serde(default)]
+    err_msg: String,
+    #[serde(default)]
+    err_code: String,
+}
+
+/// A streaming result message from the Deepgram WebSocket.
+#[derive(Debug, Deserialize)]
+struct StreamingResult {
+    #[serde(rename = "type")]
+    msg_type: String,
+    #[serde(default)]
+    is_final: bool,
+    #[serde(default)]
+    channel: Option<StreamingChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamingChannel {
+    alternatives: Vec<DeepgramAlternative>,
+}
+
+// ===========================================================================
+// REST backend (non-streaming)
+// ===========================================================================
+
+/// Deepgram REST transcription backend.
+///
+/// Sends the full WAV file to `/v1/listen` and returns the complete transcript.
+pub struct DeepgramRestBackend {
+    client: reqwest::Client,
+    api_key: String,
+}
+
+impl DeepgramRestBackend {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key,
+        }
+    }
+}
+
+#[async_trait]
+impl TranscriptionBackend for DeepgramRestBackend {
+    async fn transcribe(
+        &self,
+        audio: &[u8],
+        config: &TranscriptionConfig,
+    ) -> anyhow::Result<String> {
+        if audio.is_empty() {
+            anyhow::bail!("cannot transcribe empty audio");
+        }
+
+        let api_key = resolve_api_key(&self.api_key)?;
+
+        debug!(
+            "sending {} bytes to Deepgram REST API (model={}, language={})",
+            audio.len(),
+            config.model,
+            config.language
+        );
+
+        let params = build_query_params(config, &[]);
+
+        let response = self
+            .client
+            .post(DEEPGRAM_REST_URL)
+            .header("Authorization", format!("Token {api_key}"))
+            .header("Content-Type", "audio/wav")
+            .query(&params)
+            .body(audio.to_vec())
+            .send()
+            .await?;
+
+        let status = response.status();
+        let body = response.text().await?;
+
+        if !status.is_success() {
+            if let Ok(err_resp) = serde_json::from_str::<DeepgramErrorResponse>(&body) {
+                match status.as_u16() {
+                    401 | 403 => {
+                        anyhow::bail!("Deepgram API: invalid API key — {}", err_resp.err_msg)
+                    }
+                    429 => {
+                        anyhow::bail!("Deepgram API: rate limited — {}", err_resp.err_msg)
+                    }
+                    _ => anyhow::bail!(
+                        "Deepgram API error ({} {}): {}",
+                        status.as_u16(),
+                        err_resp.err_code,
+                        err_resp.err_msg
+                    ),
+                }
+            }
+            anyhow::bail!("Deepgram API error ({}): {}", status.as_u16(), body);
+        }
+
+        let parsed: DeepgramResponse = serde_json::from_str(&body)?;
+        let text = parsed
+            .results
+            .channels
+            .first()
+            .and_then(|ch| ch.alternatives.first())
+            .map(|alt| alt.transcript.trim().to_string())
+            .unwrap_or_default();
+
+        if text.is_empty() {
+            warn!("Deepgram returned empty transcription");
+        }
+
+        Ok(text)
+    }
+
+    // Uses the default transcribe_stream (collect + transcribe) since this
+    // backend does not support streaming.
+}
+
+// ===========================================================================
+// Streaming backend (WebSocket)
+// ===========================================================================
+
+/// Deepgram streaming transcription backend.
+///
+/// Opens a WebSocket to Deepgram, sends raw PCM audio as binary frames,
+/// and receives incremental transcription results. Only emits `is_final`
+/// results to avoid duplicates.
+pub struct DeepgramStreamingBackend {
+    api_key: String,
+}
+
+impl DeepgramStreamingBackend {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key }
+    }
+}
+
+#[async_trait]
+impl TranscriptionBackend for DeepgramStreamingBackend {
+    async fn transcribe(
+        &self,
+        audio: &[u8],
+        config: &TranscriptionConfig,
+    ) -> anyhow::Result<String> {
+        // For non-streaming use, set up the full WebSocket pipeline with a
+        // single audio chunk, then collect the result.
+        let (audio_tx, audio_rx) = mpsc::channel::<AudioChunk>(16);
+        let (text_tx, mut text_rx) = mpsc::channel::<String>(16);
+
+        // Decode WAV to get raw samples.
+        let cursor = std::io::Cursor::new(audio);
+        let reader = hound::WavReader::new(cursor)?;
+        let samples: Vec<i16> = reader.into_samples::<i16>().collect::<Result<_, _>>()?;
+
+        // Send all audio as one chunk, then close.
+        audio_tx.send(samples).await.ok();
+        drop(audio_tx);
+
+        let config_clone = config.clone();
+        let stream_result = self.transcribe_stream(audio_rx, text_tx, &config_clone);
+
+        let collector = async {
+            let mut full_text = String::new();
+            while let Some(text) = text_rx.recv().await {
+                if !full_text.is_empty() {
+                    full_text.push(' ');
+                }
+                full_text.push_str(&text);
+            }
+            full_text
+        };
+
+        let (stream_res, text) = tokio::join!(stream_result, collector);
+        stream_res?;
+
+        Ok(text)
+    }
+
+    async fn transcribe_stream(
+        &self,
+        mut audio_rx: mpsc::Receiver<AudioChunk>,
+        text_tx: mpsc::Sender<String>,
+        config: &TranscriptionConfig,
+    ) -> anyhow::Result<()> {
+        let api_key = resolve_api_key(&self.api_key)?;
+
+        let params = build_query_params(
+            config,
+            &[
+                ("encoding", "linear16"),
+                ("sample_rate", "16000"),
+                ("channels", "1"),
+                ("interim_results", "false"),
+            ],
+        );
+
+        // Build the WebSocket URL with query parameters.
+        let query_string: String = params
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join("&");
+        let url = format!("{DEEPGRAM_WS_URL}?{query_string}");
+
+        info!("connecting to Deepgram streaming API");
+
+        let request = tungstenite::http::Request::builder()
+            .uri(&url)
+            .header("Authorization", format!("Token {api_key}"))
+            .header(
+                "Sec-WebSocket-Key",
+                tungstenite::handshake::client::generate_key(),
+            )
+            .header("Sec-WebSocket-Version", "13")
+            .header("Host", "api.deepgram.com")
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket")
+            .body(())?;
+
+        let (ws_stream, _response) = tokio_tungstenite::connect_async(request).await?;
+        let (mut ws_sink, mut ws_source) = ws_stream.split();
+
+        info!("connected to Deepgram streaming API");
+
+        // Spawn a task to send audio as raw PCM binary frames.
+        let send_task = tokio::spawn(async move {
+            while let Some(chunk) = audio_rx.recv().await {
+                // Convert i16 samples to little-endian bytes.
+                let bytes: Vec<u8> = chunk.iter().flat_map(|s| s.to_le_bytes()).collect();
+
+                if ws_sink
+                    .send(tungstenite::Message::Binary(bytes.into()))
+                    .await
+                    .is_err()
+                {
+                    error!("Deepgram WebSocket send failed — connection may be closed");
+                    break;
+                }
+            }
+
+            // Signal end of audio stream.
+            debug!("sending CloseStream to Deepgram");
+            let close_msg = r#"{"type":"CloseStream"}"#;
+            ws_sink
+                .send(tungstenite::Message::Text(close_msg.into()))
+                .await
+                .ok();
+        });
+
+        // Receive transcription results.
+        let timeout_duration = std::time::Duration::from_secs(15);
+        while let Ok(Some(msg_result)) =
+            tokio::time::timeout(timeout_duration, ws_source.next()).await
+        {
+            match msg_result {
+                Ok(tungstenite::Message::Text(text)) => {
+                    match serde_json::from_str::<StreamingResult>(&text) {
+                        Ok(result) => match result.msg_type.as_str() {
+                            "Results" => {
+                                // Only emit final results to avoid duplicates.
+                                if result.is_final {
+                                    let transcript = result
+                                        .channel
+                                        .and_then(|ch| ch.alternatives.into_iter().next())
+                                        .map(|alt| alt.transcript.trim().to_string())
+                                        .unwrap_or_default();
+
+                                    if !transcript.is_empty() {
+                                        debug!("deepgram final: {transcript}");
+                                        text_tx.send(transcript).await.ok();
+                                    }
+                                }
+                            }
+                            "Metadata" => {
+                                debug!("deepgram metadata received");
+                            }
+                            "SpeechStarted" => {
+                                debug!("deepgram speech started");
+                            }
+                            "UtteranceEnd" => {
+                                debug!("deepgram utterance end");
+                            }
+                            other => {
+                                debug!("unhandled Deepgram message type: {other}");
+                            }
+                        },
+                        Err(e) => {
+                            debug!("failed to parse Deepgram message: {e}");
+                            debug!("raw message: {text}");
+                        }
+                    }
+                }
+                Ok(tungstenite::Message::Close(_)) => {
+                    info!("Deepgram WebSocket closed by server");
+                    break;
+                }
+                Err(e) => {
+                    error!("Deepgram WebSocket receive error: {e}");
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        send_task.await.ok();
+        info!("Deepgram stream finished");
+
+        Ok(())
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_language_auto_to_multi() {
+        assert_eq!(map_language("auto"), "multi");
+    }
+
+    #[test]
+    fn map_language_passthrough() {
+        assert_eq!(map_language("en"), "en");
+        assert_eq!(map_language("fr"), "fr");
+        assert_eq!(map_language("ja"), "ja");
+    }
+
+    #[test]
+    fn parse_rest_response() {
+        let body = r#"{
+            "metadata": {"request_id": "test"},
+            "results": {
+                "channels": [{
+                    "alternatives": [{
+                        "transcript": "Hello world.",
+                        "confidence": 0.98
+                    }]
+                }]
+            }
+        }"#;
+        let parsed: DeepgramResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(
+            parsed.results.channels[0].alternatives[0].transcript,
+            "Hello world."
+        );
+    }
+
+    #[test]
+    fn parse_rest_response_empty_transcript() {
+        let body = r#"{
+            "results": {
+                "channels": [{
+                    "alternatives": [{
+                        "transcript": "",
+                        "confidence": 0.0
+                    }]
+                }]
+            }
+        }"#;
+        let parsed: DeepgramResponse = serde_json::from_str(body).unwrap();
+        assert!(parsed.results.channels[0].alternatives[0]
+            .transcript
+            .is_empty());
+    }
+
+    #[test]
+    fn parse_error_response() {
+        let body = r#"{"err_msg": "Invalid credentials", "err_code": "INVALID_AUTH"}"#;
+        let parsed: DeepgramErrorResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.err_msg, "Invalid credentials");
+        assert_eq!(parsed.err_code, "INVALID_AUTH");
+    }
+
+    #[test]
+    fn parse_streaming_result_final() {
+        let body = r#"{
+            "type": "Results",
+            "channel_index": [0, 1],
+            "duration": 1.5,
+            "start": 0.0,
+            "is_final": true,
+            "speech_final": true,
+            "channel": {
+                "alternatives": [{
+                    "transcript": "Hello world.",
+                    "confidence": 0.98
+                }]
+            }
+        }"#;
+        let parsed: StreamingResult = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.msg_type, "Results");
+        assert!(parsed.is_final);
+        let transcript = &parsed.channel.unwrap().alternatives[0].transcript;
+        assert_eq!(transcript, "Hello world.");
+    }
+
+    #[test]
+    fn parse_streaming_result_interim() {
+        let body = r#"{
+            "type": "Results",
+            "is_final": false,
+            "channel": {
+                "alternatives": [{"transcript": "Hel", "confidence": 0.5}]
+            }
+        }"#;
+        let parsed: StreamingResult = serde_json::from_str(body).unwrap();
+        assert!(!parsed.is_final);
+    }
+
+    #[test]
+    fn parse_streaming_metadata() {
+        let body = r#"{"type": "Metadata", "request_id": "abc123"}"#;
+        let parsed: StreamingResult = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.msg_type, "Metadata");
+    }
+
+    #[tokio::test]
+    async fn rest_rejects_empty_audio() {
+        let backend = DeepgramRestBackend::new("test-key".to_string());
+        let config = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "nova-3".to_string(),
+            prompt: None,
+        };
+        let err = backend.transcribe(&[], &config).await.unwrap_err();
+        assert!(err.to_string().contains("empty audio"));
+    }
+
+    #[test]
+    fn build_query_params_includes_smart_format() {
+        let config = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "nova-3".to_string(),
+            prompt: None,
+        };
+        let params = build_query_params(&config, &[]);
+        assert!(params
+            .iter()
+            .any(|(k, v)| *k == "smart_format" && *v == "true"));
+        assert!(params.iter().any(|(k, v)| *k == "model" && *v == "nova-3"));
+        assert!(params.iter().any(|(k, v)| *k == "language" && *v == "en"));
+    }
+
+    #[test]
+    fn build_query_params_auto_language() {
+        let config = TranscriptionConfig {
+            language: "auto".to_string(),
+            model: "nova-3".to_string(),
+            prompt: None,
+        };
+        let params = build_query_params(&config, &[]);
+        assert!(params
+            .iter()
+            .any(|(k, v)| *k == "language" && *v == "multi"));
+    }
+}

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -1,6 +1,7 @@
 //! Transcription backends: trait definition and implementations.
 
 pub mod dedup;
+pub mod deepgram;
 pub mod groq;
 pub mod local_parakeet;
 pub mod local_vosk;


### PR DESCRIPTION
## Summary
- Adds Deepgram Nova-3 as a new cloud transcription backend with two modes: REST (`deepgram`) and WebSocket streaming (`deepgram-streaming`)
- Deepgram offers $200 in free credits on signup, supports 60+ languages, and auto-detect via `language=multi`
- Integrated into config, daemon, and interactive setup wizard

## Test plan
- [x] Tested streaming backend — real-time transcription works
- [x] Tested REST backend — full-audio transcription works
- [x] Tested auto-detect (`language = "auto"` → `multi`) — correctly detects English and French
- [x] All 157 unit tests pass
- [x] Clippy clean, cargo build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)