### PR TITLE
Feature/osd overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -206,7 +206,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -359,6 +359,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -371,6 +385,32 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
 
 [[package]]
 name = "cc"
@@ -622,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +752,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -966,7 +1018,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -1432,6 +1484,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1498,6 +1556,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmap2"
@@ -1927,7 +1994,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2006,6 +2073,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -2227,6 +2303,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2234,7 +2323,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2442,6 +2531,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2 0.9.10",
+ "pkg-config",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkbcommon 0.7.0",
+ "xkeysym",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,7 +2651,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-version",
@@ -2549,7 +2666,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3105,6 +3222,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,6 +3403,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "smithay-client-toolkit",
  "strsim",
  "swayipc",
  "thiserror 2.0.18",
@@ -3202,9 +3412,10 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "wayland-client",
  "whisper-rs",
  "x11rb",
- "xkbcommon",
+ "xkbcommon 0.8.0",
  "zbus",
 ]
 
@@ -3640,7 +3851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -3651,13 +3862,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e"
+dependencies = [
+ "libc",
+ "memmap2 0.8.0",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkbcommon"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
 dependencies = [
  "libc",
- "memmap2",
+ "memmap2 0.9.10",
  "xkeysym",
 ]
 
@@ -3666,6 +3894,9 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "yoke"
@@ -3712,7 +3943,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,6 +2769,31 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
 
 [[package]]
 name = "tinystr"
@@ -3407,6 +3450,7 @@ dependencies = [
  "strsim",
  "swayipc",
  "thiserror 2.0.18",
+ "tiny-skia",
  "tokio",
  "tokio-tungstenite",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,10 @@ name = "whisrsd"
 path = "src/daemon/main.rs"
 
 [features]
-default = ["local-whisper", "tray"]
+default = ["local-whisper", "tray", "overlay"]
 local-whisper = ["dep:whisper-rs"]
 tray = ["dep:ksni"]
+overlay = ["dep:smithay-client-toolkit", "dep:wayland-client"]
 
 [dependencies]
 anyhow = "1"
@@ -61,6 +62,14 @@ zbus = "5"
 
 [dependencies.ksni]
 version = "0.3"
+optional = true
+
+[dependencies.smithay-client-toolkit]
+version = "0.19"
+optional = true
+
+[dependencies.wayland-client]
+version = "0.31"
 optional = true
 
 [dependencies.whisper-rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/daemon/main.rs"
 default = ["local-whisper", "tray", "overlay"]
 local-whisper = ["dep:whisper-rs"]
 tray = ["dep:ksni"]
-overlay = ["dep:smithay-client-toolkit", "dep:wayland-client"]
+overlay = ["dep:smithay-client-toolkit", "dep:wayland-client", "dep:tiny-skia"]
 
 [dependencies]
 anyhow = "1"
@@ -71,6 +71,12 @@ optional = true
 [dependencies.wayland-client]
 version = "0.31"
 optional = true
+
+[dependencies.tiny-skia]
+version = "0.12"
+optional = true
+default-features = false
+features = ["std", "simd"]
 
 [dependencies.whisper-rs]
 version = "0.16"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription acc
 tray = true                 # system tray icon (requires SNI host like waybar)
 overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 
+# Optional — controls overlay appearance when enabled.
+# Defaults to a 100×34 pill with the "ember" theme.
+[overlay]
+theme = "ember"             # "ember" (default) | "carbon" | "cyan" | "custom"
+width = 100                 # 90..=120 (clamped)
+height = 34                 # 28..=40 (clamped)
+
+# When theme = "custom", these override the named theme. Hex strings:
+# #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to ember.
+# [overlay.colors]
+# background   = "#0E0E10E5"
+# ring         = "#F9731640"
+# recording    = "#F97316"
+# transcribing = "#F0EDF5"
+# glow         = "#F97316"
+
 [audio]
 device = "default"
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ audio_feedback = true       # play tones on record start/stop/done
 audio_feedback_volume = 0.5 # 0.0 to 1.0
 vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription accuracy
 tray = true                 # system tray icon (requires SNI host like waybar)
+overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 
 [audio]
 device = "default"
@@ -205,6 +206,23 @@ command = "Super+Shift+G"
 
 Environment variable overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, `WHISRS_OPENAI_API_KEY`
 
+### GNOME overlay
+
+GNOME Wayland does not support the wlroots layer-shell protocol used by Hyprland
+and Sway. To use `overlay = true` on GNOME, install the bundled GNOME Shell
+extension:
+
+```bash
+mkdir -p ~/.local/share/gnome-shell/extensions
+cp -r contrib/gnome-shell-extension/whisrs-overlay@eresende.github \
+  ~/.local/share/gnome-shell/extensions/
+gnome-extensions enable whisrs-overlay@eresende.github
+systemctl --user restart whisrs.service
+```
+
+If GNOME has not discovered the extension yet, log out and back in, then run the
+`gnome-extensions enable` command again.
+
 ---
 
 ## CLI Commands
@@ -229,7 +247,7 @@ whisrs log --clear  # Clear all history
 | **Hyprland** | Tested, full support |
 | **Sway / i3** | Implemented, needs community testing |
 | **X11 (any WM)** | Implemented, needs community testing |
-| **GNOME Wayland** | Limited, requires `window-calls` extension for window tracking |
+| **GNOME Wayland** | Limited window tracking; overlay requires bundled GNOME Shell extension |
 | **KDE Wayland** | Implemented via D-Bus, needs community testing |
 | **Audio** | PipeWire, PulseAudio, ALSA (auto-detected via cpal) |
 | **Distros** | Any Linux with the system dependencies above |

--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ tray = true                 # system tray icon (requires SNI host like waybar)
 overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 
 # Optional — controls overlay appearance when enabled.
-# Defaults to a 100×34 pill with the "carbon" theme.
+# Defaults to a 100×64 pill with the "carbon" theme.
 # When the overlay is on, recording/transcribing toast notifications are
 # auto-suppressed (errors still pop) so the same event isn't double-signaled.
 [overlay]
 theme = "carbon"            # "carbon" (default) | "ember" | "cyan" | "custom"
 width = 100                 # 90..=120 (clamped)
-height = 34                 # 28..=40 (clamped)
+height = 64                 # 56..=72 (clamped)
 
 # When theme = "custom", these override the named theme. Hex strings:
 # #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to carbon.

--- a/README.md
+++ b/README.md
@@ -174,20 +174,22 @@ tray = true                 # system tray icon (requires SNI host like waybar)
 overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 
 # Optional — controls overlay appearance when enabled.
-# Defaults to a 100×34 pill with the "ember" theme.
+# Defaults to a 100×34 pill with the "carbon" theme.
+# When the overlay is on, recording/transcribing toast notifications are
+# auto-suppressed (errors still pop) so the same event isn't double-signaled.
 [overlay]
-theme = "ember"             # "ember" (default) | "carbon" | "cyan" | "custom"
+theme = "carbon"            # "carbon" (default) | "ember" | "cyan" | "custom"
 width = 100                 # 90..=120 (clamped)
 height = 34                 # 28..=40 (clamped)
 
 # When theme = "custom", these override the named theme. Hex strings:
-# #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to ember.
+# #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to carbon.
 # [overlay.colors]
-# background   = "#0E0E10E5"
-# ring         = "#F9731640"
-# recording    = "#F97316"
-# transcribing = "#F0EDF5"
-# glow         = "#F97316"
+# background   = "#0E0E10EB"
+# ring         = "#3A3A4050"
+# recording    = "#F0EDF5"
+# transcribing = "#9CA3AF"
+# glow         = "#F0EDF5"
 
 [audio]
 device = "default"

--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ tray = true                 # system tray icon (requires SNI host like waybar)
 overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 
 # Optional — controls overlay appearance when enabled.
-# Defaults to a 100×64 pill with the "carbon" theme.
+# Defaults to a 100×40 pill with the "carbon" theme.
 # When the overlay is on, recording/transcribing toast notifications are
 # auto-suppressed (errors still pop) so the same event isn't double-signaled.
 [overlay]
 theme = "carbon"            # "carbon" (default) | "ember" | "cyan" | "custom"
 width = 100                 # 90..=120 (clamped)
-height = 64                 # 56..=72 (clamped)
+height = 40                 # 36..=48 (clamped)
 
 # When theme = "custom", these override the named theme. Hex strings:
 # #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to carbon.

--- a/contrib/gnome-shell-extension/README.md
+++ b/contrib/gnome-shell-extension/README.md
@@ -1,0 +1,50 @@
+# whisrs GNOME Shell overlay
+
+This extension renders the whisrs bottom recording overlay on GNOME Wayland.
+The daemon publishes recording state over the session D-Bus name
+`org.whisrs.Overlay`; the extension listens for those state changes and draws
+inside GNOME Shell.
+
+Install locally:
+
+```bash
+mkdir -p ~/.local/share/gnome-shell/extensions
+cp -r contrib/gnome-shell-extension/whisrs-overlay@eresende.github \
+  ~/.local/share/gnome-shell/extensions/
+gnome-extensions enable whisrs-overlay@eresende.github
+```
+
+Then set this in `~/.config/whisrs/config.toml`:
+
+```toml
+[general]
+overlay = true
+```
+
+Restart the daemon:
+
+```bash
+systemctl --user restart whisrs.service
+```
+
+If GNOME does not load the extension immediately, log out and back in, then run
+the `gnome-extensions enable` command again.
+
+## Updating the extension
+
+On Wayland, GNOME Shell caches extension bytecode and there is no in-session
+reload. After changing any file, clear the cache and log out:
+
+```bash
+rm -rf ~/.cache/gnome-shell/extensions/whisrs-overlay@eresende.github
+```
+
+Then log out and back in. For already-installed extensions where only
+`stylesheet.css` changed, a disable/enable cycle is sometimes enough:
+
+```bash
+gnome-extensions disable whisrs-overlay@eresende.github
+gnome-extensions enable whisrs-overlay@eresende.github
+```
+
+But for `extension.js` changes a full session restart is required.

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -11,8 +11,8 @@ const DBUS_INTERFACE = 'org.whisrs.Overlay';
 const DBUS_PATH = '/org/whisrs/Overlay';
 const STATE_SIGNAL = 'StateChanged';
 const LEVEL_SIGNAL = 'LevelChanged';
-const OVERLAY_WIDTH = 260;
-const OVERLAY_HEIGHT = 62;
+const OVERLAY_WIDTH = 250;
+const OVERLAY_HEIGHT = 50;
 
 export default class WhisrsOverlayExtension extends Extension {
     enable() {
@@ -23,22 +23,26 @@ export default class WhisrsOverlayExtension extends Extension {
             visible: false,
         });
 
-        this._dot = new St.Widget({style_class: 'whisrs-overlay-dot'});
+        // Bars (recording)
         this._bars = [];
-        const bars = new St.BoxLayout({
+        this._barsBox = new St.BoxLayout({
             style_class: 'whisrs-overlay-bars',
             y_align: Clutter.ActorAlign.CENTER,
         });
-        for (let i = 0; i < 6; i++) {
+        for (let i = 0; i < 4; i++) {
             const bar = new St.Widget({
                 style_class: 'whisrs-overlay-bar',
                 y_align: Clutter.ActorAlign.CENTER,
                 y_expand: false,
             });
             this._bars.push(bar);
-            bars.add_child(bar);
+            this._barsBox.add_child(bar);
         }
 
+        // Spinner arc (transcribing) — drawn as a styled widget
+        this._spinner = new St.Widget({style_class: 'whisrs-overlay-spinner'});
+
+        // Label
         this._label = new St.Label({
             style_class: 'whisrs-overlay-label',
             text: '',
@@ -46,9 +50,19 @@ export default class WhisrsOverlayExtension extends Extension {
         this._label.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
         this._label.clutter_text.set_line_wrap(false);
 
-        this._actor.add_child(this._dot);
-        this._actor.add_child(bars);
+        // Divider + timer (recording only)
+        this._divider = new St.Widget({style_class: 'whisrs-overlay-divider'});
+        this._timer = new St.Label({
+            style_class: 'whisrs-overlay-timer',
+            text: '00:00',
+        });
+        this._timer.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
+
+        this._actor.add_child(this._barsBox);
+        this._actor.add_child(this._spinner);
         this._actor.add_child(this._label);
+        this._actor.add_child(this._divider);
+        this._actor.add_child(this._timer);
         Main.uiGroup.add_child(this._actor);
 
         this._monitorsChangedId = Main.layoutManager.connect(
@@ -61,25 +75,17 @@ export default class WhisrsOverlayExtension extends Extension {
         );
 
         this._signalId = Gio.DBus.session.signal_subscribe(
-            null,
-            DBUS_INTERFACE,
-            STATE_SIGNAL,
-            DBUS_PATH,
-            null,
+            null, DBUS_INTERFACE, STATE_SIGNAL, DBUS_PATH, null,
             Gio.DBusSignalFlags.NONE,
-            (_connection, _sender, _path, _iface, _signal, parameters) => {
+            (_c, _s, _p, _i, _sig, parameters) => {
                 const [state] = parameters.deep_unpack();
                 this._setState(state);
             }
         );
         this._levelSignalId = Gio.DBus.session.signal_subscribe(
-            null,
-            DBUS_INTERFACE,
-            LEVEL_SIGNAL,
-            DBUS_PATH,
-            null,
+            null, DBUS_INTERFACE, LEVEL_SIGNAL, DBUS_PATH, null,
             Gio.DBusSignalFlags.NONE,
-            (_connection, _sender, _path, _iface, _signal, parameters) => {
+            (_c, _s, _p, _i, _sig, parameters) => {
                 const [level] = parameters.deep_unpack();
                 this._setLevel(level);
             }
@@ -95,17 +101,14 @@ export default class WhisrsOverlayExtension extends Extension {
             Gio.DBus.session.signal_unsubscribe(this._signalId);
             this._signalId = 0;
         }
-
         if (this._levelSignalId) {
             Gio.DBus.session.signal_unsubscribe(this._levelSignalId);
             this._levelSignalId = 0;
         }
-
         if (this._monitorsChangedId) {
             Main.layoutManager.disconnect(this._monitorsChangedId);
             this._monitorsChangedId = 0;
         }
-
         if (this._allocationChangedId) {
             this._actor.disconnect(this._allocationChangedId);
             this._allocationChangedId = 0;
@@ -113,9 +116,12 @@ export default class WhisrsOverlayExtension extends Extension {
 
         this._actor?.destroy();
         this._actor = null;
-        this._dot = null;
-        this._label = null;
         this._bars = [];
+        this._barsBox = null;
+        this._spinner = null;
+        this._label = null;
+        this._divider = null;
+        this._timer = null;
     }
 
     _setState(state) {
@@ -129,16 +135,25 @@ export default class WhisrsOverlayExtension extends Extension {
 
         if (normalized === 'recording') {
             this._state = 'recording';
+            this._recordingStart = Date.now();
             this._label.text = 'RECORDING';
             this._actor.add_style_class_name('whisrs-overlay-recording');
             this._actor.visible = true;
+            this._barsBox.visible = true;
+            this._spinner.visible = false;
+            this._divider.visible = true;
+            this._timer.visible = true;
             this._startAnimation();
             this._position();
         } else if (normalized === 'transcribing') {
             this._state = 'transcribing';
-            this._label.text = 'TRANSCRIBING';
+            this._label.text = 'TRANSCRIBING ....';
             this._actor.add_style_class_name('whisrs-overlay-transcribing');
             this._actor.visible = true;
+            this._barsBox.visible = false;
+            this._spinner.visible = true;
+            this._divider.visible = false;
+            this._timer.visible = false;
             this._startAnimation();
             this._position();
         } else {
@@ -155,12 +170,10 @@ export default class WhisrsOverlayExtension extends Extension {
             return;
 
         const monitor = Main.layoutManager.primaryMonitor;
-        const width = OVERLAY_WIDTH;
-        const height = OVERLAY_HEIGHT;
-        const x = Math.floor(monitor.x + (monitor.width - width) / 2);
-        const y = Math.floor(monitor.y + monitor.height - height - 34);
+        const x = Math.floor(monitor.x + (monitor.width - OVERLAY_WIDTH) / 2);
+        const y = Math.floor(monitor.y + monitor.height - OVERLAY_HEIGHT - 60);
         this._actor.set_position(Math.max(monitor.x, x), Math.max(monitor.y, y));
-        this._actor.set_size(width, height);
+        this._actor.set_size(OVERLAY_WIDTH, OVERLAY_HEIGHT);
         this._layoutChildren();
         this._actor.set_pivot_point(0.5, 0.5);
         this._actor.set_easing_mode(Clutter.AnimationMode.EASE_OUT_QUAD);
@@ -168,20 +181,32 @@ export default class WhisrsOverlayExtension extends Extension {
     }
 
     _layoutChildren() {
-        if (!this._actor || !this._dot || !this._label)
+        if (!this._actor || !this._label)
             return;
 
-        this._dot.set_position(18, 26);
-        this._dot.set_size(10, 10);
+        const cy = Math.floor(OVERLAY_HEIGHT / 2);
 
-        const bars = this._bars?.[0]?.get_parent();
-        if (bars) {
-            bars.set_position(42, 15);
-            bars.set_size(66, 32);
+        // Recording layout: [bars] [RECORDING] | [00:00]
+        if (this._barsBox) {
+            this._barsBox.set_position(24, cy - 16);
+            this._barsBox.set_size(36, 32);
         }
+        if (this._label) {
+            const labelX = this._state === 'transcribing' ? 62 : 70;
+            this._label.set_position(labelX, cy - 10);
+        }
+        if (this._divider) {
+            this._divider.set_position(178, cy - 12);
+            this._divider.set_size(1, 24);
+        }
+        if (this._timer)
+            this._timer.set_position(188, cy - 10);
 
-        this._label.set_position(122, 22);
-        this._label.set_size(120, 20);
+        // Transcribing layout: [spinner] [TRANSCRIBING]
+        if (this._spinner) {
+            this._spinner.set_position(16, cy - 12);
+            this._spinner.set_size(24, 24);
+        }
     }
 
     _startAnimation() {
@@ -193,13 +218,11 @@ export default class WhisrsOverlayExtension extends Extension {
         this._targetLevel = 0;
         this._animationId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 24, () => {
             this._frame++;
-            // Snap up instantly, decay smoothly
             const target = this._targetLevel ?? 0;
-            if (target > this._level)
-                this._level = target;
-            else
-                this._level = Math.max(0, this._level * 0.85);
+            this._level = target > this._level ? target : Math.max(0, this._level * 0.85);
             this._updateBars();
+            this._updateTimer();
+            this._updateSpinner();
             return GLib.SOURCE_CONTINUE;
         });
         this._updateBars();
@@ -213,24 +236,35 @@ export default class WhisrsOverlayExtension extends Extension {
     }
 
     _updateBars() {
-        if (!this._bars)
+        if (!this._bars || this._state !== 'recording')
             return;
 
         for (let i = 0; i < this._bars.length; i++) {
-            let level = 0;
-            if (this._state === 'recording') {
-                const raw = Number.isFinite(this._level) ? this._level : 0;
-                // Noise gate: below 0.1 treat as silence, above it scale to full range
-                level = raw < 0.1 ? 0 : Math.min(1, (raw - 0.1) / 0.6);
-            } else if (this._state === 'transcribing') {
-                // Animated wave during transcription
-                const phase = ((this._frame + i * 5) % 24) / 24;
-                level = Math.abs(Math.sin(phase * Math.PI * 2));
-            }
-            const variance = 0.7 + (((i * 7 + 3) % 6) / 6) * 0.3;
+            const raw = Number.isFinite(this._level) ? this._level : 0;
+            const level = raw < 0.1 ? 0 : Math.min(1, (raw - 0.1) / 0.85);
+            const variance = 0.6 + (((i * 7 + 3) % 4) / 4) * 0.4;
             const height = 4 + Math.round(Math.min(1, level * variance) * 28);
             this._bars[i].set_height(height);
         }
+    }
+
+    _updateTimer() {
+        if (!this._timer || this._state !== 'recording' || !this._recordingStart)
+            return;
+
+        const elapsed = Math.floor((Date.now() - this._recordingStart) / 1000);
+        const mm = String(Math.floor(elapsed / 60)).padStart(2, '0');
+        const ss = String(elapsed % 60).padStart(2, '0');
+        this._timer.text = `${mm}:${ss}`;
+    }
+
+    _updateSpinner() {
+        if (!this._spinner || this._state !== 'transcribing')
+            return;
+
+        const angle = (this._frame * 8) % 360;
+        this._spinner.set_pivot_point(0.5, 0.5);
+        this._spinner.set_rotation_angle(Clutter.RotateAxis.Z_AXIS, angle);
     }
 
     _setLevel(level) {

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -11,12 +11,12 @@ const DBUS_PATH = '/org/whisrs/Overlay';
 const STATE_SIGNAL = 'StateChanged';
 const LEVEL_SIGNAL = 'LevelChanged';
 
-const OVERLAY_WIDTH = 140;
-const OVERLAY_HEIGHT = 28;
-const BOTTOM_MARGIN = 22;
+const OVERLAY_WIDTH = 110;
+const OVERLAY_HEIGHT = 40;
+const BOTTOM_MARGIN = 24;
 const BAR_COUNT = 5;
-const BAR_BASELINE = 3;
-const BAR_MAX_H = 18;
+const BAR_BASELINE = 4;
+const BAR_MAX_H = 28;
 
 export default class WhisrsOverlayExtension extends Extension {
     enable() {
@@ -26,8 +26,6 @@ export default class WhisrsOverlayExtension extends Extension {
             reactive: false,
             visible: false,
         });
-
-        this._dot = new St.Widget({style_class: 'whisrs-overlay-dot'});
 
         this._barsBox = new St.BoxLayout({
             style_class: 'whisrs-overlay-bars',
@@ -44,7 +42,6 @@ export default class WhisrsOverlayExtension extends Extension {
             this._barsBox.add_child(bar);
         }
 
-        this._actor.add_child(this._dot);
         this._actor.add_child(this._barsBox);
         Main.uiGroup.add_child(this._actor);
 
@@ -98,7 +95,6 @@ export default class WhisrsOverlayExtension extends Extension {
         this._actor = null;
         this._bars = [];
         this._barsBox = null;
-        this._dot = null;
     }
 
     _setState(state) {
@@ -144,14 +140,12 @@ export default class WhisrsOverlayExtension extends Extension {
         this._actor.set_size(OVERLAY_WIDTH, OVERLAY_HEIGHT);
 
         const cy = Math.floor(OVERLAY_HEIGHT / 2);
-        if (this._dot) {
-            this._dot.set_position(10, cy - 3);
-            this._dot.set_size(6, 6);
-        }
         if (this._barsBox) {
-            const barsX = 26;
+            // 5 bars × 4px wide + 4 gaps × 3px = 32px, centered.
+            const barBlock = BAR_COUNT * 4 + (BAR_COUNT - 1) * 3;
+            const barsX = Math.floor((OVERLAY_WIDTH - barBlock) / 2);
             this._barsBox.set_position(barsX, cy - Math.floor(BAR_MAX_H / 2));
-            this._barsBox.set_size(OVERLAY_WIDTH - barsX - 8, BAR_MAX_H);
+            this._barsBox.set_size(barBlock, BAR_MAX_H);
         }
     }
 

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -1,7 +1,6 @@
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
-import Pango from 'gi://Pango';
 import St from 'gi://St';
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
@@ -11,8 +10,13 @@ const DBUS_INTERFACE = 'org.whisrs.Overlay';
 const DBUS_PATH = '/org/whisrs/Overlay';
 const STATE_SIGNAL = 'StateChanged';
 const LEVEL_SIGNAL = 'LevelChanged';
-const OVERLAY_WIDTH = 250;
-const OVERLAY_HEIGHT = 50;
+
+const OVERLAY_WIDTH = 140;
+const OVERLAY_HEIGHT = 28;
+const BOTTOM_MARGIN = 22;
+const BAR_COUNT = 5;
+const BAR_BASELINE = 3;
+const BAR_MAX_H = 18;
 
 export default class WhisrsOverlayExtension extends Extension {
     enable() {
@@ -23,13 +27,14 @@ export default class WhisrsOverlayExtension extends Extension {
             visible: false,
         });
 
-        // Bars (recording)
-        this._bars = [];
+        this._dot = new St.Widget({style_class: 'whisrs-overlay-dot'});
+
         this._barsBox = new St.BoxLayout({
             style_class: 'whisrs-overlay-bars',
             y_align: Clutter.ActorAlign.CENTER,
         });
-        for (let i = 0; i < 4; i++) {
+        this._bars = [];
+        for (let i = 0; i < BAR_COUNT; i++) {
             const bar = new St.Widget({
                 style_class: 'whisrs-overlay-bar',
                 y_align: Clutter.ActorAlign.CENTER,
@@ -39,38 +44,12 @@ export default class WhisrsOverlayExtension extends Extension {
             this._barsBox.add_child(bar);
         }
 
-        // Spinner arc (transcribing) — drawn as a styled widget
-        this._spinner = new St.Widget({style_class: 'whisrs-overlay-spinner'});
-
-        // Label
-        this._label = new St.Label({
-            style_class: 'whisrs-overlay-label',
-            text: '',
-        });
-        this._label.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
-        this._label.clutter_text.set_line_wrap(false);
-
-        // Divider + timer (recording only)
-        this._divider = new St.Widget({style_class: 'whisrs-overlay-divider'});
-        this._timer = new St.Label({
-            style_class: 'whisrs-overlay-timer',
-            text: '00:00',
-        });
-        this._timer.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
-
+        this._actor.add_child(this._dot);
         this._actor.add_child(this._barsBox);
-        this._actor.add_child(this._spinner);
-        this._actor.add_child(this._label);
-        this._actor.add_child(this._divider);
-        this._actor.add_child(this._timer);
         Main.uiGroup.add_child(this._actor);
 
         this._monitorsChangedId = Main.layoutManager.connect(
             'monitors-changed',
-            () => this._position()
-        );
-        this._allocationChangedId = this._actor.connect(
-            'notify::allocation',
             () => this._position()
         );
 
@@ -91,6 +70,11 @@ export default class WhisrsOverlayExtension extends Extension {
             }
         );
 
+        this._state = 'idle';
+        this._level = 0;
+        this._targetLevel = 0;
+        this._frame = 0;
+
         this._position();
     }
 
@@ -109,23 +93,16 @@ export default class WhisrsOverlayExtension extends Extension {
             Main.layoutManager.disconnect(this._monitorsChangedId);
             this._monitorsChangedId = 0;
         }
-        if (this._allocationChangedId) {
-            this._actor.disconnect(this._allocationChangedId);
-            this._allocationChangedId = 0;
-        }
 
         this._actor?.destroy();
         this._actor = null;
         this._bars = [];
         this._barsBox = null;
-        this._spinner = null;
-        this._label = null;
-        this._divider = null;
-        this._timer = null;
+        this._dot = null;
     }
 
     _setState(state) {
-        if (!this._actor || !this._label)
+        if (!this._actor)
             return;
 
         const normalized = String(state).toLowerCase();
@@ -135,32 +112,23 @@ export default class WhisrsOverlayExtension extends Extension {
 
         if (normalized === 'recording') {
             this._state = 'recording';
-            this._recordingStart = Date.now();
-            this._label.text = 'RECORDING';
             this._actor.add_style_class_name('whisrs-overlay-recording');
             this._actor.visible = true;
-            this._barsBox.visible = true;
-            this._spinner.visible = false;
-            this._divider.visible = true;
-            this._timer.visible = true;
             this._startAnimation();
-            this._position();
         } else if (normalized === 'transcribing') {
             this._state = 'transcribing';
-            this._label.text = 'TRANSCRIBING ....';
             this._actor.add_style_class_name('whisrs-overlay-transcribing');
             this._actor.visible = true;
-            this._barsBox.visible = false;
-            this._spinner.visible = true;
-            this._divider.visible = false;
-            this._timer.visible = false;
             this._startAnimation();
-            this._position();
         } else {
             this._state = 'idle';
-            this._label.text = '';
             this._actor.add_style_class_name('whisrs-overlay-hidden');
-            this._actor.visible = false;
+            // Hide after the snappy CSS fade-out completes.
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 80, () => {
+                if (this._state === 'idle' && this._actor)
+                    this._actor.visible = false;
+                return GLib.SOURCE_REMOVE;
+            });
             this._stopAnimation();
         }
     }
@@ -171,41 +139,19 @@ export default class WhisrsOverlayExtension extends Extension {
 
         const monitor = Main.layoutManager.primaryMonitor;
         const x = Math.floor(monitor.x + (monitor.width - OVERLAY_WIDTH) / 2);
-        const y = Math.floor(monitor.y + monitor.height - OVERLAY_HEIGHT - 60);
+        const y = Math.floor(monitor.y + monitor.height - OVERLAY_HEIGHT - BOTTOM_MARGIN);
         this._actor.set_position(Math.max(monitor.x, x), Math.max(monitor.y, y));
         this._actor.set_size(OVERLAY_WIDTH, OVERLAY_HEIGHT);
-        this._layoutChildren();
-        this._actor.set_pivot_point(0.5, 0.5);
-        this._actor.set_easing_mode(Clutter.AnimationMode.EASE_OUT_QUAD);
-        this._actor.set_easing_duration(120);
-    }
-
-    _layoutChildren() {
-        if (!this._actor || !this._label)
-            return;
 
         const cy = Math.floor(OVERLAY_HEIGHT / 2);
-
-        // Recording layout: [bars] [RECORDING] | [00:00]
+        if (this._dot) {
+            this._dot.set_position(10, cy - 3);
+            this._dot.set_size(6, 6);
+        }
         if (this._barsBox) {
-            this._barsBox.set_position(24, cy - 16);
-            this._barsBox.set_size(36, 32);
-        }
-        if (this._label) {
-            const labelX = this._state === 'transcribing' ? 62 : 70;
-            this._label.set_position(labelX, cy - 10);
-        }
-        if (this._divider) {
-            this._divider.set_position(178, cy - 12);
-            this._divider.set_size(1, 24);
-        }
-        if (this._timer)
-            this._timer.set_position(188, cy - 10);
-
-        // Transcribing layout: [spinner] [TRANSCRIBING]
-        if (this._spinner) {
-            this._spinner.set_position(16, cy - 12);
-            this._spinner.set_size(24, 24);
+            const barsX = 26;
+            this._barsBox.set_position(barsX, cy - Math.floor(BAR_MAX_H / 2));
+            this._barsBox.set_size(OVERLAY_WIDTH - barsX - 8, BAR_MAX_H);
         }
     }
 
@@ -213,16 +159,11 @@ export default class WhisrsOverlayExtension extends Extension {
         if (this._animationId)
             return;
 
-        this._frame = 0;
-        this._level = 0;
-        this._targetLevel = 0;
         this._animationId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 24, () => {
             this._frame++;
             const target = this._targetLevel ?? 0;
             this._level = target > this._level ? target : Math.max(0, this._level * 0.85);
             this._updateBars();
-            this._updateTimer();
-            this._updateSpinner();
             return GLib.SOURCE_CONTINUE;
         });
         this._updateBars();
@@ -236,35 +177,33 @@ export default class WhisrsOverlayExtension extends Extension {
     }
 
     _updateBars() {
-        if (!this._bars || this._state !== 'recording')
+        if (!this._bars || this._bars.length === 0)
             return;
 
-        for (let i = 0; i < this._bars.length; i++) {
+        if (this._state === 'recording') {
             const raw = Number.isFinite(this._level) ? this._level : 0;
-            const level = raw < 0.1 ? 0 : Math.min(1, (raw - 0.1) / 0.85);
-            const variance = 0.6 + (((i * 7 + 3) % 4) / 4) * 0.4;
-            const height = 4 + Math.round(Math.min(1, level * variance) * 28);
-            this._bars[i].set_height(height);
+            const level = Math.max(0, Math.min(1, raw));
+            for (let i = 0; i < this._bars.length; i++) {
+                const variance = 0.7 + Math.sin(i * 1.7) * 0.3;
+                const phase = Math.abs(Math.sin(this._frame / 6.0 + i * 0.9));
+                const effective = Math.min(1, Math.max(0, level * variance));
+                const dynamic = effective * (0.6 + 0.4 * phase);
+                const h = Math.max(BAR_BASELINE, Math.round(BAR_BASELINE + dynamic * (BAR_MAX_H - BAR_BASELINE)));
+                this._bars[i].set_height(h);
+                this._bars[i].opacity = 255;
+            }
+        } else if (this._state === 'transcribing') {
+            const cycle = BAR_COUNT * 2 - 2;
+            const pos = Math.floor(this._frame / 4) % Math.max(1, cycle);
+            const active = pos < BAR_COUNT ? pos : cycle - pos;
+            for (let i = 0; i < this._bars.length; i++) {
+                const dist = Math.abs(i - active);
+                const intensity = Math.max(0.18, 1 - dist / 2.5);
+                const h = Math.round(BAR_BASELINE + (BAR_MAX_H - BAR_BASELINE) * (0.45 + 0.55 * intensity));
+                this._bars[i].set_height(Math.max(BAR_BASELINE, h));
+                this._bars[i].opacity = Math.round(255 * intensity);
+            }
         }
-    }
-
-    _updateTimer() {
-        if (!this._timer || this._state !== 'recording' || !this._recordingStart)
-            return;
-
-        const elapsed = Math.floor((Date.now() - this._recordingStart) / 1000);
-        const mm = String(Math.floor(elapsed / 60)).padStart(2, '0');
-        const ss = String(elapsed % 60).padStart(2, '0');
-        this._timer.text = `${mm}:${ss}`;
-    }
-
-    _updateSpinner() {
-        if (!this._spinner || this._state !== 'transcribing')
-            return;
-
-        const angle = (this._frame * 8) % 360;
-        this._spinner.set_pivot_point(0.5, 0.5);
-        this._spinner.set_rotation_angle(Clutter.RotateAxis.Z_AXIS, angle);
     }
 
     _setLevel(level) {
@@ -273,7 +212,5 @@ export default class WhisrsOverlayExtension extends Extension {
             return;
 
         this._targetLevel = Math.max(0, Math.min(1, numeric));
-        if (this._state === 'recording')
-            this._updateBars();
     }
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -15,10 +15,10 @@ const THEME_SIGNAL = 'ThemeChanged';
 const OVERLAY_WIDTH = 100;
 const OVERLAY_HEIGHT = 40;
 const BOTTOM_MARGIN = 16;
-const BAR_COUNT = 5;
-const BAR_W = 4;
-const BAR_GAP = 3;
-const BAR_BASELINE = 3;
+const BAR_COUNT = 7;
+const BAR_W = 3;
+const BAR_GAP = 2;
+const BAR_BASELINE = 6;
 const BAR_VPAD = 6;
 
 // Spawn animation: pill height morphs from a 4-px sliver to its full
@@ -94,6 +94,8 @@ export default class WhisrsOverlayExtension extends Extension {
         this._state = 'idle';
         this._level = 0;
         this._targetLevel = 0;
+        this._levelVelocity = 0;
+        this._lastUpdateMs = 0;
         this._frame = 0;
 
         this._position();
@@ -243,16 +245,25 @@ export default class WhisrsOverlayExtension extends Extension {
     _startAnimation() {
         if (this._animationId) return;
 
-        // Envelope follower: fast attack (instant peak tracking) + slow
-        // release. Holds the bar height during speech so the bars don't
-        // bounce with every audio buffer's RMS variation.
-        this._animationId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 24, () => {
+        // Critically-damped-ish spring on the displayed level, stepped
+        // with real wall-clock dt so the time constants are real-world ms,
+        // not "per tick". Tuned to settle in ~150–200 ms with no
+        // perceptible overshoot — the bars *track* the voice rather than
+        // chase it. ~16 ms tick ≈ 60 fps.
+        const STIFFNESS = 360;
+        const DAMPING = 32;
+        this._lastUpdateMs = GLib.get_monotonic_time() / 1000;
+        this._animationId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 16, () => {
             this._frame++;
+            const nowMs = GLib.get_monotonic_time() / 1000;
+            const dt = Math.min(0.1, Math.max(0, (nowMs - this._lastUpdateMs) / 1000));
+            this._lastUpdateMs = nowMs;
             const target = this._targetLevel ?? 0;
-            if (target > this._level) {
-                this._level = target;
-            } else {
-                this._level = this._level * 0.85 + target * 0.15;
+            if (dt > 0) {
+                const force = (target - this._level) * STIFFNESS;
+                const drag = this._levelVelocity * DAMPING;
+                this._levelVelocity += (force - drag) * dt;
+                this._level = Math.max(0, Math.min(1, this._level + this._levelVelocity * dt));
             }
             this._updateBars();
             return GLib.SOURCE_CONTINUE;
@@ -265,13 +276,21 @@ export default class WhisrsOverlayExtension extends Extension {
             GLib.Source.remove(this._animationId);
             this._animationId = 0;
         }
+        this._levelVelocity = 0;
+        this._level = 0;
     }
 
+    /// Wavy taper across the bar row — center bar at ~100 %, with a cosine
+    /// modulation so adjacent bars alternate between "taller" and "shorter"
+    /// inside a gaussian envelope. Reads as an equalizer pattern instead
+    /// of a smooth bell.
     _taper(i) {
         if (BAR_COUNT <= 1) return 1;
         const center = (BAR_COUNT - 1) / 2;
         const d = (i - center) / center;
-        return Math.exp(-d * d);
+        const envelope = Math.exp(-d * d);
+        const wave = 0.75 + 0.25 * Math.cos(Math.PI * (i - center));
+        return envelope * wave;
     }
 
     _updateBars() {

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -10,18 +10,24 @@ const DBUS_INTERFACE = 'org.whisrs.Overlay';
 const DBUS_PATH = '/org/whisrs/Overlay';
 const STATE_SIGNAL = 'StateChanged';
 const LEVEL_SIGNAL = 'LevelChanged';
+const THEME_SIGNAL = 'ThemeChanged';
 
-const OVERLAY_WIDTH = 110;
-const OVERLAY_HEIGHT = 40;
-const BOTTOM_MARGIN = 24;
-const BAR_COUNT = 5;
-const BAR_BASELINE = 4;
-const BAR_MAX_H = 28;
+const OVERLAY_WIDTH = 100;
+const OVERLAY_HEIGHT = 34;
+const BOTTOM_MARGIN = 16;
+const BAR_COUNT = 18;
+const BAR_W = 2;
+const BAR_GAP = 2;
+const BAR_BASELINE = 2;
+
+const KNOWN_THEMES = ['ember', 'carbon', 'cyan'];
 
 export default class WhisrsOverlayExtension extends Extension {
     enable() {
+        this._theme = 'ember';
+
         this._actor = new St.Widget({
-            style_class: 'whisrs-overlay whisrs-overlay-hidden',
+            style_class: 'whisrs-overlay whisrs-overlay-hidden whisrs-theme-ember',
             layout_manager: new Clutter.FixedLayout(),
             reactive: false,
             visible: false,
@@ -66,6 +72,14 @@ export default class WhisrsOverlayExtension extends Extension {
                 this._setLevel(level);
             }
         );
+        this._themeSignalId = Gio.DBus.session.signal_subscribe(
+            null, DBUS_INTERFACE, THEME_SIGNAL, DBUS_PATH, null,
+            Gio.DBusSignalFlags.NONE,
+            (_c, _s, _p, _i, _sig, parameters) => {
+                const [theme] = parameters.deep_unpack();
+                this._setTheme(theme);
+            }
+        );
 
         this._state = 'idle';
         this._level = 0;
@@ -78,14 +92,13 @@ export default class WhisrsOverlayExtension extends Extension {
     disable() {
         this._stopAnimation();
 
-        if (this._signalId) {
-            Gio.DBus.session.signal_unsubscribe(this._signalId);
-            this._signalId = 0;
+        for (const id of [this._signalId, this._levelSignalId, this._themeSignalId]) {
+            if (id) Gio.DBus.session.signal_unsubscribe(id);
         }
-        if (this._levelSignalId) {
-            Gio.DBus.session.signal_unsubscribe(this._levelSignalId);
-            this._levelSignalId = 0;
-        }
+        this._signalId = 0;
+        this._levelSignalId = 0;
+        this._themeSignalId = 0;
+
         if (this._monitorsChangedId) {
             Main.layoutManager.disconnect(this._monitorsChangedId);
             this._monitorsChangedId = 0;
@@ -97,9 +110,17 @@ export default class WhisrsOverlayExtension extends Extension {
         this._barsBox = null;
     }
 
+    _setTheme(theme) {
+        if (!this._actor) return;
+        const next = KNOWN_THEMES.includes(String(theme)) ? String(theme) : 'ember';
+        if (next === this._theme) return;
+        this._actor.remove_style_class_name(`whisrs-theme-${this._theme}`);
+        this._actor.add_style_class_name(`whisrs-theme-${next}`);
+        this._theme = next;
+    }
+
     _setState(state) {
-        if (!this._actor)
-            return;
+        if (!this._actor) return;
 
         const normalized = String(state).toLowerCase();
         this._actor.remove_style_class_name('whisrs-overlay-recording');
@@ -119,7 +140,6 @@ export default class WhisrsOverlayExtension extends Extension {
         } else {
             this._state = 'idle';
             this._actor.add_style_class_name('whisrs-overlay-hidden');
-            // Hide after the snappy CSS fade-out completes.
             GLib.timeout_add(GLib.PRIORITY_DEFAULT, 80, () => {
                 if (this._state === 'idle' && this._actor)
                     this._actor.visible = false;
@@ -130,8 +150,7 @@ export default class WhisrsOverlayExtension extends Extension {
     }
 
     _position() {
-        if (!this._actor)
-            return;
+        if (!this._actor) return;
 
         const monitor = Main.layoutManager.primaryMonitor;
         const x = Math.floor(monitor.x + (monitor.width - OVERLAY_WIDTH) / 2);
@@ -140,18 +159,17 @@ export default class WhisrsOverlayExtension extends Extension {
         this._actor.set_size(OVERLAY_WIDTH, OVERLAY_HEIGHT);
 
         const cy = Math.floor(OVERLAY_HEIGHT / 2);
+        const barBlock = BAR_COUNT * BAR_W + (BAR_COUNT - 1) * BAR_GAP;
+        const barsX = Math.floor((OVERLAY_WIDTH - barBlock) / 2);
+        const maxH = OVERLAY_HEIGHT - 10;
         if (this._barsBox) {
-            // 5 bars × 4px wide + 4 gaps × 3px = 32px, centered.
-            const barBlock = BAR_COUNT * 4 + (BAR_COUNT - 1) * 3;
-            const barsX = Math.floor((OVERLAY_WIDTH - barBlock) / 2);
-            this._barsBox.set_position(barsX, cy - Math.floor(BAR_MAX_H / 2));
-            this._barsBox.set_size(barBlock, BAR_MAX_H);
+            this._barsBox.set_position(barsX, cy - Math.floor(maxH / 2));
+            this._barsBox.set_size(barBlock, maxH);
         }
     }
 
     _startAnimation() {
-        if (this._animationId)
-            return;
+        if (this._animationId) return;
 
         this._animationId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 24, () => {
             this._frame++;
@@ -170,41 +188,49 @@ export default class WhisrsOverlayExtension extends Extension {
         }
     }
 
+    _taper(i) {
+        if (BAR_COUNT <= 1) return 1;
+        const center = (BAR_COUNT - 1) / 2;
+        const d = (i - center) / center;
+        return Math.exp(-d * d);
+    }
+
     _updateBars() {
-        if (!this._bars || this._bars.length === 0)
-            return;
+        if (!this._bars || this._bars.length === 0) return;
+
+        const maxH = OVERLAY_HEIGHT - 10;
 
         if (this._state === 'recording') {
             const raw = Number.isFinite(this._level) ? this._level : 0;
             const level = Math.max(0, Math.min(1, raw));
             for (let i = 0; i < this._bars.length; i++) {
-                const variance = 0.7 + Math.sin(i * 1.7) * 0.3;
-                const phase = Math.abs(Math.sin(this._frame / 6.0 + i * 0.9));
-                const effective = Math.min(1, Math.max(0, level * variance));
-                const dynamic = effective * (0.6 + 0.4 * phase);
-                const h = Math.max(BAR_BASELINE, Math.round(BAR_BASELINE + dynamic * (BAR_MAX_H - BAR_BASELINE)));
+                const taper = this._taper(i);
+                const phase = Math.abs(Math.sin(this._frame / 5 + i * 0.7));
+                const effective = Math.min(1, Math.max(0, level * taper));
+                const dynamic = effective * (0.7 + 0.3 * phase);
+                const h = Math.max(BAR_BASELINE, Math.round(BAR_BASELINE + dynamic * (maxH - BAR_BASELINE)));
                 this._bars[i].set_height(h);
                 this._bars[i].opacity = 255;
             }
         } else if (this._state === 'transcribing') {
             const cycle = BAR_COUNT * 2 - 2;
-            const pos = Math.floor(this._frame / 4) % Math.max(1, cycle);
+            const pos = Math.floor(this._frame / 3) % Math.max(1, cycle);
             const active = pos < BAR_COUNT ? pos : cycle - pos;
             for (let i = 0; i < this._bars.length; i++) {
+                const taper = this._taper(i);
                 const dist = Math.abs(i - active);
-                const intensity = Math.max(0.18, 1 - dist / 2.5);
-                const h = Math.round(BAR_BASELINE + (BAR_MAX_H - BAR_BASELINE) * (0.45 + 0.55 * intensity));
-                this._bars[i].set_height(Math.max(BAR_BASELINE, h));
-                this._bars[i].opacity = Math.round(255 * intensity);
+                const intensity = Math.max(0.15, Math.exp(-(dist * dist) / 4));
+                const dynamic = intensity * taper;
+                const h = Math.max(BAR_BASELINE, Math.round(BAR_BASELINE + dynamic * (maxH - BAR_BASELINE) * 0.85));
+                this._bars[i].set_height(h);
+                this._bars[i].opacity = Math.round(255 * (0.3 + 0.7 * intensity));
             }
         }
     }
 
     _setLevel(level) {
         const numeric = Number(level);
-        if (!Number.isFinite(numeric))
-            return;
-
+        if (!Number.isFinite(numeric)) return;
         this._targetLevel = Math.max(0, Math.min(1, numeric));
     }
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -13,16 +13,22 @@ const LEVEL_SIGNAL = 'LevelChanged';
 const THEME_SIGNAL = 'ThemeChanged';
 
 const OVERLAY_WIDTH = 100;
-const OVERLAY_HEIGHT = 34;
+const OVERLAY_HEIGHT = 64;
 const BOTTOM_MARGIN = 16;
 const BAR_COUNT = 5;
-const BAR_W = 6;
-const BAR_GAP = 4;
-const BAR_BASELINE = 3;
+const BAR_W = 3;
+const BAR_GAP = 3;
+const BAR_BASELINE = 2;
+const BAR_VPAD = 7;
 
-const SPAWN_IN_MS = 180;
+// Spawn animation: pill height morphs from a 4-px sliver to its full
+// height, anchored to the bottom of its placement. Slight overshoot via
+// EASE_OUT_BACK for a "physical arrival" pop.
+const SPAWN_IN_MS = 220;
 const SPAWN_OUT_MS = 140;
+const SPAWN_PILL_MIN_H = 4;
 const BARS_GRACE_MS = 80;
+const BARS_FADE_MS = 80;
 
 const KNOWN_THEMES = ['ember', 'carbon', 'cyan'];
 
@@ -158,34 +164,55 @@ export default class WhisrsOverlayExtension extends Extension {
         }
     }
 
-    /// Slide the pill up + scale up + fade in. Clutter applies the easing.
+    /// Pill "draws out" from a thin line at the bottom edge, growing to
+    /// full height with EASE_OUT_BACK overshoot. Bars stay invisible
+    /// during the grow, then fade in once the pill is mostly settled.
     _spawnIn() {
         if (!this._actor) return;
-        // Snap to the start state without easing.
-        this._actor.set_easing_duration(0);
-        this._actor.translation_y = 8;
-        this._actor.set_pivot_point(0.5, 0.5);
-        this._actor.set_scale(0.92, 0.92);
-        this._actor.opacity = 0;
 
-        // Then animate to the rest state.
-        this._actor.set_easing_mode(Clutter.AnimationMode.EASE_OUT_CUBIC);
+        // Snap to the start state.
+        this._actor.set_easing_duration(0);
+        this._actor.set_pivot_point(0.5, 1.0); // bottom-center
+        this._actor.set_scale(1.0, SPAWN_PILL_MIN_H / OVERLAY_HEIGHT);
+        this._actor.opacity = 0;
+        if (this._barsBox) this._barsBox.opacity = 0;
+
+        // Then animate to full size — Clutter's EASE_OUT_BACK gives the
+        // small overshoot that makes the arrival feel physical.
+        this._actor.set_easing_mode(Clutter.AnimationMode.EASE_OUT_BACK);
         this._actor.set_easing_duration(SPAWN_IN_MS);
-        this._actor.translation_y = 0;
         this._actor.set_scale(1.0, 1.0);
+
+        this._actor.set_easing_mode(Clutter.AnimationMode.EASE_OUT_QUAD);
+        this._actor.set_easing_duration(Math.round(SPAWN_IN_MS * 0.64));
         this._actor.opacity = 255;
 
-        // Hold bars at baseline while the pill is still flying in.
-        this._barsGraceUntil = Date.now() + BARS_GRACE_MS;
+        // Bars: grace, then a quick fade-in once the pill is mostly grown.
+        this._barsGraceUntil = Date.now() + BARS_GRACE_MS + BARS_FADE_MS;
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, BARS_GRACE_MS, () => {
+            if (this._barsBox && this._state !== 'idle') {
+                this._barsBox.set_easing_mode(Clutter.AnimationMode.EASE_OUT_QUAD);
+                this._barsBox.set_easing_duration(BARS_FADE_MS);
+                this._barsBox.opacity = 255;
+            }
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
-    /// Reverse the spawn: slide down + slight shrink + fade out, then hide.
+    /// Reverse: collapse height back to a sliver while fading out, then
+    /// hide. EASE_IN_CUBIC for a sharp accelerated dismiss.
     _spawnOut() {
         if (!this._actor) return;
+
+        if (this._barsBox) {
+            this._barsBox.set_easing_mode(Clutter.AnimationMode.EASE_IN_QUAD);
+            this._barsBox.set_easing_duration(Math.round(SPAWN_OUT_MS * 0.7));
+            this._barsBox.opacity = 0;
+        }
+
         this._actor.set_easing_mode(Clutter.AnimationMode.EASE_IN_CUBIC);
         this._actor.set_easing_duration(SPAWN_OUT_MS);
-        this._actor.translation_y = 8;
-        this._actor.set_scale(0.96, 0.96);
+        this._actor.set_scale(1.0, SPAWN_PILL_MIN_H / OVERLAY_HEIGHT);
         this._actor.opacity = 0;
 
         GLib.timeout_add(GLib.PRIORITY_DEFAULT, SPAWN_OUT_MS + 20, () => {
@@ -206,7 +233,7 @@ export default class WhisrsOverlayExtension extends Extension {
         const cy = Math.floor(OVERLAY_HEIGHT / 2);
         const barBlock = BAR_COUNT * BAR_W + (BAR_COUNT - 1) * BAR_GAP;
         const barsX = Math.floor((OVERLAY_WIDTH - barBlock) / 2);
-        const maxH = OVERLAY_HEIGHT - 10;
+        const maxH = OVERLAY_HEIGHT - BAR_VPAD * 2;
         if (this._barsBox) {
             this._barsBox.set_position(barsX, cy - Math.floor(maxH / 2));
             this._barsBox.set_size(barBlock, maxH);
@@ -253,7 +280,8 @@ export default class WhisrsOverlayExtension extends Extension {
                 const taper = this._taper(i);
                 const phase = Math.abs(Math.sin(this._frame / 5 + i * 0.7));
                 const effective = Math.min(1, Math.max(0, level * taper));
-                const dynamic = effective * (0.7 + 0.3 * phase);
+                // Audio-led: 85% level, 15% phase animation.
+                const dynamic = effective * (0.85 + 0.15 * phase);
                 const h = Math.max(BAR_BASELINE, Math.round(BAR_BASELINE + dynamic * (maxH - BAR_BASELINE)));
                 this._bars[i].set_height(h);
                 this._bars[i].opacity = 255;

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -1,0 +1,245 @@
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Pango from 'gi://Pango';
+import St from 'gi://St';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+const DBUS_INTERFACE = 'org.whisrs.Overlay';
+const DBUS_PATH = '/org/whisrs/Overlay';
+const STATE_SIGNAL = 'StateChanged';
+const LEVEL_SIGNAL = 'LevelChanged';
+const OVERLAY_WIDTH = 260;
+const OVERLAY_HEIGHT = 62;
+
+export default class WhisrsOverlayExtension extends Extension {
+    enable() {
+        this._actor = new St.Widget({
+            style_class: 'whisrs-overlay whisrs-overlay-hidden',
+            layout_manager: new Clutter.FixedLayout(),
+            reactive: false,
+            visible: false,
+        });
+
+        this._dot = new St.Widget({style_class: 'whisrs-overlay-dot'});
+        this._bars = [];
+        const bars = new St.BoxLayout({
+            style_class: 'whisrs-overlay-bars',
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        for (let i = 0; i < 6; i++) {
+            const bar = new St.Widget({
+                style_class: 'whisrs-overlay-bar',
+                y_align: Clutter.ActorAlign.CENTER,
+                y_expand: false,
+            });
+            this._bars.push(bar);
+            bars.add_child(bar);
+        }
+
+        this._label = new St.Label({
+            style_class: 'whisrs-overlay-label',
+            text: '',
+        });
+        this._label.clutter_text.set_ellipsize(Pango.EllipsizeMode.NONE);
+        this._label.clutter_text.set_line_wrap(false);
+
+        this._actor.add_child(this._dot);
+        this._actor.add_child(bars);
+        this._actor.add_child(this._label);
+        Main.uiGroup.add_child(this._actor);
+
+        this._monitorsChangedId = Main.layoutManager.connect(
+            'monitors-changed',
+            () => this._position()
+        );
+        this._allocationChangedId = this._actor.connect(
+            'notify::allocation',
+            () => this._position()
+        );
+
+        this._signalId = Gio.DBus.session.signal_subscribe(
+            null,
+            DBUS_INTERFACE,
+            STATE_SIGNAL,
+            DBUS_PATH,
+            null,
+            Gio.DBusSignalFlags.NONE,
+            (_connection, _sender, _path, _iface, _signal, parameters) => {
+                const [state] = parameters.deep_unpack();
+                this._setState(state);
+            }
+        );
+        this._levelSignalId = Gio.DBus.session.signal_subscribe(
+            null,
+            DBUS_INTERFACE,
+            LEVEL_SIGNAL,
+            DBUS_PATH,
+            null,
+            Gio.DBusSignalFlags.NONE,
+            (_connection, _sender, _path, _iface, _signal, parameters) => {
+                const [level] = parameters.deep_unpack();
+                this._setLevel(level);
+            }
+        );
+
+        this._position();
+    }
+
+    disable() {
+        this._stopAnimation();
+
+        if (this._signalId) {
+            Gio.DBus.session.signal_unsubscribe(this._signalId);
+            this._signalId = 0;
+        }
+
+        if (this._levelSignalId) {
+            Gio.DBus.session.signal_unsubscribe(this._levelSignalId);
+            this._levelSignalId = 0;
+        }
+
+        if (this._monitorsChangedId) {
+            Main.layoutManager.disconnect(this._monitorsChangedId);
+            this._monitorsChangedId = 0;
+        }
+
+        if (this._allocationChangedId) {
+            this._actor.disconnect(this._allocationChangedId);
+            this._allocationChangedId = 0;
+        }
+
+        this._actor?.destroy();
+        this._actor = null;
+        this._dot = null;
+        this._label = null;
+        this._bars = [];
+    }
+
+    _setState(state) {
+        if (!this._actor || !this._label)
+            return;
+
+        const normalized = String(state).toLowerCase();
+        this._actor.remove_style_class_name('whisrs-overlay-recording');
+        this._actor.remove_style_class_name('whisrs-overlay-transcribing');
+        this._actor.remove_style_class_name('whisrs-overlay-hidden');
+
+        if (normalized === 'recording') {
+            this._state = 'recording';
+            this._label.text = 'RECORDING';
+            this._actor.add_style_class_name('whisrs-overlay-recording');
+            this._actor.visible = true;
+            this._startAnimation();
+            this._position();
+        } else if (normalized === 'transcribing') {
+            this._state = 'transcribing';
+            this._label.text = 'TRANSCRIBING';
+            this._actor.add_style_class_name('whisrs-overlay-transcribing');
+            this._actor.visible = true;
+            this._startAnimation();
+            this._position();
+        } else {
+            this._state = 'idle';
+            this._label.text = '';
+            this._actor.add_style_class_name('whisrs-overlay-hidden');
+            this._actor.visible = false;
+            this._stopAnimation();
+        }
+    }
+
+    _position() {
+        if (!this._actor)
+            return;
+
+        const monitor = Main.layoutManager.primaryMonitor;
+        const width = OVERLAY_WIDTH;
+        const height = OVERLAY_HEIGHT;
+        const x = Math.floor(monitor.x + (monitor.width - width) / 2);
+        const y = Math.floor(monitor.y + monitor.height - height - 34);
+        this._actor.set_position(Math.max(monitor.x, x), Math.max(monitor.y, y));
+        this._actor.set_size(width, height);
+        this._layoutChildren();
+        this._actor.set_pivot_point(0.5, 0.5);
+        this._actor.set_easing_mode(Clutter.AnimationMode.EASE_OUT_QUAD);
+        this._actor.set_easing_duration(120);
+    }
+
+    _layoutChildren() {
+        if (!this._actor || !this._dot || !this._label)
+            return;
+
+        this._dot.set_position(18, 26);
+        this._dot.set_size(10, 10);
+
+        const bars = this._bars?.[0]?.get_parent();
+        if (bars) {
+            bars.set_position(42, 15);
+            bars.set_size(66, 32);
+        }
+
+        this._label.set_position(122, 22);
+        this._label.set_size(120, 20);
+    }
+
+    _startAnimation() {
+        if (this._animationId)
+            return;
+
+        this._frame = 0;
+        this._level = 0;
+        this._targetLevel = 0;
+        this._animationId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 24, () => {
+            this._frame++;
+            // Snap up instantly, decay smoothly
+            const target = this._targetLevel ?? 0;
+            if (target > this._level)
+                this._level = target;
+            else
+                this._level = Math.max(0, this._level * 0.85);
+            this._updateBars();
+            return GLib.SOURCE_CONTINUE;
+        });
+        this._updateBars();
+    }
+
+    _stopAnimation() {
+        if (this._animationId) {
+            GLib.Source.remove(this._animationId);
+            this._animationId = 0;
+        }
+    }
+
+    _updateBars() {
+        if (!this._bars)
+            return;
+
+        for (let i = 0; i < this._bars.length; i++) {
+            let level = 0;
+            if (this._state === 'recording') {
+                const raw = Number.isFinite(this._level) ? this._level : 0;
+                // Noise gate: below 0.1 treat as silence, above it scale to full range
+                level = raw < 0.1 ? 0 : Math.min(1, (raw - 0.1) / 0.6);
+            } else if (this._state === 'transcribing') {
+                // Animated wave during transcription
+                const phase = ((this._frame + i * 5) % 24) / 24;
+                level = Math.abs(Math.sin(phase * Math.PI * 2));
+            }
+            const variance = 0.7 + (((i * 7 + 3) % 6) / 6) * 0.3;
+            const height = 4 + Math.round(Math.min(1, level * variance) * 28);
+            this._bars[i].set_height(height);
+        }
+    }
+
+    _setLevel(level) {
+        const numeric = Number(level);
+        if (!Number.isFinite(numeric))
+            return;
+
+        this._targetLevel = Math.max(0, Math.min(1, numeric));
+        if (this._state === 'recording')
+            this._updateBars();
+    }
+}

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -13,13 +13,13 @@ const LEVEL_SIGNAL = 'LevelChanged';
 const THEME_SIGNAL = 'ThemeChanged';
 
 const OVERLAY_WIDTH = 100;
-const OVERLAY_HEIGHT = 64;
+const OVERLAY_HEIGHT = 40;
 const BOTTOM_MARGIN = 16;
 const BAR_COUNT = 5;
-const BAR_W = 3;
+const BAR_W = 4;
 const BAR_GAP = 3;
-const BAR_BASELINE = 2;
-const BAR_VPAD = 7;
+const BAR_BASELINE = 3;
+const BAR_VPAD = 6;
 
 // Spawn animation: pill height morphs from a 4-px sliver to its full
 // height, anchored to the bottom of its placement. Slight overshoot via
@@ -276,13 +276,12 @@ export default class WhisrsOverlayExtension extends Extension {
             const grace = this._barsGraceUntil && Date.now() < this._barsGraceUntil;
             const raw = grace ? 0 : (Number.isFinite(this._level) ? this._level : 0);
             const level = Math.max(0, Math.min(1, raw));
+            // Pure level-driven: each bar stays anchored at the pill
+            // center and grows symmetrically. No per-frame phase wobble.
             for (let i = 0; i < this._bars.length; i++) {
                 const taper = this._taper(i);
-                const phase = Math.abs(Math.sin(this._frame / 5 + i * 0.7));
                 const effective = Math.min(1, Math.max(0, level * taper));
-                // Audio-led: 85% level, 15% phase animation.
-                const dynamic = effective * (0.85 + 0.15 * phase);
-                const h = Math.max(BAR_BASELINE, Math.round(BAR_BASELINE + dynamic * (maxH - BAR_BASELINE)));
+                const h = Math.max(BAR_BASELINE, Math.round(BAR_BASELINE + effective * (maxH - BAR_BASELINE)));
                 this._bars[i].set_height(h);
                 this._bars[i].opacity = 255;
             }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -15,19 +15,23 @@ const THEME_SIGNAL = 'ThemeChanged';
 const OVERLAY_WIDTH = 100;
 const OVERLAY_HEIGHT = 34;
 const BOTTOM_MARGIN = 16;
-const BAR_COUNT = 18;
-const BAR_W = 2;
-const BAR_GAP = 2;
-const BAR_BASELINE = 2;
+const BAR_COUNT = 5;
+const BAR_W = 6;
+const BAR_GAP = 4;
+const BAR_BASELINE = 3;
+
+const SPAWN_IN_MS = 180;
+const SPAWN_OUT_MS = 140;
+const BARS_GRACE_MS = 80;
 
 const KNOWN_THEMES = ['ember', 'carbon', 'cyan'];
 
 export default class WhisrsOverlayExtension extends Extension {
     enable() {
-        this._theme = 'ember';
+        this._theme = 'carbon';
 
         this._actor = new St.Widget({
-            style_class: 'whisrs-overlay whisrs-overlay-hidden whisrs-theme-ember',
+            style_class: 'whisrs-overlay whisrs-overlay-hidden whisrs-theme-carbon',
             layout_manager: new Clutter.FixedLayout(),
             reactive: false,
             visible: false,
@@ -112,7 +116,7 @@ export default class WhisrsOverlayExtension extends Extension {
 
     _setTheme(theme) {
         if (!this._actor) return;
-        const next = KNOWN_THEMES.includes(String(theme)) ? String(theme) : 'ember';
+        const next = KNOWN_THEMES.includes(String(theme)) ? String(theme) : 'carbon';
         if (next === this._theme) return;
         this._actor.remove_style_class_name(`whisrs-theme-${this._theme}`);
         this._actor.add_style_class_name(`whisrs-theme-${next}`);
@@ -123,6 +127,9 @@ export default class WhisrsOverlayExtension extends Extension {
         if (!this._actor) return;
 
         const normalized = String(state).toLowerCase();
+        const wasIdle = this._state === 'idle';
+        const nowIdle = normalized === 'idle';
+
         this._actor.remove_style_class_name('whisrs-overlay-recording');
         this._actor.remove_style_class_name('whisrs-overlay-transcribing');
         this._actor.remove_style_class_name('whisrs-overlay-hidden');
@@ -131,22 +138,60 @@ export default class WhisrsOverlayExtension extends Extension {
             this._state = 'recording';
             this._actor.add_style_class_name('whisrs-overlay-recording');
             this._actor.visible = true;
+            if (wasIdle) this._spawnIn();
             this._startAnimation();
         } else if (normalized === 'transcribing') {
             this._state = 'transcribing';
             this._actor.add_style_class_name('whisrs-overlay-transcribing');
             this._actor.visible = true;
+            if (wasIdle) this._spawnIn();
             this._startAnimation();
         } else {
             this._state = 'idle';
             this._actor.add_style_class_name('whisrs-overlay-hidden');
-            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 80, () => {
-                if (this._state === 'idle' && this._actor)
-                    this._actor.visible = false;
-                return GLib.SOURCE_REMOVE;
-            });
+            if (!wasIdle) this._spawnOut();
             this._stopAnimation();
         }
+
+        if (!wasIdle && !nowIdle) {
+            // Recording <-> Transcribing — keep the pill steady.
+        }
+    }
+
+    /// Slide the pill up + scale up + fade in. Clutter applies the easing.
+    _spawnIn() {
+        if (!this._actor) return;
+        // Snap to the start state without easing.
+        this._actor.set_easing_duration(0);
+        this._actor.translation_y = 8;
+        this._actor.set_pivot_point(0.5, 0.5);
+        this._actor.set_scale(0.92, 0.92);
+        this._actor.opacity = 0;
+
+        // Then animate to the rest state.
+        this._actor.set_easing_mode(Clutter.AnimationMode.EASE_OUT_CUBIC);
+        this._actor.set_easing_duration(SPAWN_IN_MS);
+        this._actor.translation_y = 0;
+        this._actor.set_scale(1.0, 1.0);
+        this._actor.opacity = 255;
+
+        // Hold bars at baseline while the pill is still flying in.
+        this._barsGraceUntil = Date.now() + BARS_GRACE_MS;
+    }
+
+    /// Reverse the spawn: slide down + slight shrink + fade out, then hide.
+    _spawnOut() {
+        if (!this._actor) return;
+        this._actor.set_easing_mode(Clutter.AnimationMode.EASE_IN_CUBIC);
+        this._actor.set_easing_duration(SPAWN_OUT_MS);
+        this._actor.translation_y = 8;
+        this._actor.set_scale(0.96, 0.96);
+        this._actor.opacity = 0;
+
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, SPAWN_OUT_MS + 20, () => {
+            if (this._state === 'idle' && this._actor) this._actor.visible = false;
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
     _position() {
@@ -201,7 +246,8 @@ export default class WhisrsOverlayExtension extends Extension {
         const maxH = OVERLAY_HEIGHT - 10;
 
         if (this._state === 'recording') {
-            const raw = Number.isFinite(this._level) ? this._level : 0;
+            const grace = this._barsGraceUntil && Date.now() < this._barsGraceUntil;
+            const raw = grace ? 0 : (Number.isFinite(this._level) ? this._level : 0);
             const level = Math.max(0, Math.min(1, raw));
             for (let i = 0; i < this._bars.length; i++) {
                 const taper = this._taper(i);

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/extension.js
@@ -243,10 +243,17 @@ export default class WhisrsOverlayExtension extends Extension {
     _startAnimation() {
         if (this._animationId) return;
 
+        // Envelope follower: fast attack (instant peak tracking) + slow
+        // release. Holds the bar height during speech so the bars don't
+        // bounce with every audio buffer's RMS variation.
         this._animationId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 24, () => {
             this._frame++;
             const target = this._targetLevel ?? 0;
-            this._level = target > this._level ? target : Math.max(0, this._level * 0.85);
+            if (target > this._level) {
+                this._level = target;
+            } else {
+                this._level = this._level * 0.85 + target * 0.15;
+            }
             this._updateBars();
             return GLib.SOURCE_CONTINUE;
         });

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
@@ -3,5 +3,5 @@
   "name": "whisrs Overlay",
   "description": "Bottom-screen recording overlay for whisrs on GNOME Wayland.",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "version": 2
+  "version": 3
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
@@ -3,5 +3,5 @@
   "name": "whisrs Overlay",
   "description": "Bottom-screen recording overlay for whisrs on GNOME Wayland.",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "version": 4
+  "version": 5
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
@@ -3,5 +3,5 @@
   "name": "whisrs Overlay",
   "description": "Bottom-screen recording overlay for whisrs on GNOME Wayland.",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "version": 3
+  "version": 4
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "whisrs-overlay@eresende.github",
+  "name": "whisrs Overlay",
+  "description": "Bottom-screen recording overlay for whisrs on GNOME Wayland.",
+  "shell-version": ["45", "46", "47", "48", "49"],
+  "version": 2
+}

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
@@ -3,5 +3,5 @@
   "name": "whisrs Overlay",
   "description": "Bottom-screen recording overlay for whisrs on GNOME Wayland.",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "version": 7
+  "version": 8
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
@@ -3,5 +3,5 @@
   "name": "whisrs Overlay",
   "description": "Bottom-screen recording overlay for whisrs on GNOME Wayland.",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "version": 5
+  "version": 6
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/metadata.json
@@ -3,5 +3,5 @@
   "name": "whisrs Overlay",
   "description": "Bottom-screen recording overlay for whisrs on GNOME Wayland.",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "version": 6
+  "version": 7
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -1,61 +1,80 @@
 .whisrs-overlay {
-  width: 260px;
-  height: 62px;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.34);
-  background-color: rgba(18, 22, 28, 0.91);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.34);
-  transition-duration: 120ms;
+  width: 280px;
+  height: 56px;
+  border-radius: 999px;
+  border: 2px solid rgba(239, 68, 68, 0.0);
+  background-color: rgba(18, 20, 24, 0.95);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  transition-duration: 150ms;
 }
 
 .whisrs-overlay-hidden {
   opacity: 0;
 }
 
-.whisrs-overlay-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background-color: #ef4444;
+.whisrs-overlay-recording {
+  border-color: rgba(239, 68, 68, 0.7);
 }
 
-.whisrs-overlay-recording .whisrs-overlay-dot {
-  background-color: #ef4444;
-  box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.16);
+.whisrs-overlay-transcribing {
+  border-color: rgba(96, 165, 250, 0.5);
 }
 
-.whisrs-overlay-transcribing .whisrs-overlay-dot {
-  background-color: #f59e0b;
-  box-shadow: 0 0 0 6px rgba(245, 158, 11, 0.16);
-}
-
+/* Bars */
 .whisrs-overlay-bars {
   height: 32px;
-  width: 66px;
-  spacing: 5px;
+  spacing: 3px;
   align-items: center;
 }
 
 .whisrs-overlay-bar {
   width: 5px;
-  border-radius: 999px;
+  border-radius: 3px;
   background-color: #ef4444;
-  height: 8px;
-  min-height: 8px;
-  max-height: 34px;
-}
-
-.whisrs-overlay-recording .whisrs-overlay-bar {
-  background-color: #ef4444;
+  height: 4px;
+  min-height: 4px;
+  max-height: 32px;
 }
 
 .whisrs-overlay-transcribing .whisrs-overlay-bar {
-  background-color: #f59e0b;
+  background-color: #60a5fa;
 }
 
+/* Spinner — a partial arc via border trick */
+.whisrs-overlay-spinner {
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 2px solid rgba(96, 165, 250, 0.2);
+  border-top-color: #60a5fa;
+}
+
+/* Label */
 .whisrs-overlay-label {
-  color: #f5f5f5;
   font-size: 13px;
-  font-weight: 650;
-  letter-spacing: 0;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+
+.whisrs-overlay-recording .whisrs-overlay-label {
+  color: #ef4444;
+}
+
+.whisrs-overlay-transcribing .whisrs-overlay-label {
+  color: #60a5fa;
+}
+
+/* Divider */
+.whisrs-overlay-divider {
+  width: 1px;
+  height: 24px;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Timer */
+.whisrs-overlay-timer {
+  color: rgba(200, 200, 200, 0.7);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: monospace;
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -1,14 +1,12 @@
-/* whisrs brand:
- *   bg            #161420 (dark slate w/ purple tint)
- *   ring accent   #6C3FC5 (deep purple, brand primary)
- *   recording     #A3E635 (terminal green)
- *   transcribing  #6C3FC5 (deep purple)
+/* Themes are matched by class:
+ *   .whisrs-theme-ember    — default amber "tally light"
+ *   .whisrs-theme-carbon   — monochrome terminal
+ *   .whisrs-theme-cyan     — cool electric blue
  */
 
 .whisrs-overlay {
   border-radius: 999px;
-  background-color: rgba(22, 20, 32, 0.94);
-  border: 1px solid rgba(108, 63, 197, 0.28);
+  background-color: rgba(14, 14, 16, 0.92);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
   transition-duration: 60ms;
 }
@@ -18,19 +16,51 @@
 }
 
 .whisrs-overlay-bars {
-  spacing: 3px;
+  spacing: 2px;
   align-items: center;
 }
 
 .whisrs-overlay-bar {
-  width: 4px;
-  border-radius: 2px;
-  background-color: #a3e635;
-  height: 4px;
-  min-height: 4px;
-  max-height: 28px;
+  width: 2px;
+  border-radius: 1px;
+  background-color: #f0edf5;
+  height: 2px;
+  min-height: 2px;
+  max-height: 24px;
 }
 
-.whisrs-overlay-transcribing .whisrs-overlay-bar {
-  background-color: #6c3fc5;
+/* Ember (default) — amber recording, soft white transcribing. */
+.whisrs-theme-ember {
+  border: 1px solid rgba(249, 115, 22, 0.25);
+}
+.whisrs-theme-ember.whisrs-overlay-recording .whisrs-overlay-bar {
+  background-color: #f97316;
+  box-shadow: 0 0 4px rgba(249, 115, 22, 0.5);
+}
+.whisrs-theme-ember.whisrs-overlay-transcribing .whisrs-overlay-bar {
+  background-color: #f0edf5;
+}
+
+/* Carbon — monochrome. */
+.whisrs-theme-carbon {
+  border: 1px solid rgba(58, 58, 64, 0.5);
+}
+.whisrs-theme-carbon.whisrs-overlay-recording .whisrs-overlay-bar {
+  background-color: #f0edf5;
+}
+.whisrs-theme-carbon.whisrs-overlay-transcribing .whisrs-overlay-bar {
+  background-color: #9ca3af;
+}
+
+/* Cyan — electric blue. */
+.whisrs-theme-cyan {
+  border: 1px solid rgba(34, 211, 238, 0.25);
+  background-color: rgba(10, 15, 20, 0.92);
+}
+.whisrs-theme-cyan.whisrs-overlay-recording .whisrs-overlay-bar {
+  background-color: #22d3ee;
+  box-shadow: 0 0 4px rgba(34, 211, 238, 0.5);
+}
+.whisrs-theme-cyan.whisrs-overlay-transcribing .whisrs-overlay-bar {
+  background-color: #38bdf8;
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -1,7 +1,15 @@
+/* whisrs brand:
+ *   bg            #161420 (dark slate w/ purple tint)
+ *   ring accent   #6C3FC5 (deep purple, brand primary)
+ *   recording     #A3E635 (terminal green)
+ *   transcribing  #6C3FC5 (deep purple)
+ */
+
 .whisrs-overlay {
   border-radius: 999px;
-  background-color: rgba(18, 20, 24, 0.92);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  background-color: rgba(22, 20, 32, 0.94);
+  border: 1px solid rgba(108, 63, 197, 0.28);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
   transition-duration: 60ms;
 }
 
@@ -9,31 +17,20 @@
   opacity: 0;
 }
 
-/* Status dot */
-.whisrs-overlay-dot {
-  border-radius: 999px;
-  background-color: #ef4444;
-}
-
-.whisrs-overlay-transcribing .whisrs-overlay-dot {
-  background-color: #60a5fa;
-}
-
-/* Bars */
 .whisrs-overlay-bars {
-  spacing: 4px;
+  spacing: 3px;
   align-items: center;
 }
 
 .whisrs-overlay-bar {
-  width: 6px;
-  border-radius: 3px;
-  background-color: #ef4444;
-  height: 3px;
-  min-height: 3px;
-  max-height: 18px;
+  width: 4px;
+  border-radius: 2px;
+  background-color: #a3e635;
+  height: 4px;
+  min-height: 4px;
+  max-height: 28px;
 }
 
 .whisrs-overlay-transcribing .whisrs-overlay-bar {
-  background-color: #60a5fa;
+  background-color: #6c3fc5;
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -21,11 +21,11 @@
 }
 
 .whisrs-overlay-bar {
-  width: 4px;
-  border-radius: 2px;
+  width: 3px;
+  border-radius: 1.5px;
   background-color: #f0edf5;
-  height: 3px;
-  min-height: 3px;
+  height: 6px;
+  min-height: 6px;
   max-height: 28px;
 }
 

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -1,80 +1,39 @@
 .whisrs-overlay {
-  width: 280px;
-  height: 56px;
   border-radius: 999px;
-  border: 2px solid rgba(239, 68, 68, 0.0);
-  background-color: rgba(18, 20, 24, 0.95);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-  transition-duration: 150ms;
+  background-color: rgba(18, 20, 24, 0.92);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  transition-duration: 60ms;
 }
 
 .whisrs-overlay-hidden {
   opacity: 0;
 }
 
-.whisrs-overlay-recording {
-  border-color: rgba(239, 68, 68, 0.7);
+/* Status dot */
+.whisrs-overlay-dot {
+  border-radius: 999px;
+  background-color: #ef4444;
 }
 
-.whisrs-overlay-transcribing {
-  border-color: rgba(96, 165, 250, 0.5);
+.whisrs-overlay-transcribing .whisrs-overlay-dot {
+  background-color: #60a5fa;
 }
 
 /* Bars */
 .whisrs-overlay-bars {
-  height: 32px;
-  spacing: 3px;
+  spacing: 4px;
   align-items: center;
 }
 
 .whisrs-overlay-bar {
-  width: 5px;
+  width: 6px;
   border-radius: 3px;
   background-color: #ef4444;
-  height: 4px;
-  min-height: 4px;
-  max-height: 32px;
+  height: 3px;
+  min-height: 3px;
+  max-height: 18px;
 }
 
 .whisrs-overlay-transcribing .whisrs-overlay-bar {
   background-color: #60a5fa;
-}
-
-/* Spinner — a partial arc via border trick */
-.whisrs-overlay-spinner {
-  width: 20px;
-  height: 20px;
-  border-radius: 999px;
-  border: 2px solid rgba(96, 165, 250, 0.2);
-  border-top-color: #60a5fa;
-}
-
-/* Label */
-.whisrs-overlay-label {
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: 1px;
-}
-
-.whisrs-overlay-recording .whisrs-overlay-label {
-  color: #ef4444;
-}
-
-.whisrs-overlay-transcribing .whisrs-overlay-label {
-  color: #60a5fa;
-}
-
-/* Divider */
-.whisrs-overlay-divider {
-  width: 1px;
-  height: 24px;
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
-/* Timer */
-.whisrs-overlay-timer {
-  color: rgba(200, 200, 200, 0.7);
-  font-size: 13px;
-  font-weight: 500;
-  font-family: monospace;
 }

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -21,12 +21,12 @@
 }
 
 .whisrs-overlay-bar {
-  width: 2px;
-  border-radius: 1px;
+  width: 3px;
+  border-radius: 2px;
   background-color: #f0edf5;
   height: 2px;
   min-height: 2px;
-  max-height: 24px;
+  max-height: 50px;
 }
 
 /* Ember (default) — amber recording, soft white transcribing. */

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -1,0 +1,61 @@
+.whisrs-overlay {
+  width: 260px;
+  height: 62px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  background-color: rgba(18, 22, 28, 0.91);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.34);
+  transition-duration: 120ms;
+}
+
+.whisrs-overlay-hidden {
+  opacity: 0;
+}
+
+.whisrs-overlay-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background-color: #ef4444;
+}
+
+.whisrs-overlay-recording .whisrs-overlay-dot {
+  background-color: #ef4444;
+  box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.16);
+}
+
+.whisrs-overlay-transcribing .whisrs-overlay-dot {
+  background-color: #f59e0b;
+  box-shadow: 0 0 0 6px rgba(245, 158, 11, 0.16);
+}
+
+.whisrs-overlay-bars {
+  height: 32px;
+  width: 66px;
+  spacing: 5px;
+  align-items: center;
+}
+
+.whisrs-overlay-bar {
+  width: 5px;
+  border-radius: 999px;
+  background-color: #ef4444;
+  height: 8px;
+  min-height: 8px;
+  max-height: 34px;
+}
+
+.whisrs-overlay-recording .whisrs-overlay-bar {
+  background-color: #ef4444;
+}
+
+.whisrs-overlay-transcribing .whisrs-overlay-bar {
+  background-color: #f59e0b;
+}
+
+.whisrs-overlay-label {
+  color: #f5f5f5;
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: 0;
+}

--- a/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
+++ b/contrib/gnome-shell-extension/whisrs-overlay@eresende.github/stylesheet.css
@@ -21,12 +21,12 @@
 }
 
 .whisrs-overlay-bar {
-  width: 3px;
+  width: 4px;
   border-radius: 2px;
   background-color: #f0edf5;
-  height: 2px;
-  min-height: 2px;
-  max-height: 50px;
+  height: 3px;
+  min-height: 3px;
+  max-height: 28px;
 }
 
 /* Ember (default) — amber recording, soft white transcribing. */

--- a/src/audio/capture.rs
+++ b/src/audio/capture.rs
@@ -245,9 +245,10 @@ fn audio_level(data: &[i16]) -> f32 {
         .sum();
     let rms = (sum_squares / data.len() as f32).sqrt();
 
-    // Map RMS to a perceptual 0–1 range.  A sqrt curve gives quiet speech
-    // visible movement while keeping loud speech below saturation.
-    (rms * 100.0).sqrt().clamp(0.0, 1.0)
+    // Soft compressor: 1 - exp(-k*rms). Keeps quiet speech visible without
+    // saturating on the first loud syllable, so bars actually track speech
+    // dynamics instead of pegging at full deflection.
+    (1.0 - (-rms * 12.0).exp()).clamp(0.0, 1.0)
 }
 
 /// Encode raw PCM samples (16kHz, mono, i16) to a WAV byte buffer.

--- a/src/audio/capture.rs
+++ b/src/audio/capture.rs
@@ -54,6 +54,13 @@ impl AudioCaptureHandle {
     /// The capture runs on a dedicated thread. Audio chunks are sent through
     /// the internal channel; call `take_receiver()` to get the receiving end.
     pub fn start() -> anyhow::Result<Self> {
+        Self::start_with_level_tx(None)
+    }
+
+    /// Start capturing audio and optionally publish a normalized volume level.
+    pub fn start_with_level_tx(
+        level_tx: Option<tokio::sync::watch::Sender<f32>>,
+    ) -> anyhow::Result<Self> {
         let (tx, rx) = mpsc::unbounded_channel::<AudioChunk>();
         let stop_signal = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop_signal);
@@ -64,7 +71,7 @@ impl AudioCaptureHandle {
         let thread_handle = std::thread::Builder::new()
             .name("whisrs-audio".into())
             .spawn(move || {
-                run_capture(tx, stop_clone, init_tx);
+                run_capture(tx, stop_clone, init_tx, level_tx);
             })
             .context("failed to spawn audio capture thread")?;
 
@@ -130,8 +137,9 @@ fn run_capture(
     tx: mpsc::UnboundedSender<AudioChunk>,
     stop_signal: Arc<AtomicBool>,
     init_tx: std::sync::mpsc::Sender<anyhow::Result<()>>,
+    level_tx: Option<tokio::sync::watch::Sender<f32>>,
 ) {
-    let result = setup_and_run(tx, stop_signal, &init_tx);
+    let result = setup_and_run(tx, stop_signal, &init_tx, level_tx);
     if let Err(e) = result {
         // If init_tx hasn't been used yet, send the error.
         init_tx.send(Err(e)).ok();
@@ -142,6 +150,7 @@ fn setup_and_run(
     tx: mpsc::UnboundedSender<AudioChunk>,
     stop_signal: Arc<AtomicBool>,
     init_tx: &std::sync::mpsc::Sender<anyhow::Result<()>>,
+    level_tx: Option<tokio::sync::watch::Sender<f32>>,
 ) -> anyhow::Result<()> {
     let host = cpal::default_host();
     let device = host
@@ -185,10 +194,14 @@ fn setup_and_run(
         error!("audio stream error: {err}");
     };
 
+    let callback_level_tx = level_tx.clone();
     let stream = device
         .build_input_stream(
             &config,
             move |data: &[i16], _info: &cpal::InputCallbackInfo| {
+                if let Some(level_tx) = &callback_level_tx {
+                    let _ = level_tx.send(audio_level(data));
+                }
                 if tx.send(data.to_vec()).is_err() {
                     // Channel closed — capture is stopping.
                 }
@@ -210,9 +223,31 @@ fn setup_and_run(
     }
 
     debug!("audio capture stopping");
+    if let Some(level_tx) = &level_tx {
+        let _ = level_tx.send(0.0);
+    }
     drop(stream);
 
     Ok(())
+}
+
+fn audio_level(data: &[i16]) -> f32 {
+    if data.is_empty() {
+        return 0.0;
+    }
+
+    let sum_squares: f32 = data
+        .iter()
+        .map(|sample| {
+            let normalized = *sample as f32 / i16::MAX as f32;
+            normalized * normalized
+        })
+        .sum();
+    let rms = (sum_squares / data.len() as f32).sqrt();
+
+    // Map RMS to a perceptual 0–1 range.  A sqrt curve gives quiet speech
+    // visible movement while keeping loud speech below saturation.
+    (rms * 100.0).sqrt().clamp(0.0, 1.0)
 }
 
 /// Encode raw PCM samples (16kHz, mono, i16) to a WAV byte buffer.

--- a/src/audio/capture.rs
+++ b/src/audio/capture.rs
@@ -245,10 +245,11 @@ fn audio_level(data: &[i16]) -> f32 {
         .sum();
     let rms = (sum_squares / data.len() as f32).sqrt();
 
-    // Soft compressor: 1 - exp(-k*rms). Keeps quiet speech visible without
-    // saturating on the first loud syllable, so bars actually track speech
-    // dynamics instead of pegging at full deflection.
-    (1.0 - (-rms * 12.0).exp()).clamp(0.0, 1.0)
+    // Soft compressor: 1 - exp(-k*rms). k=18 maps typical speech RMS
+    // (~0.05–0.15) to the 0.6–0.95 range, so the visualizer reaches the
+    // top of its dynamic range during normal speech instead of hovering
+    // around 30 % deflection.
+    (1.0 - (-rms * 18.0).exp()).clamp(0.0, 1.0)
 }
 
 /// Encode raw PCM samples (16kHz, mono, i16) to a WAV byte buffer.

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -114,6 +114,9 @@ pub fn run_setup() -> Result<()> {
     // 5. Extra options.
     let (remove_filler_words, audio_feedback) = configure_extras()?;
 
+    // 5b. Bottom recording overlay.
+    let overlay = configure_overlay();
+
     // 6. Command mode LLM (optional).
     let llm_config = configure_llm()?;
 
@@ -130,7 +133,7 @@ pub fn run_setup() -> Result<()> {
             audio_feedback_volume: 0.5,
             vocabulary: Vec::new(),
             tray: true,
-            overlay: false,
+            overlay,
         },
         audio: AudioConfig {
             device: "default".to_string(),
@@ -1073,6 +1076,122 @@ fn configure_extras() -> Result<(bool, bool)> {
     }
 
     Ok((remove_fillers, audio_feedback))
+}
+
+/// Ask the user whether to enable the bottom recording overlay, and on GNOME
+/// offer to install the bundled Shell extension that renders it.
+fn configure_overlay() -> bool {
+    println!("\n{BOLD}Recording overlay (optional)...{RESET}");
+    println!("  {DIM}A small audio meter at the bottom of the screen while recording.{RESET}");
+
+    let enable = Confirm::new()
+        .with_prompt("Enable the recording overlay?")
+        .default(false)
+        .interact()
+        .unwrap_or(false);
+
+    if !enable {
+        return false;
+    }
+
+    if detect_compositor().as_deref() == Some("gnome") {
+        offer_install_gnome_extension();
+    }
+
+    println!("  {GREEN}Overlay enabled{RESET}");
+    true
+}
+
+/// On GNOME, offer to copy the bundled Shell extension into the user's
+/// extensions directory and enable it. Falls back to printing manual
+/// instructions if anything fails (e.g. running from a `cargo install` build
+/// without the contrib/ tree).
+fn offer_install_gnome_extension() {
+    const UUID: &str = "whisrs-overlay@eresende.github";
+    let ext_src = find_contrib_file(&format!("gnome-shell-extension/{UUID}"));
+
+    let ext_target_root = dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("~/.local/share"))
+        .join("gnome-shell/extensions");
+    let ext_target = ext_target_root.join(UUID);
+
+    println!();
+    println!("  {DIM}GNOME does not support wlroots layer-shell. The bundled GNOME{RESET}");
+    println!("  {DIM}Shell extension renders the overlay inside the shell instead.{RESET}");
+
+    if ext_target.exists() {
+        println!(
+            "  {GREEN}Extension already installed at {}{RESET}",
+            ext_target.display()
+        );
+        return;
+    }
+
+    let choice = Select::new()
+        .with_prompt("Install the GNOME Shell extension now?")
+        .items(&["Yes — copy and enable", "No — I'll install it manually"])
+        .default(0)
+        .interact();
+
+    if !matches!(choice, Ok(0)) {
+        println!("  {DIM}Install manually with:{RESET}");
+        println!(
+            "    cp -r contrib/gnome-shell-extension/{UUID} ~/.local/share/gnome-shell/extensions/"
+        );
+        println!("    gnome-extensions enable {UUID}");
+        return;
+    }
+
+    let Some(src) = ext_src else {
+        println!(
+            "  {YELLOW}Extension source not found in contrib/ — install whisrs from a clone of{RESET}"
+        );
+        println!(
+            "  {YELLOW}https://github.com/y0sif/whisrs and re-run setup, or copy the extension{RESET}"
+        );
+        println!("  {YELLOW}directory manually as shown above.{RESET}");
+        return;
+    };
+
+    if let Err(e) = fs::create_dir_all(&ext_target_root) {
+        println!(
+            "  {RED}Failed to create {}: {e}{RESET}",
+            ext_target_root.display()
+        );
+        return;
+    }
+
+    let status = std::process::Command::new("cp")
+        .arg("-r")
+        .arg(&src)
+        .arg(&ext_target_root)
+        .status();
+    match status {
+        Ok(s) if s.success() => {
+            println!(
+                "  {GREEN}Installed extension to {}{RESET}",
+                ext_target.display()
+            );
+        }
+        _ => {
+            println!("  {RED}Failed to copy extension files{RESET}");
+            return;
+        }
+    }
+
+    let status = std::process::Command::new("gnome-extensions")
+        .args(["enable", UUID])
+        .status();
+    match status {
+        Ok(s) if s.success() => {
+            println!("  {GREEN}Enabled GNOME Shell extension{RESET}");
+            println!("  {YELLOW}Log out and back in if it doesn't appear immediately.{RESET}");
+        }
+        _ => {
+            println!("  {YELLOW}Could not enable automatically. Run:{RESET}");
+            println!("    gnome-extensions enable {UUID}");
+        }
+    }
 }
 
 /// LLM provider choices for command mode.

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -115,7 +115,7 @@ pub fn run_setup() -> Result<()> {
     let (remove_filler_words, audio_feedback) = configure_extras()?;
 
     // 5b. Bottom recording overlay.
-    let overlay = configure_overlay();
+    let (overlay, overlay_config) = configure_overlay();
 
     // 6. Command mode LLM (optional).
     let llm_config = configure_llm()?;
@@ -146,6 +146,7 @@ pub fn run_setup() -> Result<()> {
         local_parakeet: None,
         llm: llm_config,
         hotkeys: None,
+        overlay: if overlay { overlay_config } else { None },
     };
 
     let config_path = write_config(&config)?;
@@ -1080,7 +1081,7 @@ fn configure_extras() -> Result<(bool, bool)> {
 
 /// Ask the user whether to enable the bottom recording overlay, and on GNOME
 /// offer to install the bundled Shell extension that renders it.
-fn configure_overlay() -> bool {
+fn configure_overlay() -> (bool, Option<crate::OverlayConfig>) {
     println!("\n{BOLD}Recording overlay (optional)...{RESET}");
     println!("  {DIM}A small audio meter at the bottom of the screen while recording.{RESET}");
 
@@ -1091,15 +1092,43 @@ fn configure_overlay() -> bool {
         .unwrap_or(false);
 
     if !enable {
-        return false;
+        return (false, None);
     }
+
+    let theme = pick_overlay_theme();
 
     if detect_compositor().as_deref() == Some("gnome") {
         offer_install_gnome_extension();
     }
 
-    println!("  {GREEN}Overlay enabled{RESET}");
-    true
+    println!("  {GREEN}Overlay enabled (theme: {theme}){RESET}");
+    let cfg = crate::OverlayConfig {
+        theme,
+        ..crate::OverlayConfig::default()
+    };
+    (true, Some(cfg))
+}
+
+/// Theme picker for the overlay. Always returns a named theme — "custom" is
+/// left for power users to set in config.toml.
+fn pick_overlay_theme() -> String {
+    println!();
+    let selection = Select::new()
+        .with_prompt("Pick an overlay theme")
+        .items(&[
+            "Ember   — warm amber \"tally light\" (recommended)",
+            "Carbon  — monochrome, terminal-clean",
+            "Cyan    — electric blue, audio-equipment vibe",
+        ])
+        .default(0)
+        .interact()
+        .unwrap_or(0);
+
+    match selection {
+        1 => "carbon".to_string(),
+        2 => "cyan".to_string(),
+        _ => "ember".to_string(),
+    }
 }
 
 /// On GNOME, offer to copy the bundled Shell extension into the user's

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -1116,8 +1116,8 @@ fn pick_overlay_theme() -> String {
     let selection = Select::new()
         .with_prompt("Pick an overlay theme")
         .items(&[
-            "Ember   — warm amber \"tally light\" (recommended)",
-            "Carbon  — monochrome, terminal-clean",
+            "Carbon  — monochrome, terminal-clean (recommended)",
+            "Ember   — warm amber \"tally light\"",
             "Cyan    — electric blue, audio-equipment vibe",
         ])
         .default(0)
@@ -1125,9 +1125,9 @@ fn pick_overlay_theme() -> String {
         .unwrap_or(0);
 
     match selection {
-        1 => "carbon".to_string(),
+        1 => "ember".to_string(),
         2 => "cyan".to_string(),
-        _ => "ember".to_string(),
+        _ => "carbon".to_string(),
     }
 }
 

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -130,6 +130,7 @@ pub fn run_setup() -> Result<()> {
             audio_feedback_volume: 0.5,
             vocabulary: Vec::new(),
             tray: true,
+            overlay: false,
         },
         audio: AudioConfig {
             device: "default".to_string(),

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -122,6 +122,7 @@ fn load_config() -> (Config, Option<String>) {
                             local_parakeet: None,
                             llm: None,
                             hotkeys: None,
+                            overlay: None,
                         },
                         Some(msg),
                     );
@@ -145,6 +146,7 @@ fn load_config() -> (Config, Option<String>) {
                         local_parakeet: None,
                         llm: None,
                         hotkeys: None,
+                        overlay: None,
                     },
                     Some(msg),
                 );
@@ -168,6 +170,7 @@ fn load_config() -> (Config, Option<String>) {
             local_parakeet: None,
             llm: None,
             hotkeys: None,
+            overlay: None,
         },
         None,
     )
@@ -544,6 +547,7 @@ async fn main() -> Result<()> {
 
     let tray_enabled = config.general.tray;
     let overlay_enabled = config.general.overlay;
+    let overlay_config = config.overlay.clone().unwrap_or_default();
     let context = Arc::new(DaemonContext {
         config,
         window_tracker,
@@ -562,7 +566,11 @@ async fn main() -> Result<()> {
     // Start bottom recording overlay if enabled.
     // Spawned as a background task so desktop integration failures do not stop the daemon.
     if overlay_enabled {
-        tokio::spawn(whisrs::overlay::spawn_overlay(state_rx, overlay_level_rx));
+        tokio::spawn(whisrs::overlay::spawn_overlay(
+            state_rx,
+            overlay_level_rx,
+            overlay_config,
+        ));
     }
 
     let sock_path = socket_path();

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -73,6 +73,27 @@ struct DaemonContext {
     state_tx: tokio::sync::watch::Sender<State>,
     /// Normalized microphone level for speech-reactive overlays.
     overlay_level_tx: Option<tokio::sync::watch::Sender<f32>>,
+    /// `true` when the visual overlay is enabled. State-transition toasts
+    /// are suppressed in that case to avoid duplicate signaling — the
+    /// overlay already shows recording/transcribing state visually.
+    /// Error notifications still fire.
+    overlay_enabled: bool,
+}
+
+impl DaemonContext {
+    /// Should we surface a state/progress notification (not an error)?
+    /// Suppressed when the overlay is on so we don't double-signal the
+    /// same event.
+    fn notify_state(&self) -> bool {
+        self.notify && !self.overlay_enabled
+    }
+
+    /// Should we surface an error notification? Always yes when the user
+    /// has notifications enabled — errors are critical and the overlay
+    /// can't carry their detail.
+    fn notify_error(&self) -> bool {
+        self.notify
+    }
 }
 
 /// Try to connect to an existing socket.
@@ -555,6 +576,7 @@ async fn main() -> Result<()> {
         notify,
         state_tx,
         overlay_level_tx: overlay_enabled.then_some(overlay_level_tx),
+        overlay_enabled,
     });
 
     // Start system tray if enabled.
@@ -746,6 +768,7 @@ async fn handle_toggle(
                 let backend = Arc::clone(&context.transcription_backend);
                 let wid = window_id.clone();
                 let ctx_notify = context.notify;
+                let ctx_overlay = context.overlay_enabled;
                 let window_tracker_for_pipeline = Arc::clone(&context.window_tracker);
                 // Restore focus before starting the pipeline.
                 let wid_for_focus = wid.clone();
@@ -772,6 +795,7 @@ async fn handle_toggle(
                         config,
                         wid,
                         ctx_notify,
+                        ctx_overlay,
                         silence_timeout,
                         ds_ref,
                         window_tracker_for_pipeline,
@@ -808,7 +832,7 @@ async fn handle_toggle(
                     if context.config.general.audio_feedback {
                         feedback::play_start(context.config.general.audio_feedback_volume);
                     }
-                    if context.notify {
+                    if context.notify_state() {
                         send_notification("whisrs", "Recording...");
                     }
                     Response::Ok { state: new_state }
@@ -836,7 +860,7 @@ async fn handle_toggle(
                     if context.config.general.audio_feedback {
                         feedback::play_stop(context.config.general.audio_feedback_volume);
                     }
-                    if context.notify {
+                    if context.notify_state() {
                         send_notification("whisrs", "Transcribing...");
                     }
 
@@ -893,7 +917,7 @@ async fn handle_toggle(
                                             context.config.general.audio_feedback_volume,
                                         );
                                     }
-                                    if context.notify {
+                                    if context.notify_state() {
                                         let preview = truncate_preview(&text, 77);
                                         send_notification("whisrs", &format!("Done: {preview}"));
                                     }
@@ -901,7 +925,7 @@ async fn handle_toggle(
                                 }
                                 Err(e) => {
                                     error!("transcription failed: {e:#}");
-                                    if context.notify {
+                                    if context.notify_error() {
                                         send_notification(
                                             "whisrs",
                                             &format!("Transcription failed: {e}"),
@@ -936,6 +960,7 @@ async fn run_streaming_pipeline(
     config: TranscriptionConfig,
     window_id: Option<String>,
     notify: bool,
+    overlay_enabled: bool,
     silence_timeout_ms: u64,
     daemon_state: Arc<Mutex<DaemonState>>,
     window_tracker: Arc<dyn WindowTracker>,
@@ -947,6 +972,9 @@ async fn run_streaming_pipeline(
     language: String,
     state_tx: tokio::sync::watch::Sender<State>,
 ) -> Result<String> {
+    // State-progress toasts are noise when the overlay is on.
+    let notify_state = notify && !overlay_enabled;
+    let notify_error = notify;
     let pipeline_start = std::time::Instant::now();
     let (audio_tx, backend_rx) = tokio::sync::mpsc::channel::<Vec<i16>>(256);
     let (text_tx, mut text_rx) = tokio::sync::mpsc::channel::<String>(64);
@@ -1034,7 +1062,7 @@ async fn run_streaming_pipeline(
         // Check for auto-stop.
         if auto_stop.feed(&chunk) {
             info!("silence auto-stop triggered after {silence_timeout_ms}ms");
-            if notify {
+            if notify_state {
                 send_notification("whisrs", "Auto-stopped (silence detected)");
             }
 
@@ -1090,9 +1118,10 @@ async fn run_streaming_pipeline(
     // Wait for typing to finish.
     let full_text = typing_task.await.unwrap_or_default();
 
-    // Notify user about streaming errors.
+    // Notify user about streaming errors. Errors always pop, even with the
+    // overlay on — the overlay can't carry the failure detail.
     if let Some(err_msg) = &stream_error {
-        if notify {
+        if notify_error {
             if full_text.is_empty() {
                 send_notification("whisrs", &format!("Transcription error: {err_msg}"));
             } else {
@@ -1118,7 +1147,7 @@ async fn run_streaming_pipeline(
         if audio_feedback {
             feedback::play_done(audio_feedback_volume);
         }
-        if notify {
+        if notify_state {
             let preview = truncate_preview(&full_text, 77);
             if !preview.is_empty() {
                 send_notification("whisrs", &format!("Done: {preview}"));
@@ -1174,7 +1203,7 @@ async fn process_recording_batch(
                         "audio saved for recovery: {} — retry with: whisrs transcribe-recovery",
                         path.display()
                     );
-                    if context.notify {
+                    if context.notify_error() {
                         send_notification(
                             "whisrs",
                             &format!(
@@ -1488,7 +1517,7 @@ async fn command_mode_start(
         });
     }
 
-    if context.notify {
+    if context.notify_state() {
         send_notification(
             "whisrs",
             "Command mode: speak your instruction... (press again to stop)",
@@ -1561,7 +1590,7 @@ async fn command_mode_background(
     }
 
     if all_samples.is_empty() {
-        if context.notify {
+        if context.notify_error() {
             send_notification("whisrs", "Command mode: no audio captured");
         }
         let mut ds = daemon_state.lock().await;
@@ -1569,7 +1598,7 @@ async fn command_mode_background(
         return;
     }
 
-    if context.notify {
+    if context.notify_state() {
         send_notification("whisrs", "Processing command...");
     }
 
@@ -1598,7 +1627,7 @@ async fn command_mode_background(
         Ok(text) => text,
         Err(e) => {
             error!("command mode: transcription failed: {e}");
-            if context.notify {
+            if context.notify_error() {
                 send_notification("whisrs", &format!("Command failed: {e}"));
             }
             let mut ds = daemon_state.lock().await;
@@ -1608,7 +1637,7 @@ async fn command_mode_background(
     };
 
     if instruction.is_empty() {
-        if context.notify {
+        if context.notify_error() {
             send_notification("whisrs", "Could not understand instruction — try again");
         }
         let mut ds = daemon_state.lock().await;
@@ -1624,7 +1653,7 @@ async fn command_mode_background(
             Ok(text) => text,
             Err(e) => {
                 error!("command mode: LLM failed: {e}");
-                if context.notify {
+                if context.notify_error() {
                     send_notification("whisrs", &format!("Command failed: {e}"));
                 }
                 let mut ds = daemon_state.lock().await;
@@ -1676,7 +1705,7 @@ async fn command_mode_background(
     if context.config.general.audio_feedback {
         feedback::play_done(context.config.general.audio_feedback_volume);
     }
-    if context.notify {
+    if context.notify_state() {
         send_notification("whisrs", &format!("Command applied: {instruction}"));
     }
 
@@ -1903,7 +1932,7 @@ async fn handle_cancel(
                 let _ = level_tx.send(0.0);
             }
             info!("cancelled recording");
-            if context.notify {
+            if context.notify_state() {
                 send_notification("whisrs", "Recording cancelled");
             }
             Response::Ok { state: new_state }

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -71,6 +71,8 @@ struct DaemonContext {
     notify: bool,
     /// Broadcast channel for state changes (consumed by system tray).
     state_tx: tokio::sync::watch::Sender<State>,
+    /// Normalized microphone level for speech-reactive overlays.
+    overlay_level_tx: Option<tokio::sync::watch::Sender<f32>>,
 }
 
 /// Try to connect to an existing socket.
@@ -536,22 +538,31 @@ async fn main() -> Result<()> {
         std::any::type_name_of_val(&*window_tracker)
     );
 
-    // State broadcast channel — consumed by system tray.
+    // State broadcast channel — consumed by system tray and overlay.
     let (state_tx, state_rx) = tokio::sync::watch::channel(State::Idle);
+    let (overlay_level_tx, overlay_level_rx) = tokio::sync::watch::channel(0.0_f32);
 
     let tray_enabled = config.general.tray;
+    let overlay_enabled = config.general.overlay;
     let context = Arc::new(DaemonContext {
         config,
         window_tracker,
         transcription_backend: backend,
         notify,
         state_tx,
+        overlay_level_tx: overlay_enabled.then_some(overlay_level_tx),
     });
 
     // Start system tray if enabled.
     // Spawned as a background task so retries don't block the IPC server.
     if tray_enabled {
-        tokio::spawn(whisrs::tray::spawn_tray(state_rx));
+        tokio::spawn(whisrs::tray::spawn_tray(state_rx.clone()));
+    }
+
+    // Start bottom recording overlay if enabled.
+    // Spawned as a background task so desktop integration failures do not stop the daemon.
+    if overlay_enabled {
+        tokio::spawn(whisrs::overlay::spawn_overlay(state_rx, overlay_level_rx));
     }
 
     let sock_path = socket_path();
@@ -691,19 +702,20 @@ async fn handle_toggle(
             };
 
             // Start recording.
-            let mut capture = match AudioCaptureHandle::start() {
-                Ok(c) => c,
-                Err(e) => {
-                    let msg = format!("{e}");
-                    let friendly = if msg.contains("no default audio input device") {
-                        format_no_microphone_error()
-                    } else {
-                        format!("Failed to start audio capture: {e}")
-                    };
-                    error!("{friendly}");
-                    return Response::Error { message: friendly };
-                }
-            };
+            let mut capture =
+                match AudioCaptureHandle::start_with_level_tx(context.overlay_level_tx.clone()) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let msg = format!("{e}");
+                        let friendly = if msg.contains("no default audio input device") {
+                            format_no_microphone_error()
+                        } else {
+                            format!("Failed to start audio capture: {e}")
+                        };
+                        error!("{friendly}");
+                        return Response::Error { message: friendly };
+                    }
+                };
 
             // For streaming backends: start the streaming pipeline immediately.
             // Audio flows in real-time from microphone → API → text at cursor.
@@ -810,6 +822,9 @@ async fn handle_toggle(
                     info!("stopped recording, transitioning to transcribing");
                     // Broadcast transcribing state for tray.
                     let _ = context.state_tx.send(State::Transcribing);
+                    if let Some(level_tx) = &context.overlay_level_tx {
+                        let _ = level_tx.send(0.0);
+                    }
                     if context.config.general.audio_feedback {
                         feedback::play_stop(context.config.general.audio_feedback_volume);
                     }
@@ -851,6 +866,9 @@ async fn handle_toggle(
                         Ok(new_state) => {
                             // Broadcast idle state for tray.
                             let _ = context.state_tx.send(new_state);
+                            if let Some(level_tx) = &context.overlay_level_tx {
+                                let _ = level_tx.send(0.0);
+                            }
                             match result {
                                 Ok(text) => {
                                     info!("transcription complete: {} chars", text.len());
@@ -1432,14 +1450,15 @@ async fn command_mode_start(
         feedback::play_start(context.config.general.audio_feedback_volume);
     }
 
-    let mut capture = match AudioCaptureHandle::start() {
-        Ok(c) => c,
-        Err(e) => {
-            return Response::Error {
-                message: format!("failed to start audio capture: {e}"),
-            };
-        }
-    };
+    let mut capture =
+        match AudioCaptureHandle::start_with_level_tx(context.overlay_level_tx.clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                return Response::Error {
+                    message: format!("failed to start audio capture: {e}"),
+                };
+            }
+        };
 
     let audio_rx = capture.take_receiver();
 
@@ -1657,6 +1676,9 @@ async fn command_mode_background(
     let mut ds = daemon_state.lock().await;
     let _ = ds.state_machine.transition(Action::TranscriptionDone);
     let _ = context.state_tx.send(ds.state_machine.state());
+    if let Some(level_tx) = &context.overlay_level_tx {
+        let _ = level_tx.send(0.0);
+    }
 }
 
 /// Simulate a key combo (e.g. Ctrl+C, Ctrl+V) via a temporary uinput device.
@@ -1869,6 +1891,9 @@ async fn handle_cancel(
                 task.abort();
             }
             ds.recording_window_id = None;
+            if let Some(level_tx) = &context.overlay_level_tx {
+                let _ = level_tx.send(0.0);
+            }
             info!("cancelled recording");
             if context.notify {
                 send_notification("whisrs", "Recording cancelled");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,9 @@ pub struct Config {
     /// Global hotkey configuration.
     #[serde(default)]
     pub hotkeys: Option<HotkeyConfig>,
+    /// Overlay appearance config (theme, dimensions, optional custom colors).
+    #[serde(default)]
+    pub overlay: Option<OverlayConfig>,
 }
 
 /// Global hotkey configuration — key combos that trigger actions.
@@ -112,6 +115,101 @@ pub struct HotkeyConfig {
     pub cancel: Option<String>,
     /// Hotkey to start command mode (e.g. "Super+Shift+C").
     pub command: Option<String>,
+}
+
+/// Visual configuration for the bottom recording overlay.
+///
+/// The shape is intentionally clamped tight (90–120 × 28–40) to keep the
+/// gaussian-tapered bar layout legible. Themes pick the colors; if `colors`
+/// is set, those override the theme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OverlayConfig {
+    /// Theme name: `"ember"` (default), `"carbon"`, `"cyan"`, or `"custom"`.
+    /// Unknown values fall back to `"ember"` with a warning.
+    #[serde(default = "default_overlay_theme")]
+    pub theme: String,
+    /// Pill width in pixels (clamped to 90..=120).
+    #[serde(default = "default_overlay_width")]
+    pub width: u32,
+    /// Pill height in pixels (clamped to 28..=40).
+    #[serde(default = "default_overlay_height")]
+    pub height: u32,
+    /// Custom color overrides; honored when `theme = "custom"`.
+    /// Hex strings: `#RGB`, `#RRGGBB`, or `#RRGGBBAA`.
+    #[serde(default)]
+    pub colors: Option<OverlayColors>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OverlayColors {
+    pub background: Option<String>,
+    pub ring: Option<String>,
+    pub recording: Option<String>,
+    pub transcribing: Option<String>,
+    pub glow: Option<String>,
+}
+
+fn default_overlay_theme() -> String {
+    "ember".to_string()
+}
+fn default_overlay_width() -> u32 {
+    100
+}
+fn default_overlay_height() -> u32 {
+    34
+}
+
+impl Default for OverlayConfig {
+    fn default() -> Self {
+        Self {
+            theme: default_overlay_theme(),
+            width: default_overlay_width(),
+            height: default_overlay_height(),
+            colors: None,
+        }
+    }
+}
+
+impl OverlayConfig {
+    /// Width clamped to the supported range. Out-of-range values fall back
+    /// silently to the nearest bound — we don't fail config load over UI.
+    pub fn clamped_width(&self) -> u32 {
+        self.width.clamp(90, 120)
+    }
+    pub fn clamped_height(&self) -> u32 {
+        self.height.clamp(28, 40)
+    }
+}
+
+/// Parse a hex color string into ARGB bytes `[A, R, G, B]` matching the
+/// overlay renderer's color format. Accepts `#RGB`, `#RRGGBB`, `#RRGGBBAA`.
+/// Returns `None` for malformed input so callers can fall back to a theme
+/// default.
+pub fn parse_hex_color(s: &str) -> Option<[u8; 4]> {
+    let s = s.trim().trim_start_matches('#');
+    let (r, g, b, a) = match s.len() {
+        3 => {
+            let r = u8::from_str_radix(&s[0..1].repeat(2), 16).ok()?;
+            let g = u8::from_str_radix(&s[1..2].repeat(2), 16).ok()?;
+            let b = u8::from_str_radix(&s[2..3].repeat(2), 16).ok()?;
+            (r, g, b, 255u8)
+        }
+        6 => {
+            let r = u8::from_str_radix(&s[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&s[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&s[4..6], 16).ok()?;
+            (r, g, b, 255u8)
+        }
+        8 => {
+            let r = u8::from_str_radix(&s[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&s[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&s[4..6], 16).ok()?;
+            let a = u8::from_str_radix(&s[6..8], 16).ok()?;
+            (r, g, b, a)
+        }
+        _ => return None,
+    };
+    Some([a, r, g, b])
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -647,6 +745,7 @@ mod tests {
             local_parakeet: None,
             llm: None,
             hotkeys: None,
+            overlay: None,
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("Unknown backend"));
@@ -686,6 +785,7 @@ mod tests {
             local_parakeet: None,
             llm: None,
             hotkeys: None,
+            overlay: None,
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("no API key"));
@@ -710,6 +810,7 @@ mod tests {
             local_parakeet: None,
             llm: None,
             hotkeys: None,
+            overlay: None,
         };
         let result = config.validate();
         assert!(result.is_ok());
@@ -735,6 +836,7 @@ mod tests {
             local_parakeet: None,
             llm: None,
             hotkeys: None,
+            overlay: None,
         };
         let warnings = config.validate().unwrap();
         assert!(warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod history;
 pub mod hotkey;
 pub mod input;
 pub mod llm;
+pub mod overlay;
 pub mod post_processing;
 pub mod state;
 pub mod transcription;
@@ -142,6 +143,9 @@ pub struct GeneralConfig {
     /// Enable system tray icon.
     #[serde(default = "default_true")]
     pub tray: bool,
+    /// Enable bottom-screen recording overlay.
+    #[serde(default)]
+    pub overlay: bool,
 }
 
 impl Default for GeneralConfig {
@@ -157,6 +161,7 @@ impl Default for GeneralConfig {
             audio_feedback_volume: default_audio_feedback_volume(),
             vocabulary: Vec::new(),
             tray: true,
+            overlay: false,
         }
     }
 }
@@ -645,6 +650,22 @@ mod tests {
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("Unknown backend"));
+    }
+
+    #[test]
+    fn config_defaults_overlay_off_for_old_configs() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "local-whisper"
+
+            [audio]
+            device = "default"
+            "#,
+        )
+        .unwrap();
+
+        assert!(!config.general.overlay);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ fn default_overlay_width() -> u32 {
     100
 }
 fn default_overlay_height() -> u32 {
-    64
+    40
 }
 
 impl Default for OverlayConfig {
@@ -177,7 +177,7 @@ impl OverlayConfig {
         self.width.clamp(90, 120)
     }
     pub fn clamped_height(&self) -> u32 {
-        self.height.clamp(56, 72)
+        self.height.clamp(36, 48)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub struct OverlayColors {
 }
 
 fn default_overlay_theme() -> String {
-    "ember".to_string()
+    "carbon".to_string()
 }
 fn default_overlay_width() -> u32 {
     100

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ fn default_overlay_width() -> u32 {
     100
 }
 fn default_overlay_height() -> u32 {
-    34
+    64
 }
 
 impl Default for OverlayConfig {
@@ -177,7 +177,7 @@ impl OverlayConfig {
         self.width.clamp(90, 120)
     }
     pub fn clamped_height(&self) -> u32 {
-        self.height.clamp(28, 40)
+        self.height.clamp(56, 72)
     }
 }
 

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -13,6 +13,7 @@ pub use service::spawn_overlay;
 pub async fn spawn_overlay(
     _state_rx: tokio::sync::watch::Receiver<crate::State>,
     _level_rx: tokio::sync::watch::Receiver<f32>,
+    _config: crate::OverlayConfig,
 ) {
     tracing::warn!("overlay feature is disabled at compile time");
 }

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -1,0 +1,18 @@
+//! Bottom-screen recording overlay.
+//!
+//! The overlay is optional and currently implemented for wlroots layer-shell
+//! compositors such as Hyprland and Sway.
+
+#[cfg(feature = "overlay")]
+mod service;
+
+#[cfg(feature = "overlay")]
+pub use service::spawn_overlay;
+
+#[cfg(not(feature = "overlay"))]
+pub async fn spawn_overlay(
+    _state_rx: tokio::sync::watch::Receiver<crate::State>,
+    _level_rx: tokio::sync::watch::Receiver<f32>,
+) {
+    tracing::warn!("overlay feature is disabled at compile time");
+}

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -46,9 +46,10 @@ use wayland_client::{
 
 use crate::State;
 
-const WIDTH: u32 = 420;
-const HEIGHT: u32 = 96;
-const BOTTOM_MARGIN: i32 = 34;
+const WIDTH: u32 = 140;
+const HEIGHT: u32 = 28;
+const BOTTOM_MARGIN: i32 = 22;
+const FADE_STEP: f32 = 0.55;
 
 /// Spawn the bottom recording overlay.
 ///
@@ -210,7 +211,9 @@ fn run_overlay(
         first_configure: true,
         width: WIDTH,
         height: HEIGHT,
-        state: State::Idle,
+        target_state: State::Idle,
+        visible_state: State::Idle,
+        alpha: 0.0,
         frame: 0,
         level: 0.0,
     };
@@ -236,7 +239,9 @@ struct Overlay {
     first_configure: bool,
     width: u32,
     height: u32,
-    state: State,
+    target_state: State,
+    visible_state: State,
+    alpha: f32,
     frame: u32,
     level: f32,
 }
@@ -244,14 +249,30 @@ struct Overlay {
 impl Overlay {
     fn apply_state_updates(&mut self) {
         while let Ok(state) = self.state_rx.try_recv() {
-            self.state = state;
+            self.target_state = state;
+            if state != State::Idle {
+                self.visible_state = state;
+            }
         }
         while let Ok(level) = self.level_rx.try_recv() {
-            // Decay toward new value; take max to preserve peaks within a frame
             self.level = level.clamp(0.0, 1.0);
         }
-        // Decay level each frame so silence brings bars down
-        self.level = (self.level * 0.88).max(0.0);
+        self.level = (self.level * 0.85).max(0.0);
+
+        let target_alpha = if self.target_state == State::Idle {
+            0.0
+        } else {
+            1.0
+        };
+        let diff = target_alpha - self.alpha;
+        if diff.abs() <= FADE_STEP {
+            self.alpha = target_alpha;
+        } else {
+            self.alpha += diff.signum() * FADE_STEP;
+        }
+        if self.alpha == 0.0 {
+            self.visible_state = State::Idle;
+        }
     }
 
     fn draw(&mut self, qh: &QueueHandle<Self>) {
@@ -271,7 +292,15 @@ impl Overlay {
             return;
         };
 
-        draw_overlay(canvas, width, height, self.state, self.frame, self.level);
+        draw_overlay(
+            canvas,
+            width,
+            height,
+            self.visible_state,
+            self.frame,
+            self.level,
+            self.alpha,
+        );
         self.frame = self.frame.wrapping_add(1);
 
         self.layer
@@ -423,56 +452,43 @@ impl ProvidesRegistryState for Overlay {
     registry_handlers![OutputState];
 }
 
-fn draw_overlay(canvas: &mut [u8], width: u32, height: u32, state: State, frame: u32, level: f32) {
+fn draw_overlay(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    state: State,
+    frame: u32,
+    level: f32,
+    alpha: f32,
+) {
     clear(canvas);
 
-    if state == State::Idle {
+    if alpha <= 0.0 || state == State::Idle {
         return;
     }
 
-    let bg = [232, 18, 22, 28];
-    let border = [105, 255, 255, 255];
+    let bg = scale_alpha([235, 18, 20, 24], alpha);
     let accent = match state {
-        State::Recording => [255, 239, 68, 68],
-        State::Transcribing => [255, 245, 158, 11],
-        State::Idle => [0, 0, 0, 0],
+        State::Recording => scale_alpha([255, 239, 68, 68], alpha),
+        State::Transcribing => scale_alpha([255, 96, 165, 250], alpha),
+        State::Idle => return,
     };
 
-    let x = 8;
-    let y = 8;
-    let w = width.saturating_sub(16);
-    let h = height.saturating_sub(16);
-    rounded_rect(canvas, width, height, x, y, w, h, 18, bg);
-    rounded_stroke(canvas, width, height, x, y, w, h, 18, border);
+    let radius = height / 2;
+    rounded_rect(canvas, width, height, 0, 0, width, height, radius, bg);
 
-    draw_status_dot(canvas, width, height, 48, height / 2, accent, frame);
-    draw_wave(
-        canvas,
-        width,
-        height,
-        WaveParams {
-            x: 92,
-            cy: height / 2,
-            color: accent,
-            frame,
-            level,
-        },
-    );
-
-    let label = match state {
-        State::Recording => "RECORDING",
-        State::Transcribing => "TRANSCRIBING",
-        State::Idle => "",
+    let cy = height / 2;
+    let dot_pulse = match state {
+        State::Recording => (((frame as f32 / 12.0).sin() + 1.0) * 0.5 * 1.0) as i32,
+        _ => 0,
     };
-    draw_text(
-        canvas,
-        width,
-        height,
-        244,
-        (height / 2).saturating_sub(10),
-        label,
-        [245, 245, 245, 245],
-    );
+    circle(canvas, width, height, 14, cy, 3 + dot_pulse, accent);
+
+    match state {
+        State::Recording => draw_bars(canvas, width, height, accent, frame, level),
+        State::Transcribing => draw_sweep(canvas, width, height, accent, frame),
+        State::Idle => {}
+    }
 }
 
 fn clear(canvas: &mut [u8]) {
@@ -494,37 +510,6 @@ fn rounded_rect(
     for py in y..y + h {
         for px in x..x + w {
             if inside_rounded_rect(px, py, x, y, w, h, radius) {
-                blend_pixel(canvas, width, height, px, py, color);
-            }
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn rounded_stroke(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
-    x: u32,
-    y: u32,
-    w: u32,
-    h: u32,
-    radius: u32,
-    color: [u8; 4],
-) {
-    for py in y..y + h {
-        for px in x..x + w {
-            if inside_rounded_rect(px, py, x, y, w, h, radius)
-                && !inside_rounded_rect(
-                    px,
-                    py,
-                    x + 1,
-                    y + 1,
-                    w - 2,
-                    h - 2,
-                    radius.saturating_sub(1),
-                )
-            {
                 blend_pixel(canvas, width, height, px, py, color);
             }
         }
@@ -553,62 +538,59 @@ fn inside_rounded_rect(px: u32, py: u32, x: u32, y: u32, w: u32, h: u32, radius:
     dx * dx + dy * dy <= (radius as i32) * (radius as i32)
 }
 
-fn draw_status_dot(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
-    cx: u32,
-    cy: u32,
-    color: [u8; 4],
-    frame: u32,
-) {
-    let pulse = ((frame / 4) % 18) as i32;
-    circle(
-        canvas,
-        width,
-        height,
-        cx,
-        cy,
-        9 + pulse / 3,
-        [34, color[1], color[2], color[3]],
-    );
-    circle(canvas, width, height, cx, cy, 7, color);
+fn scale_alpha(color: [u8; 4], alpha: f32) -> [u8; 4] {
+    let a = (color[0] as f32 * alpha.clamp(0.0, 1.0)).round() as u8;
+    [a, color[1], color[2], color[3]]
 }
 
-struct WaveParams {
-    x: u32,
-    cy: u32,
-    color: [u8; 4],
-    frame: u32,
-    level: f32,
+const BAR_COUNT: u32 = 5;
+const BAR_W: u32 = 6;
+const BAR_X_START: u32 = 30;
+const BAR_PITCH: u32 = 22;
+const BAR_BASELINE: i32 = 3;
+const BAR_MAX_H: i32 = 18;
+
+fn draw_bars(canvas: &mut [u8], width: u32, height: u32, color: [u8; 4], frame: u32, level: f32) {
+    let cy = (height / 2) as i32;
+    for i in 0..BAR_COUNT {
+        let variance = 0.7 + (i as f32 * 1.7).sin() * 0.3;
+        let phase = ((frame as f32 / 6.0) + i as f32 * 0.9).sin().abs();
+        let effective = (level * variance).clamp(0.0, 1.0);
+        let dynamic = effective * (0.6 + 0.4 * phase);
+        let h = (BAR_BASELINE as f32 + dynamic * (BAR_MAX_H - BAR_BASELINE) as f32)
+            .round()
+            .max(BAR_BASELINE as f32) as i32;
+        let bx = BAR_X_START + i * BAR_PITCH;
+        let by = (cy - h / 2).max(0) as u32;
+        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 3, color);
+    }
 }
 
-fn draw_wave(canvas: &mut [u8], width: u32, height: u32, params: WaveParams) {
-    let WaveParams {
-        x,
-        cy,
-        color,
-        frame,
-        level,
-    } = params;
-    for i in 0..10 {
-        let phase = ((frame + i * 5) % 32) as f32 / 32.0;
-        let animated = (phase * std::f32::consts::TAU).sin().abs();
-        let variance = 0.65 + (i % 3) as f32 * 0.18;
-        let effective = (level * variance).min(1.0);
-        let bar_h = 6 + ((animated * 0.3 + effective * 0.7) * 26.0) as u32;
-        let bx = x + i * 12;
-        rounded_rect(
-            canvas,
-            width,
-            height,
-            bx,
-            cy - bar_h / 2,
-            6,
-            bar_h,
-            3,
-            color,
-        );
+fn draw_sweep(canvas: &mut [u8], width: u32, height: u32, color: [u8; 4], frame: u32) {
+    let cy = (height / 2) as i32;
+    let cycle = (BAR_COUNT as i32) * 2 - 2;
+    let pos = ((frame / 4) as i32) % cycle.max(1);
+    let active = if pos < BAR_COUNT as i32 {
+        pos
+    } else {
+        cycle - pos
+    };
+    for i in 0..BAR_COUNT {
+        let dist = (i as i32 - active).abs() as f32;
+        let intensity = (1.0 - dist / 2.5).max(0.18);
+        let bar_color = [
+            (color[0] as f32 * intensity).round() as u8,
+            color[1],
+            color[2],
+            color[3],
+        ];
+        let h = (BAR_BASELINE as f32
+            + (BAR_MAX_H - BAR_BASELINE) as f32 * (0.45 + 0.55 * intensity))
+            .round() as i32;
+        let h = h.max(BAR_BASELINE);
+        let bx = BAR_X_START + i * BAR_PITCH;
+        let by = (cy - h / 2).max(0) as u32;
+        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 3, bar_color);
     }
 }
 
@@ -620,99 +602,6 @@ fn circle(canvas: &mut [u8], width: u32, height: u32, cx: u32, cy: u32, r: i32, 
             if dx * dx + dy * dy <= r * r {
                 blend_pixel(canvas, width, height, x, y, color);
             }
-        }
-    }
-}
-
-fn draw_text(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
-    x: u32,
-    y: u32,
-    text: &str,
-    color: [u8; 4],
-) {
-    let mut cursor = x;
-    for ch in text.chars() {
-        if ch == ' ' {
-            cursor += 8;
-        } else {
-            draw_char(canvas, width, height, cursor, y, ch, color);
-            cursor += 13;
-        }
-    }
-}
-
-fn draw_char(canvas: &mut [u8], width: u32, height: u32, x: u32, y: u32, ch: char, color: [u8; 4]) {
-    let glyph = glyph(ch);
-    for (row, bits) in glyph.iter().enumerate() {
-        for col in 0..5 {
-            if bits & (1 << (4 - col)) != 0 {
-                let px = x + col * 2;
-                let py = y + row as u32 * 2;
-                rect(canvas, width, height, px, py, 2, 2, color);
-            }
-        }
-    }
-}
-
-fn glyph(ch: char) -> [u8; 7] {
-    match ch {
-        'A' => [
-            0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001,
-        ],
-        'B' => [
-            0b11110, 0b10001, 0b10001, 0b11110, 0b10001, 0b10001, 0b11110,
-        ],
-        'C' => [
-            0b01111, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b01111,
-        ],
-        'D' => [
-            0b11110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11110,
-        ],
-        'E' => [
-            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111,
-        ],
-        'G' => [
-            0b01111, 0b10000, 0b10000, 0b10111, 0b10001, 0b10001, 0b01111,
-        ],
-        'I' => [
-            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b11111,
-        ],
-        'N' => [
-            0b10001, 0b11001, 0b10101, 0b10011, 0b10001, 0b10001, 0b10001,
-        ],
-        'O' => [
-            0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110,
-        ],
-        'R' => [
-            0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001,
-        ],
-        'S' => [
-            0b01111, 0b10000, 0b10000, 0b01110, 0b00001, 0b00001, 0b11110,
-        ],
-        'T' => [
-            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100,
-        ],
-        _ => [0; 7],
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn rect(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
-    x: u32,
-    y: u32,
-    w: u32,
-    h: u32,
-    color: [u8; 4],
-) {
-    for py in y..(y + h).min(height) {
-        for px in x..(x + w).min(width) {
-            blend_pixel(canvas, width, height, px, py, color);
         }
     }
 }
@@ -733,14 +622,46 @@ mod tests {
     #[test]
     fn idle_draw_is_transparent() {
         let mut canvas = vec![1; (WIDTH * HEIGHT * 4) as usize];
-        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Idle, 0, 0.0);
+        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Idle, 0, 0.0, 0.0);
+        assert!(canvas.iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn faded_out_draw_is_transparent() {
+        let mut canvas = vec![1; (WIDTH * HEIGHT * 4) as usize];
+        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Recording, 0, 1.0, 0.0);
         assert!(canvas.iter().all(|b| *b == 0));
     }
 
     #[test]
     fn active_draw_has_visible_pixels() {
         let mut canvas = vec![0; (WIDTH * HEIGHT * 4) as usize];
-        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Recording, 0, 1.0);
+        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Recording, 0, 1.0, 1.0);
         assert!(canvas.chunks_exact(4).any(|px| px[3] != 0));
+    }
+
+    #[test]
+    fn silence_draws_minimal_baseline() {
+        // Bar color (red) overdraws the dark background; counting red-dominant
+        // pixels measures bar area regardless of the underlying pill.
+        // ARGB color is stored on disk as little-endian B,G,R,A — so the
+        // canvas byte layout is [B, G, R, A] per pixel.
+        fn red_pixels(canvas: &[u8]) -> usize {
+            canvas
+                .chunks_exact(4)
+                .filter(|px| px[2] > 128 && px[0] < 80 && px[1] < 80)
+                .count()
+        }
+
+        let mut quiet = vec![0; (WIDTH * HEIGHT * 4) as usize];
+        let mut loud = vec![0; (WIDTH * HEIGHT * 4) as usize];
+        draw_overlay(&mut quiet, WIDTH, HEIGHT, State::Recording, 0, 0.0, 1.0);
+        draw_overlay(&mut loud, WIDTH, HEIGHT, State::Recording, 0, 1.0, 1.0);
+        let count_quiet = red_pixels(&quiet);
+        let count_loud = red_pixels(&loud);
+        assert!(
+            count_loud > count_quiet,
+            "loud audio should fill more bar area than silence (silence={count_quiet}, loud={count_loud})"
+        );
     }
 }

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -46,9 +46,9 @@ use wayland_client::{
 
 use crate::State;
 
-const WIDTH: u32 = 140;
-const HEIGHT: u32 = 28;
-const BOTTOM_MARGIN: i32 = 22;
+const WIDTH: u32 = 110;
+const HEIGHT: u32 = 40;
+const BOTTOM_MARGIN: i32 = 24;
 const FADE_STEP: f32 = 0.55;
 
 /// Spawn the bottom recording overlay.
@@ -467,22 +467,43 @@ fn draw_overlay(
         return;
     }
 
-    let bg = scale_alpha([235, 18, 20, 24], alpha);
+    // Brand palette: dark slate with a hint of purple, terminal green for
+    // recording, deep purple for transcribing.
+    let bg = scale_alpha([240, 22, 20, 32], alpha);
+    let inner_glow = scale_alpha([60, 108, 63, 197], alpha);
     let accent = match state {
-        State::Recording => scale_alpha([255, 239, 68, 68], alpha),
-        State::Transcribing => scale_alpha([255, 96, 165, 250], alpha),
+        State::Recording => scale_alpha([255, 163, 230, 53], alpha),
+        State::Transcribing => scale_alpha([255, 108, 63, 197], alpha),
         State::Idle => return,
     };
 
     let radius = height / 2;
     rounded_rect(canvas, width, height, 0, 0, width, height, radius, bg);
-
-    let cy = height / 2;
-    let dot_pulse = match state {
-        State::Recording => (((frame as f32 / 12.0).sin() + 1.0) * 0.5 * 1.0) as i32,
-        _ => 0,
-    };
-    circle(canvas, width, height, 14, cy, 3 + dot_pulse, accent);
+    // Subtle purple inner ring as a brand accent — barely visible, just enough
+    // to lift the pill out of pure flat black.
+    rounded_rect(
+        canvas,
+        width,
+        height,
+        1,
+        1,
+        width - 2,
+        height - 2,
+        radius - 1,
+        inner_glow,
+    );
+    // Restore the bg one pixel in so we end up with a 1px purple ring.
+    rounded_rect(
+        canvas,
+        width,
+        height,
+        2,
+        2,
+        width - 4,
+        height - 4,
+        radius - 2,
+        bg,
+    );
 
     match state {
         State::Recording => draw_bars(canvas, width, height, accent, frame, level),
@@ -544,11 +565,13 @@ fn scale_alpha(color: [u8; 4], alpha: f32) -> [u8; 4] {
 }
 
 const BAR_COUNT: u32 = 5;
-const BAR_W: u32 = 6;
-const BAR_X_START: u32 = 30;
-const BAR_PITCH: u32 = 22;
-const BAR_BASELINE: i32 = 3;
-const BAR_MAX_H: i32 = 18;
+const BAR_W: u32 = 4;
+const BAR_GAP: u32 = 3;
+const BAR_PITCH: u32 = BAR_W + BAR_GAP;
+const BAR_BLOCK_W: u32 = BAR_COUNT * BAR_W + (BAR_COUNT - 1) * BAR_GAP;
+const BAR_X_START: u32 = (WIDTH - BAR_BLOCK_W) / 2;
+const BAR_BASELINE: i32 = 4;
+const BAR_MAX_H: i32 = 28;
 
 fn draw_bars(canvas: &mut [u8], width: u32, height: u32, color: [u8; 4], frame: u32, level: f32) {
     let cy = (height / 2) as i32;
@@ -562,7 +585,7 @@ fn draw_bars(canvas: &mut [u8], width: u32, height: u32, color: [u8; 4], frame: 
             .max(BAR_BASELINE as f32) as i32;
         let bx = BAR_X_START + i * BAR_PITCH;
         let by = (cy - h / 2).max(0) as u32;
-        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 3, color);
+        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 2, color);
     }
 }
 
@@ -590,19 +613,7 @@ fn draw_sweep(canvas: &mut [u8], width: u32, height: u32, color: [u8; 4], frame:
         let h = h.max(BAR_BASELINE);
         let bx = BAR_X_START + i * BAR_PITCH;
         let by = (cy - h / 2).max(0) as u32;
-        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 3, bar_color);
-    }
-}
-
-fn circle(canvas: &mut [u8], width: u32, height: u32, cx: u32, cy: u32, r: i32, color: [u8; 4]) {
-    for y in cy.saturating_sub(r as u32)..=(cy + r as u32).min(height.saturating_sub(1)) {
-        for x in cx.saturating_sub(r as u32)..=(cx + r as u32).min(width.saturating_sub(1)) {
-            let dx = x as i32 - cx as i32;
-            let dy = y as i32 - cy as i32;
-            if dx * dx + dy * dy <= r * r {
-                blend_pixel(canvas, width, height, x, y, color);
-            }
-        }
+        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 2, bar_color);
     }
 }
 
@@ -642,14 +653,14 @@ mod tests {
 
     #[test]
     fn silence_draws_minimal_baseline() {
-        // Bar color (red) overdraws the dark background; counting red-dominant
-        // pixels measures bar area regardless of the underlying pill.
-        // ARGB color is stored on disk as little-endian B,G,R,A — so the
-        // canvas byte layout is [B, G, R, A] per pixel.
-        fn red_pixels(canvas: &[u8]) -> usize {
+        // Bar color (terminal green, brand accent) overdraws the dark pill;
+        // counting green-dominant pixels measures bar area regardless of the
+        // underlying background. ARGB on disk is little-endian B,G,R,A — so
+        // each pixel reads as [B, G, R, A].
+        fn green_pixels(canvas: &[u8]) -> usize {
             canvas
                 .chunks_exact(4)
-                .filter(|px| px[2] > 128 && px[0] < 80 && px[1] < 80)
+                .filter(|px| px[1] > 180 && px[2] < 200 && px[0] < 100)
                 .count()
         }
 
@@ -657,8 +668,8 @@ mod tests {
         let mut loud = vec![0; (WIDTH * HEIGHT * 4) as usize];
         draw_overlay(&mut quiet, WIDTH, HEIGHT, State::Recording, 0, 0.0, 1.0);
         draw_overlay(&mut loud, WIDTH, HEIGHT, State::Recording, 0, 1.0, 1.0);
-        let count_quiet = red_pixels(&quiet);
-        let count_loud = red_pixels(&loud);
+        let count_quiet = green_pixels(&quiet);
+        let count_loud = green_pixels(&loud);
         assert!(
             count_loud > count_quiet,
             "loud audio should fill more bar area than silence (silence={count_quiet}, loud={count_loud})"

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -3,6 +3,24 @@
 use std::sync::mpsc;
 use std::time::Duration;
 
+#[derive(Debug, thiserror::Error)]
+enum OverlayError {
+    #[error("Wayland connection error: {0}")]
+    Connect(#[from] wayland_client::ConnectError),
+    #[error("Wayland globals error: {0}")]
+    Globals(#[from] wayland_client::globals::GlobalError),
+    #[error("smithay bind error: {0}")]
+    Bind(#[from] wayland_client::globals::BindError),
+    #[error("smithay shm create error: {0}")]
+    Shm(#[from] smithay_client_toolkit::shm::CreatePoolError),
+    #[error("Wayland dispatch error: {0}")]
+    Dispatch(#[from] wayland_client::DispatchError),
+    #[error("D-Bus error: {0}")]
+    DBus(#[from] zbus::Error),
+    #[error("D-Bus signal error: {0}")]
+    DBusSignal(#[from] zbus::fdo::Error),
+}
+
 use smithay_client_toolkit::{
     compositor::{CompositorHandler, CompositorState},
     delegate_compositor, delegate_layer, delegate_output, delegate_registry, delegate_shm,
@@ -37,7 +55,10 @@ const BOTTOM_MARGIN: i32 = 34;
 /// The Wayland event loop runs on a dedicated OS thread because it is a
 /// blocking client loop. A small Tokio task forwards daemon state changes into
 /// that thread.
-pub async fn spawn_overlay(mut state_rx: watch::Receiver<State>, mut level_rx: watch::Receiver<f32>) {
+pub async fn spawn_overlay(
+    mut state_rx: watch::Receiver<State>,
+    mut level_rx: watch::Receiver<f32>,
+) {
     let gnome_state_rx = state_rx.clone();
     let gnome_level_rx = level_rx.clone();
     tokio::spawn(async move {
@@ -80,7 +101,7 @@ pub async fn spawn_overlay(mut state_rx: watch::Receiver<State>, mut level_rx: w
 async fn run_gnome_broadcaster(
     mut state_rx: watch::Receiver<State>,
     level_rx: watch::Receiver<f32>,
-) -> anyhow::Result<()> {
+) -> Result<(), OverlayError> {
     let conn = zbus::connection::Builder::session()?
         .serve_at("/org/whisrs/Overlay", GnomeOverlayBus)?
         .name("org.whisrs.Overlay")?
@@ -148,7 +169,10 @@ impl GnomeOverlayBus {
     }
 }
 
-fn run_overlay(state_rx: mpsc::Receiver<State>, level_rx: mpsc::Receiver<f32>) -> anyhow::Result<()> {
+fn run_overlay(
+    state_rx: mpsc::Receiver<State>,
+    level_rx: mpsc::Receiver<f32>,
+) -> Result<(), OverlayError> {
     let conn = Connection::connect_to_env()?;
     let (globals, mut event_queue) = registry_queue_init(&conn)?;
     let qh = event_queue.handle();
@@ -422,7 +446,18 @@ fn draw_overlay(canvas: &mut [u8], width: u32, height: u32, state: State, frame:
     rounded_stroke(canvas, width, height, x, y, w, h, 18, border);
 
     draw_status_dot(canvas, width, height, 48, height / 2, accent, frame);
-    draw_wave(canvas, width, height, 92, height / 2, accent, frame, level);
+    draw_wave(
+        canvas,
+        width,
+        height,
+        WaveParams {
+            x: 92,
+            cy: height / 2,
+            color: accent,
+            frame,
+            level,
+        },
+    );
 
     let label = match state {
         State::Recording => "RECORDING",
@@ -540,16 +575,22 @@ fn draw_status_dot(
     circle(canvas, width, height, cx, cy, 7, color);
 }
 
-fn draw_wave(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
+struct WaveParams {
     x: u32,
     cy: u32,
     color: [u8; 4],
     frame: u32,
     level: f32,
-) {
+}
+
+fn draw_wave(canvas: &mut [u8], width: u32, height: u32, params: WaveParams) {
+    let WaveParams {
+        x,
+        cy,
+        color,
+        frame,
+        level,
+    } = params;
     for i in 0..10 {
         let phase = ((frame + i * 5) % 32) as f32 / 32.0;
         let animated = (phase * std::f32::consts::TAU).sin().abs();

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -909,16 +909,28 @@ fn theme_color(bytes: [u8; 4], extra_alpha: f32) -> Color {
     .unwrap_or(Color::TRANSPARENT)
 }
 
-/// Gaussian taper across the bar row — center bars draw at ~100 % of their
-/// dynamic height, edges fall off to ~37 %. `i` is the bar index, `count`
-/// the total bar count.
+/// Wavy taper across the bar row — center bar at ~100 %, with a cosine
+/// modulation so adjacent bars alternate between "taller" and "shorter"
+/// inside a gaussian envelope. Reads as an equalizer pattern instead of
+/// a smooth bell:
+///
+/// ```text
+///   index:    0     1     2     3     4     5     6
+///   factor:  .20   .64   .45  1.00   .45   .64   .20
+///            short  tall  mid  PEAK  mid  tall  short
+/// ```
 fn taper_factor(i: u32, count: u32) -> f32 {
     if count <= 1 {
         return 1.0;
     }
     let center = (count as f32 - 1.0) / 2.0;
     let d = (i as f32 - center) / center; // -1..=1
-    (-d * d).exp() // exp(-1) ≈ 0.367 at edges
+    let envelope = (-d * d).exp(); // exp(-1) ≈ 0.367 at edges
+                                   // For odd `count`, (i - center) is integer ⇒ cos is ±1, giving a
+                                   // strict alternation. For even `count` the cos collapses to 0 and the
+                                   // factor is just the gaussian envelope, which is fine.
+    let wave = 0.75 + 0.25 * (std::f32::consts::PI * (i as f32 - center)).cos();
+    envelope * wave
 }
 
 /// Recording bars: react to audio level, gaussian taper across the row,

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -44,12 +44,110 @@ use wayland_client::{
     Connection, Dispatch, QueueHandle,
 };
 
-use crate::State;
+use crate::{OverlayConfig, State};
 
-const WIDTH: u32 = 110;
-const HEIGHT: u32 = 40;
-const BOTTOM_MARGIN: i32 = 24;
+const BOTTOM_MARGIN: i32 = 16;
 const FADE_STEP: f32 = 0.55;
+
+// Bar layout — fixed for visual consistency. 18 bars × 2 px + 17 gaps × 2 px
+// = 70 px wide, centered in the pill (15 px side margin at default 100 px).
+const BAR_COUNT: u32 = 18;
+const BAR_W: u32 = 2;
+const BAR_GAP: u32 = 2;
+const BAR_PITCH: u32 = BAR_W + BAR_GAP;
+const BAR_BLOCK_W: u32 = BAR_COUNT * BAR_W + (BAR_COUNT - 1) * BAR_GAP;
+const BAR_BASELINE: i32 = 2;
+
+/// Color palette for one overlay theme. Bytes are stored as `[A, R, G, B]`,
+/// matching the canvas pixel layout used by [`blend_pixel`].
+#[derive(Debug, Clone, Copy)]
+struct Theme {
+    bg: [u8; 4],
+    ring: [u8; 4],
+    rec_bar: [u8; 4],
+    trans_bar: [u8; 4],
+    glow: [u8; 4],
+}
+
+impl Theme {
+    /// Default palette — warm "tally light" amber on near-black slate.
+    const fn ember() -> Self {
+        Self {
+            bg: [235, 14, 14, 16],           // #0E0E10 @ 92%
+            ring: [64, 249, 115, 22],        // #F97316 @ 25%
+            rec_bar: [255, 249, 115, 22],    // #F97316
+            trans_bar: [255, 240, 237, 245], // #F0EDF5
+            glow: [60, 249, 115, 22],
+        }
+    }
+
+    /// Monochrome terminal palette — subdued, never distracting.
+    const fn carbon() -> Self {
+        Self {
+            bg: [235, 14, 14, 16],
+            ring: [80, 58, 58, 64],          // hairline gray
+            rec_bar: [255, 240, 237, 245],   // soft white
+            trans_bar: [255, 156, 163, 175], // warm gray
+            glow: [40, 240, 237, 245],
+        }
+    }
+
+    /// Cool electric-blue palette — audio-equipment vibe.
+    const fn cyan() -> Self {
+        Self {
+            bg: [235, 10, 15, 20],
+            ring: [64, 34, 211, 238], // #22D3EE @ 25%
+            rec_bar: [255, 34, 211, 238],
+            trans_bar: [255, 56, 189, 248], // #38BDF8
+            glow: [50, 34, 211, 238],
+        }
+    }
+
+    fn from_config(cfg: &OverlayConfig) -> Self {
+        let base = match cfg.theme.as_str() {
+            "carbon" => Self::carbon(),
+            "cyan" => Self::cyan(),
+            "ember" | "custom" => Self::ember(),
+            other => {
+                warn!("unknown overlay theme {other:?}, falling back to ember");
+                Self::ember()
+            }
+        };
+        if cfg.theme != "custom" {
+            return base;
+        }
+        let Some(c) = cfg.colors.as_ref() else {
+            return base;
+        };
+        Self {
+            bg: c
+                .background
+                .as_deref()
+                .and_then(crate::parse_hex_color)
+                .unwrap_or(base.bg),
+            ring: c
+                .ring
+                .as_deref()
+                .and_then(crate::parse_hex_color)
+                .unwrap_or(base.ring),
+            rec_bar: c
+                .recording
+                .as_deref()
+                .and_then(crate::parse_hex_color)
+                .unwrap_or(base.rec_bar),
+            trans_bar: c
+                .transcribing
+                .as_deref()
+                .and_then(crate::parse_hex_color)
+                .unwrap_or(base.trans_bar),
+            glow: c
+                .glow
+                .as_deref()
+                .and_then(crate::parse_hex_color)
+                .unwrap_or(base.glow),
+        }
+    }
+}
 
 /// Spawn the bottom recording overlay.
 ///
@@ -59,11 +157,13 @@ const FADE_STEP: f32 = 0.55;
 pub async fn spawn_overlay(
     mut state_rx: watch::Receiver<State>,
     mut level_rx: watch::Receiver<f32>,
+    config: OverlayConfig,
 ) {
     let gnome_state_rx = state_rx.clone();
     let gnome_level_rx = level_rx.clone();
+    let gnome_theme = config.theme.clone();
     tokio::spawn(async move {
-        if let Err(e) = run_gnome_broadcaster(gnome_state_rx, gnome_level_rx).await {
+        if let Err(e) = run_gnome_broadcaster(gnome_state_rx, gnome_level_rx, gnome_theme).await {
             warn!("GNOME overlay D-Bus broadcaster unavailable: {e:#}");
         }
     });
@@ -71,10 +171,11 @@ pub async fn spawn_overlay(
     let (tx, rx) = mpsc::channel::<State>();
     let (level_tx, level_rx_thread) = mpsc::channel::<f32>();
 
+    let overlay_config = config;
     std::thread::Builder::new()
         .name("whisrs-overlay".to_string())
         .spawn(move || {
-            if let Err(e) = run_overlay(rx, level_rx_thread) {
+            if let Err(e) = run_overlay(rx, level_rx_thread, overlay_config) {
                 warn!("overlay unavailable: {e:#}");
             }
         })
@@ -102,7 +203,16 @@ pub async fn spawn_overlay(
 async fn run_gnome_broadcaster(
     mut state_rx: watch::Receiver<State>,
     level_rx: watch::Receiver<f32>,
+    theme: String,
 ) -> Result<(), OverlayError> {
+    // Custom themes don't sync over D-Bus for v1 — the GNOME extension only
+    // knows the named themes it ships. Fall back to "ember" so the bar
+    // colors remain sensible.
+    let advertised_theme = match theme.as_str() {
+        "carbon" | "cyan" | "ember" => theme.clone(),
+        _ => "ember".to_string(),
+    };
+
     let conn = zbus::connection::Builder::session()?
         .serve_at("/org/whisrs/Overlay", GnomeOverlayBus)?
         .name("org.whisrs.Overlay")?
@@ -110,6 +220,7 @@ async fn run_gnome_broadcaster(
         .await?;
 
     info!("GNOME overlay D-Bus broadcaster started");
+    emit_gnome_theme(&conn, &advertised_theme).await?;
     let initial_state = *state_rx.borrow();
     emit_gnome_state(&conn, initial_state).await?;
     let initial_level = *level_rx.borrow();
@@ -161,6 +272,17 @@ async fn emit_gnome_level(conn: &zbus::Connection, level: f32) -> zbus::Result<(
     .await
 }
 
+async fn emit_gnome_theme(conn: &zbus::Connection, theme: &str) -> zbus::Result<()> {
+    conn.emit_signal(
+        None::<&str>,
+        "/org/whisrs/Overlay",
+        "org.whisrs.Overlay",
+        "ThemeChanged",
+        &theme,
+    )
+    .await
+}
+
 struct GnomeOverlayBus;
 
 #[zbus::interface(name = "org.whisrs.Overlay")]
@@ -173,7 +295,12 @@ impl GnomeOverlayBus {
 fn run_overlay(
     state_rx: mpsc::Receiver<State>,
     level_rx: mpsc::Receiver<f32>,
+    config: OverlayConfig,
 ) -> Result<(), OverlayError> {
+    let width = config.clamped_width();
+    let height = config.clamped_height();
+    let theme = Theme::from_config(&config);
+
     let conn = Connection::connect_to_env()?;
     let (globals, mut event_queue) = registry_queue_init(&conn)?;
     let qh = event_queue.handle();
@@ -189,7 +316,7 @@ fn run_overlay(
     layer.set_margin(0, 0, BOTTOM_MARGIN, 0);
     layer.set_exclusive_zone(0);
     layer.set_keyboard_interactivity(KeyboardInteractivity::None);
-    layer.set_size(WIDTH, HEIGHT);
+    layer.set_size(width, height);
 
     // Make the transparent overlay non-interactive so it never blocks clicks.
     let input_region = compositor.wl_compositor().create_region(&qh, ());
@@ -198,7 +325,7 @@ fn run_overlay(
 
     layer.commit();
 
-    let pool = SlotPool::new((WIDTH * HEIGHT * 4) as usize, &shm)?;
+    let pool = SlotPool::new((width * height * 4) as usize, &shm)?;
     let mut overlay = Overlay {
         registry_state: RegistryState::new(&globals),
         output_state: OutputState::new(&globals, &qh),
@@ -209,13 +336,14 @@ fn run_overlay(
         level_rx,
         exit: false,
         first_configure: true,
-        width: WIDTH,
-        height: HEIGHT,
+        width,
+        height,
         target_state: State::Idle,
         visible_state: State::Idle,
         alpha: 0.0,
         frame: 0,
         level: 0.0,
+        theme,
     };
 
     info!("recording overlay started");
@@ -244,6 +372,7 @@ struct Overlay {
     alpha: f32,
     frame: u32,
     level: f32,
+    theme: Theme,
 }
 
 impl Overlay {
@@ -300,6 +429,7 @@ impl Overlay {
             self.frame,
             self.level,
             self.alpha,
+            &self.theme,
         );
         self.frame = self.frame.wrapping_add(1);
 
@@ -410,8 +540,8 @@ impl LayerShellHandler for Overlay {
         configure: LayerSurfaceConfigure,
         _serial: u32,
     ) {
-        self.width = configure.new_size.0.max(WIDTH);
-        self.height = configure.new_size.1.max(HEIGHT);
+        self.width = configure.new_size.0.max(self.width);
+        self.height = configure.new_size.1.max(self.height);
 
         if self.first_configure {
             self.first_configure = false;
@@ -452,6 +582,7 @@ impl ProvidesRegistryState for Overlay {
     registry_handlers![OutputState];
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_overlay(
     canvas: &mut [u8],
     width: u32,
@@ -460,6 +591,7 @@ fn draw_overlay(
     frame: u32,
     level: f32,
     alpha: f32,
+    theme: &Theme,
 ) {
     clear(canvas);
 
@@ -467,49 +599,57 @@ fn draw_overlay(
         return;
     }
 
-    // Brand palette: dark slate with a hint of purple, terminal green for
-    // recording, deep purple for transcribing.
-    let bg = scale_alpha([240, 22, 20, 32], alpha);
-    let inner_glow = scale_alpha([60, 108, 63, 197], alpha);
-    let accent = match state {
-        State::Recording => scale_alpha([255, 163, 230, 53], alpha),
-        State::Transcribing => scale_alpha([255, 108, 63, 197], alpha),
-        State::Idle => return,
-    };
+    let bg = scale_alpha(theme.bg, alpha);
+    let ring = scale_alpha(theme.ring, alpha);
 
+    // Pill background.
     let radius = height / 2;
     rounded_rect(canvas, width, height, 0, 0, width, height, radius, bg);
-    // Subtle purple inner ring as a brand accent — barely visible, just enough
-    // to lift the pill out of pure flat black.
-    rounded_rect(
-        canvas,
-        width,
-        height,
-        1,
-        1,
-        width - 2,
-        height - 2,
-        radius - 1,
-        inner_glow,
-    );
-    // Restore the bg one pixel in so we end up with a 1px purple ring.
-    rounded_rect(
-        canvas,
-        width,
-        height,
-        2,
-        2,
-        width - 4,
-        height - 4,
-        radius - 2,
-        bg,
-    );
+    // 1 px inner ring: paint a slightly inset rect in the ring color, then
+    // re-paint the further-inset interior with the bg color. The result is a
+    // thin colored band hugging the pill edge.
+    if width > 4 && height > 4 {
+        rounded_rect(
+            canvas,
+            width,
+            height,
+            1,
+            1,
+            width - 2,
+            height - 2,
+            radius.saturating_sub(1).max(1),
+            ring,
+        );
+        rounded_rect(
+            canvas,
+            width,
+            height,
+            2,
+            2,
+            width - 4,
+            height - 4,
+            radius.saturating_sub(2).max(1),
+            bg,
+        );
+    }
 
     match state {
-        State::Recording => draw_bars(canvas, width, height, accent, frame, level),
-        State::Transcribing => draw_sweep(canvas, width, height, accent, frame),
+        State::Recording => draw_bars(canvas, width, height, theme, frame, level, alpha),
+        State::Transcribing => draw_sweep(canvas, width, height, theme, frame, alpha),
         State::Idle => {}
     }
+}
+
+/// Gaussian taper across the bar row — center bars draw at ~100 % of their
+/// dynamic height, edges fall off to ~37 %. `i` is the bar index, `count`
+/// the total bar count.
+fn taper_factor(i: u32, count: u32) -> f32 {
+    if count <= 1 {
+        return 1.0;
+    }
+    let center = (count as f32 - 1.0) / 2.0;
+    let d = (i as f32 - center) / center; // -1..=1
+    (-d * d).exp() // exp(-1) ≈ 0.367 at edges
 }
 
 fn clear(canvas: &mut [u8]) {
@@ -564,56 +704,120 @@ fn scale_alpha(color: [u8; 4], alpha: f32) -> [u8; 4] {
     [a, color[1], color[2], color[3]]
 }
 
-const BAR_COUNT: u32 = 5;
-const BAR_W: u32 = 4;
-const BAR_GAP: u32 = 3;
-const BAR_PITCH: u32 = BAR_W + BAR_GAP;
-const BAR_BLOCK_W: u32 = BAR_COUNT * BAR_W + (BAR_COUNT - 1) * BAR_GAP;
-const BAR_X_START: u32 = (WIDTH - BAR_BLOCK_W) / 2;
-const BAR_BASELINE: i32 = 4;
-const BAR_MAX_H: i32 = 28;
+/// Vertical padding inside the pill (top + bottom). Bars never reach the
+/// pill edge.
+const BAR_VPAD: i32 = 5;
 
-fn draw_bars(canvas: &mut [u8], width: u32, height: u32, color: [u8; 4], frame: u32, level: f32) {
+/// Recording bars: react to audio level, gaussian taper across the row, soft
+/// glow halo behind each bar at higher amplitudes.
+fn draw_bars(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    theme: &Theme,
+    frame: u32,
+    level: f32,
+    alpha: f32,
+) {
     let cy = (height / 2) as i32;
+    let max_h = (height as i32 - BAR_VPAD * 2).max(BAR_BASELINE + 2);
+    let bar_x_start = (width.saturating_sub(BAR_BLOCK_W)) / 2;
+
     for i in 0..BAR_COUNT {
-        let variance = 0.7 + (i as f32 * 1.7).sin() * 0.3;
-        let phase = ((frame as f32 / 6.0) + i as f32 * 0.9).sin().abs();
-        let effective = (level * variance).clamp(0.0, 1.0);
-        let dynamic = effective * (0.6 + 0.4 * phase);
-        let h = (BAR_BASELINE as f32 + dynamic * (BAR_MAX_H - BAR_BASELINE) as f32)
+        let taper = taper_factor(i, BAR_COUNT);
+        // Per-bar phase keeps movement organic instead of marching in lockstep.
+        let phase = ((frame as f32 / 5.0) + i as f32 * 0.7).sin().abs();
+        let effective = (level * taper).clamp(0.0, 1.0);
+        let dynamic = effective * (0.7 + 0.3 * phase);
+        let h = (BAR_BASELINE as f32 + dynamic * (max_h - BAR_BASELINE) as f32)
             .round()
             .max(BAR_BASELINE as f32) as i32;
-        let bx = BAR_X_START + i * BAR_PITCH;
+        let bx = bar_x_start + i * BAR_PITCH;
         let by = (cy - h / 2).max(0) as u32;
-        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 2, color);
+
+        // Glow halo behind the bar — only visible above a small threshold.
+        if effective > 0.02 {
+            let glow_intensity = (effective * 0.9 + 0.1).clamp(0.0, 1.0);
+            let glow_a = (theme.glow[0] as f32 * glow_intensity * alpha).round() as u8;
+            let glow_color = [glow_a, theme.glow[1], theme.glow[2], theme.glow[3]];
+            let glow_w = BAR_W + 2;
+            let glow_h = (h + 2).max(BAR_BASELINE + 2) as u32;
+            let glow_x = bx.saturating_sub(1);
+            let glow_y = ((cy - glow_h as i32 / 2).max(0)) as u32;
+            rounded_rect(
+                canvas,
+                width,
+                height,
+                glow_x,
+                glow_y,
+                glow_w,
+                glow_h,
+                glow_w / 2,
+                glow_color,
+            );
+        }
+
+        let bar_color = scale_alpha(theme.rec_bar, alpha);
+        rounded_rect(
+            canvas,
+            width,
+            height,
+            bx,
+            by,
+            BAR_W,
+            h as u32,
+            BAR_W / 2,
+            bar_color,
+        );
     }
 }
 
-fn draw_sweep(canvas: &mut [u8], width: u32, height: u32, color: [u8; 4], frame: u32) {
+/// Transcribing state: no audio level, just a center-out shimmer that travels
+/// across the bar row to communicate "working on it" without flat staticness.
+fn draw_sweep(canvas: &mut [u8], width: u32, height: u32, theme: &Theme, frame: u32, alpha: f32) {
     let cy = (height / 2) as i32;
+    let max_h = (height as i32 - BAR_VPAD * 2).max(BAR_BASELINE + 2);
+    let bar_x_start = (width.saturating_sub(BAR_BLOCK_W)) / 2;
+
+    // Sliding focus point that pings back and forth across the row.
     let cycle = (BAR_COUNT as i32) * 2 - 2;
-    let pos = ((frame / 4) as i32) % cycle.max(1);
+    let pos = ((frame / 3) as i32) % cycle.max(1);
     let active = if pos < BAR_COUNT as i32 {
-        pos
+        pos as f32
     } else {
-        cycle - pos
+        (cycle - pos) as f32
     };
+
     for i in 0..BAR_COUNT {
-        let dist = (i as i32 - active).abs() as f32;
-        let intensity = (1.0 - dist / 2.5).max(0.18);
-        let bar_color = [
-            (color[0] as f32 * intensity).round() as u8,
-            color[1],
-            color[2],
-            color[3],
-        ];
-        let h = (BAR_BASELINE as f32
-            + (BAR_MAX_H - BAR_BASELINE) as f32 * (0.45 + 0.55 * intensity))
-            .round() as i32;
-        let h = h.max(BAR_BASELINE);
-        let bx = BAR_X_START + i * BAR_PITCH;
+        let taper = taper_factor(i, BAR_COUNT);
+        let dist = (i as f32 - active).abs();
+        // Bell-shaped intensity centered on `active`, ~3 bars wide.
+        let intensity = (-dist * dist / 4.0).exp().max(0.15);
+        let dynamic = intensity * taper;
+        let h = (BAR_BASELINE as f32 + dynamic * (max_h - BAR_BASELINE) as f32 * 0.85)
+            .round()
+            .max(BAR_BASELINE as f32) as i32;
+        let bx = bar_x_start + i * BAR_PITCH;
         let by = (cy - h / 2).max(0) as u32;
-        rounded_rect(canvas, width, height, bx, by, BAR_W, h as u32, 2, bar_color);
+
+        let bar_a = (theme.trans_bar[0] as f32 * (0.3 + 0.7 * intensity) * alpha).round() as u8;
+        let bar_color = [
+            bar_a,
+            theme.trans_bar[1],
+            theme.trans_bar[2],
+            theme.trans_bar[3],
+        ];
+        rounded_rect(
+            canvas,
+            width,
+            height,
+            bx,
+            by,
+            BAR_W,
+            h as u32,
+            BAR_W / 2,
+            bar_color,
+        );
     }
 }
 
@@ -630,46 +834,64 @@ fn blend_pixel(canvas: &mut [u8], width: u32, height: u32, x: u32, y: u32, color
 mod tests {
     use super::*;
 
+    const W: u32 = 100;
+    const H: u32 = 34;
+
     #[test]
     fn idle_draw_is_transparent() {
-        let mut canvas = vec![1; (WIDTH * HEIGHT * 4) as usize];
-        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Idle, 0, 0.0, 0.0);
+        let mut canvas = vec![1; (W * H * 4) as usize];
+        let t = Theme::ember();
+        draw_overlay(&mut canvas, W, H, State::Idle, 0, 0.0, 0.0, &t);
         assert!(canvas.iter().all(|b| *b == 0));
     }
 
     #[test]
     fn faded_out_draw_is_transparent() {
-        let mut canvas = vec![1; (WIDTH * HEIGHT * 4) as usize];
-        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Recording, 0, 1.0, 0.0);
+        let mut canvas = vec![1; (W * H * 4) as usize];
+        let t = Theme::ember();
+        draw_overlay(&mut canvas, W, H, State::Recording, 0, 1.0, 0.0, &t);
         assert!(canvas.iter().all(|b| *b == 0));
     }
 
     #[test]
     fn active_draw_has_visible_pixels() {
-        let mut canvas = vec![0; (WIDTH * HEIGHT * 4) as usize];
-        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Recording, 0, 1.0, 1.0);
+        let mut canvas = vec![0; (W * H * 4) as usize];
+        let t = Theme::ember();
+        draw_overlay(&mut canvas, W, H, State::Recording, 0, 1.0, 1.0, &t);
         assert!(canvas.chunks_exact(4).any(|px| px[3] != 0));
     }
 
     #[test]
+    fn taper_is_strongest_in_center() {
+        let center = taper_factor(BAR_COUNT / 2, BAR_COUNT);
+        let edge_left = taper_factor(0, BAR_COUNT);
+        let edge_right = taper_factor(BAR_COUNT - 1, BAR_COUNT);
+        assert!(center > edge_left);
+        assert!(center > edge_right);
+        assert!(edge_left < 0.5);
+        assert!(edge_right < 0.5);
+    }
+
+    #[test]
     fn silence_draws_minimal_baseline() {
-        // Bar color (terminal green, brand accent) overdraws the dark pill;
-        // counting green-dominant pixels measures bar area regardless of the
-        // underlying background. ARGB on disk is little-endian B,G,R,A — so
-        // each pixel reads as [B, G, R, A].
-        fn green_pixels(canvas: &[u8]) -> usize {
+        // Recording bars in the ember theme are amber (#F97316); count
+        // amber-dominant pixels to measure bar area independent of the bg
+        // pill. ARGB on disk is little-endian B,G,R,A — each pixel is
+        // [B, G, R, A].
+        fn amber_pixels(canvas: &[u8]) -> usize {
             canvas
                 .chunks_exact(4)
-                .filter(|px| px[1] > 180 && px[2] < 200 && px[0] < 100)
+                .filter(|px| px[2] > 220 && px[1] > 80 && px[1] < 180 && px[0] < 60)
                 .count()
         }
 
-        let mut quiet = vec![0; (WIDTH * HEIGHT * 4) as usize];
-        let mut loud = vec![0; (WIDTH * HEIGHT * 4) as usize];
-        draw_overlay(&mut quiet, WIDTH, HEIGHT, State::Recording, 0, 0.0, 1.0);
-        draw_overlay(&mut loud, WIDTH, HEIGHT, State::Recording, 0, 1.0, 1.0);
-        let count_quiet = green_pixels(&quiet);
-        let count_loud = green_pixels(&loud);
+        let t = Theme::ember();
+        let mut quiet = vec![0; (W * H * 4) as usize];
+        let mut loud = vec![0; (W * H * 4) as usize];
+        draw_overlay(&mut quiet, W, H, State::Recording, 0, 0.0, 1.0, &t);
+        draw_overlay(&mut loud, W, H, State::Recording, 0, 1.0, 1.0, &t);
+        let count_quiet = amber_pixels(&quiet);
+        let count_loud = amber_pixels(&loud);
         assert!(
             count_loud > count_quiet,
             "loud audio should fill more bar area than silence (silence={count_quiet}, loud={count_loud})"

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -465,10 +465,21 @@ impl Overlay {
                 self.spawn_t = 0.0;
             }
         }
-        while let Ok(level) = self.level_rx.try_recv() {
-            self.level = level.clamp(0.0, 1.0);
+        // Envelope follower: fast attack (track peaks instantly) + slow
+        // release (hold the loudness so the bars stay tall during speech
+        // instead of bouncing with every audio buffer's RMS variation).
+        // Without this the bars track raw RMS, which oscillates between
+        // 30 %–70 % several times per word and reads as "dots bouncing
+        // up and down" rather than "amplitude expanding".
+        while let Ok(new) = self.level_rx.try_recv() {
+            let new = new.clamp(0.0, 1.0);
+            if new > self.level {
+                self.level = new;
+            } else {
+                // ~125 ms release at the typical 100 Hz audio callback rate.
+                self.level = self.level * 0.92 + new * 0.08;
+            }
         }
-        self.level = (self.level * 0.85).max(0.0);
 
         // Advance the spawn animation. `spawn_t` saturates at 1.0; at that
         // point the pill is fully shown (`spawn_in = true`) or fully hidden

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -39,7 +39,7 @@ use smithay_client_toolkit::{
     shm::{slot::SlotPool, Shm, ShmHandler},
 };
 use tiny_skia::{
-    Color, FillRule, Paint, PathBuilder, Pixmap, PremultipliedColorU8, Rect, Stroke, Transform,
+    Color, FillRule, Paint, PathBuilder, Pixmap, PremultipliedColorU8, Rect, Transform,
 };
 use tokio::sync::watch;
 use tracing::{info, warn};
@@ -58,27 +58,34 @@ const BOTTOM_MARGIN: i32 = 16;
 // per-frame steps using this constant.
 const FRAME_MS: f32 = 24.0;
 
-// Spawn animation durations (ms). Slightly faster going away than coming in
-// — the asymmetry reads as "intentional dismiss" rather than a glitch.
-const SPAWN_IN_MS: f32 = 180.0;
+// Spawn animation: the pill "draws out" from a 4-px sliver anchored at the
+// bottom of the surface up to its full configured height. Slight overshoot
+// for life. Going away is shorter and accelerated — feels intentional.
+const SPAWN_IN_MS: f32 = 220.0;
 const SPAWN_OUT_MS: f32 = 140.0;
+/// Initial pill height during the appear animation, in px.
+const SPAWN_PILL_MIN_H: f32 = 4.0;
+/// `easeOutBack` overshoot constant. 0.4 ⇒ peak ~3 % over target before
+/// settling — barely perceptible but adds a "physical arrival" feel.
+const SPAWN_OVERSHOOT_C: f32 = 0.4;
 
-// On appear, hold the bars at their baseline for this many milliseconds so
-// the audio reactivity doesn't fire while the pill is still flying in.
+/// While the pill is still growing, bars stay fully invisible for this many
+/// ms after appearance — then they fade in over `BARS_FADE_MS` while the
+/// pill finishes settling. After both have elapsed, audio reactivity
+/// unlocks.
 const BARS_GRACE_MS: f32 = 80.0;
+const BARS_FADE_MS: f32 = 80.0;
 
-// Slide-up offset (px) and scale start used by the spawn animation.
-const SPAWN_SLIDE_PX: f32 = 8.0;
-const SPAWN_SCALE_FROM: f32 = 0.92;
-
-// Bar layout — fixed for visual consistency.
-// 5 bars × 6 px + 4 gaps × 4 px = 46 px wide, centered in the pill.
+// Bar layout — thin and dense. 5 bars × 3 px + 4 gaps × 3 px = 27 px wide,
+// centered in the pill. Max bar height = HEIGHT − 2·BAR_VPAD (e.g. 50 px on
+// the default 64 px pill), giving real vertical expansion under speech.
 const BAR_COUNT: u32 = 5;
-const BAR_W: f32 = 6.0;
-const BAR_GAP: f32 = 4.0;
+const BAR_W: f32 = 3.0;
+const BAR_GAP: f32 = 3.0;
 const BAR_PITCH: f32 = BAR_W + BAR_GAP;
 const BAR_BLOCK_W: f32 = BAR_COUNT as f32 * BAR_W + (BAR_COUNT - 1) as f32 * BAR_GAP;
-const BAR_BASELINE: f32 = 3.0;
+const BAR_BASELINE: f32 = 2.0;
+const BAR_VPAD: f32 = 7.0;
 
 /// Color palette for one overlay theme. Bytes are stored as `[A, R, G, B]`,
 /// matching the canvas pixel layout used by [`blend_pixel`].
@@ -412,14 +419,25 @@ struct Overlay {
     theme: Theme,
 }
 
+/// Per-frame animation state computed from `spawn_t` + `spawn_in`. The
+/// spawn animation drives a bottom-anchored height morph (with a small
+/// overshoot on appear) instead of a slide+scale; the pill literally draws
+/// itself out of the screen edge.
 #[derive(Debug, Clone, Copy)]
 struct AnimState {
-    /// 0..=1
-    alpha: f32,
-    /// Vertical offset in px. Positive = drawn lower than rest position.
-    slide_y: f32,
-    /// Linear scale factor centered on the pill.
-    scale: f32,
+    /// Currently displayed pill height in px (bottom-anchored — the pill's
+    /// bottom edge stays glued to the surface bottom regardless of this
+    /// value).
+    pill_height: f32,
+    /// Pill alpha 0..=1. Eases in faster than the height grows so the pill
+    /// is solid before it stops moving.
+    pill_alpha: f32,
+    /// Bar alpha 0..=1. Stays at 0 during the initial grow, then fades in.
+    bar_alpha: f32,
+    /// `true` while audio reactivity should be gated to baseline. Honored
+    /// by the recording draw — silenced bars rise from baseline once this
+    /// goes false.
+    bars_locked: bool,
 }
 
 impl Overlay {
@@ -470,25 +488,59 @@ impl Overlay {
         }
     }
 
-    /// Compute the current animated transform: alpha for the cross-fade,
-    /// slide_y in px, and the centered scale factor. Uses `ease_out_cubic`
-    /// for the appear path so the pill decelerates into place, and
-    /// `ease_in_cubic` on the way out for a faster, more committed dismiss.
-    fn anim(&self) -> AnimState {
+    /// Compute the current animated transform.
+    ///
+    /// **Appear** (`spawn_in == true`, 220 ms):
+    /// - Pill height grows `SPAWN_PILL_MIN_H → full_height` with an
+    ///   `easeOutBack` curve, so it overshoots ~3 % then settles —
+    ///   gives the arrival a small "physical pop".
+    /// - Pill alpha eases in over the first ~64 % of the duration (so
+    ///   the pill is solid before it stops moving — Material 3
+    ///   "emphasized" pattern).
+    /// - Bars stay invisible for the first 80 ms, then fade in over the
+    ///   next 80 ms while the pill is still finishing its grow. After
+    ///   that window they unlock and react to audio.
+    ///
+    /// **Disappear** (`spawn_in == false`, 140 ms):
+    /// - Pill height shrinks back to `SPAWN_PILL_MIN_H` with an
+    ///   `easeInCubic` accelerate — sharper exit than entry.
+    /// - Pill and bar alpha fade in lockstep with the height collapse.
+    fn anim(&self, full_height: f32) -> AnimState {
         let t = self.spawn_t.clamp(0.0, 1.0);
         if self.spawn_in {
-            let e = ease_out_cubic(t);
+            let h_curve = ease_out_back(t, SPAWN_OVERSHOOT_C).clamp(0.0, 1.4);
+            let pill_height = SPAWN_PILL_MIN_H + h_curve * (full_height - SPAWN_PILL_MIN_H);
+
+            // Alpha finishes well before the height — so the pill is fully
+            // opaque while it's still growing. ease-out-quad over first 64%.
+            let alpha_t = (t / 0.64).clamp(0.0, 1.0);
+            let pill_alpha = 1.0 - (1.0 - alpha_t) * (1.0 - alpha_t);
+
+            // Bar grace + fade. Convert ms to t-fractions of total duration.
+            let grace_t = BARS_GRACE_MS / SPAWN_IN_MS;
+            let fade_t = BARS_FADE_MS / SPAWN_IN_MS;
+            let bar_t = ((t - grace_t) / fade_t).clamp(0.0, 1.0);
+            let bar_alpha = 1.0 - (1.0 - bar_t) * (1.0 - bar_t);
+            let bars_locked = t < grace_t + fade_t;
+
             AnimState {
-                alpha: e,
-                slide_y: (1.0 - e) * SPAWN_SLIDE_PX,
-                scale: SPAWN_SCALE_FROM + e * (1.0 - SPAWN_SCALE_FROM),
+                pill_height,
+                pill_alpha,
+                bar_alpha,
+                bars_locked,
             }
         } else {
             let e = ease_in_cubic(t);
+            let pill_height = full_height - e * (full_height - SPAWN_PILL_MIN_H);
+            let pill_alpha = 1.0 - e;
+            // Bars fade out a bit faster than the pill collapses.
+            let bar_t = (t / 0.7).clamp(0.0, 1.0);
+            let bar_alpha = 1.0 - bar_t * bar_t;
             AnimState {
-                alpha: 1.0 - e,
-                slide_y: e * SPAWN_SLIDE_PX,
-                scale: 1.0 - e * 0.04,
+                pill_height,
+                pill_alpha,
+                bar_alpha,
+                bars_locked: true,
             }
         }
     }
@@ -502,15 +554,8 @@ impl Overlay {
 
         // Render into our owned pixmap first so the buffer borrow on the
         // shm pool doesn't conflict with the pixmap borrow.
-        let anim = self.anim();
-        // Audio reactivity is gated for the first few frames after
-        // appearing, so the bars don't react to speech while the pill is
-        // still flying in.
-        let level_gated = if self.bars_grace_ms > 0.0 {
-            0.0
-        } else {
-            self.level
-        };
+        let anim = self.anim(height as f32);
+        let level_gated = if anim.bars_locked { 0.0 } else { self.level };
         draw_overlay(
             &mut self.pixmap,
             self.visible_state,
@@ -548,13 +593,17 @@ impl Overlay {
     }
 }
 
-fn ease_out_cubic(t: f32) -> f32 {
-    let inv = 1.0 - t;
-    1.0 - inv * inv * inv
-}
-
 fn ease_in_cubic(t: f32) -> f32 {
     t * t * t
+}
+
+/// "Back" easing — overshoots the target by `c × peak %` before settling.
+/// `c = 0.4` ⇒ ~3 % overshoot; `c = 1.7` is the standard CSS easeOutBack
+/// (~10 %). Output range is approximately [0, 1+c/something], typically
+/// peaking around `t ≈ 0.85`.
+fn ease_out_back(t: f32, c: f32) -> f32 {
+    let t1 = t - 1.0;
+    1.0 + (c + 1.0) * t1 * t1 * t1 + c * t1 * t1
 }
 
 /// tiny-skia stores premultiplied RGBA bytes; the wl_shm Argb8888 format on
@@ -706,12 +755,11 @@ impl ProvidesRegistryState for Overlay {
     registry_handlers![OutputState];
 }
 
-/// Render one frame of the overlay into `pixmap` using tiny-skia. The pixmap
-/// is the same size as the surface; coordinates are in pixels.
-///
-/// The animation transform (`anim`) controls a slide-up + scale + fade
-/// applied uniformly to the pill — implemented as a tiny-skia `Transform`
-/// so anti-aliasing handles the sub-pixel motion without us having to round.
+/// Render one frame of the overlay into `pixmap` using tiny-skia. The
+/// pixmap is the same size as the surface; the pill is drawn at the bottom
+/// of the surface (its bottom edge glued to the surface bottom) so the
+/// height-morph animation reads as the pill *growing out of the screen
+/// edge* instead of inflating from its center.
 fn draw_overlay(
     pixmap: &mut Pixmap,
     state: State,
@@ -722,76 +770,83 @@ fn draw_overlay(
 ) {
     pixmap.fill(Color::TRANSPARENT);
 
-    if anim.alpha <= 0.0 || state == State::Idle {
+    if anim.pill_alpha <= 0.0 || state == State::Idle {
         return;
     }
 
-    let width = pixmap.width() as f32;
-    let height = pixmap.height() as f32;
+    let surface_w = pixmap.width() as f32;
+    let surface_h = pixmap.height() as f32;
+    let pill_h = anim.pill_height.clamp(SPAWN_PILL_MIN_H, surface_h);
+    let pill_y = surface_h - pill_h; // bottom-anchored
+    let pill_w = surface_w;
 
-    // Translate-then-scale around the pill center so the spawn animation
-    // expands from the center, then translate again to apply the slide-up.
-    let cx = width / 2.0;
-    let cy = height / 2.0;
-    let transform = Transform::from_translate(cx, cy)
-        .pre_scale(anim.scale, anim.scale)
-        .post_translate(-cx, -cy)
-        .post_translate(0.0, anim.slide_y);
-
-    // Pill background.
-    let radius = height / 2.0;
-    let pill_path = build_round_rect(0.0, 0.0, width, height, radius);
-    let mut paint = Paint {
-        anti_alias: true,
-        ..Default::default()
-    };
-    paint.set_color(theme_color(theme.bg, anim.alpha));
-    if let Some(path) = &pill_path {
-        pixmap.fill_path(path, &paint, FillRule::Winding, transform, None);
+    // Outer pill — drawn in the *ring* color first. We then paint a 1 px
+    // inset pill in the *bg* color so the visible result is a perfectly
+    // even 1 px ring with no stroke-math seams. This avoids the corner
+    // join artifacts that a tiny-skia stroke produces on tight pills.
+    let outer = build_stadium(0.0, pill_y, pill_w, pill_h);
+    if let Some(path) = &outer {
+        let mut paint = Paint {
+            anti_alias: true,
+            ..Default::default()
+        };
+        paint.set_color(theme_color(theme.ring, anim.pill_alpha));
+        pixmap.fill_path(path, &paint, FillRule::Winding, Transform::identity(), None);
     }
 
-    // Hairline ring — drawn as a 1 px stroked pill.
-    let stroke = Stroke {
-        width: 1.0,
-        ..Default::default()
-    };
-    paint.set_color(theme_color(theme.ring, anim.alpha));
-    if let Some(path) = &pill_path {
-        pixmap.stroke_path(path, &paint, &stroke, transform, None);
+    if pill_w > 2.0 && pill_h > 2.0 {
+        let inner = build_stadium(1.0, pill_y + 1.0, pill_w - 2.0, pill_h - 2.0);
+        if let Some(path) = &inner {
+            let mut paint = Paint {
+                anti_alias: true,
+                ..Default::default()
+            };
+            paint.set_color(theme_color(theme.bg, anim.pill_alpha));
+            pixmap.fill_path(path, &paint, FillRule::Winding, Transform::identity(), None);
+        }
     }
 
+    if anim.bar_alpha <= 0.0 {
+        return;
+    }
+
+    let pill_cy = pill_y + pill_h / 2.0;
     match state {
-        State::Recording => draw_bars(pixmap, theme, frame, level, anim, transform),
-        State::Transcribing => draw_sweep(pixmap, theme, frame, anim, transform),
+        State::Recording => draw_bars(pixmap, theme, frame, level, anim, pill_cy),
+        State::Transcribing => draw_sweep(pixmap, theme, frame, anim, pill_cy),
         State::Idle => {}
     }
 }
 
-/// Build a centered rounded-rect path. tiny-skia doesn't ship a rounded-rect
-/// helper, so we approximate the corner arcs with cubic Bezier curves using
-/// the standard 0.5523 control-point offset.
-fn build_round_rect(x: f32, y: f32, w: f32, h: f32, r: f32) -> Option<tiny_skia::Path> {
+/// Build a stadium / pill path: rectangle + two end-cap circles, joined by
+/// the `Winding` fill rule. This is geometrically exact — no cubic-bezier
+/// approximation — so the silhouette has no minor inward dents at the
+/// corner joins, which were visible against colored rings.
+///
+/// When `w == h` it falls back to a single circle. When `h <= 0` or
+/// `w <= 0` it returns `None`.
+fn build_stadium(x: f32, y: f32, w: f32, h: f32) -> Option<tiny_skia::Path> {
     if w <= 0.0 || h <= 0.0 {
         return None;
     }
-    let r = r.min(w / 2.0).min(h / 2.0).max(0.0);
-    if r <= 0.0 {
-        return PathBuilder::from_rect(Rect::from_xywh(x, y, w, h)?).into();
+    let r = (h / 2.0).min(w / 2.0);
+    if (w - 2.0 * r).abs() < 0.01 {
+        // Square (or near-square) input ⇒ pure circle.
+        return PathBuilder::from_circle(x + r, y + r, r);
     }
-    // Standard "kappa" cubic-bezier circle approximation: 4·(√2 − 1)/3.
-    let k = 0.552_284_8_f32 * r;
-
     let mut pb = PathBuilder::new();
-    pb.move_to(x + r, y);
-    pb.line_to(x + w - r, y);
-    pb.cubic_to(x + w - r + k, y, x + w, y + r - k, x + w, y + r);
-    pb.line_to(x + w, y + h - r);
-    pb.cubic_to(x + w, y + h - r + k, x + w - r + k, y + h, x + w - r, y + h);
-    pb.line_to(x + r, y + h);
-    pb.cubic_to(x + r - k, y + h, x, y + h - r + k, x, y + h - r);
-    pb.line_to(x, y + r);
-    pb.cubic_to(x, y + r - k, x + r - k, y, x + r, y);
-    pb.close();
+    // Middle rectangle, between the two end-cap centers.
+    if let Some(rect) = Rect::from_xywh(x + r, y, w - 2.0 * r, h) {
+        pb.push_rect(rect);
+    }
+    // Left end-cap.
+    if let Some(cap) = PathBuilder::from_circle(x + r, y + r, r) {
+        pb.push_path(&cap);
+    }
+    // Right end-cap.
+    if let Some(cap) = PathBuilder::from_circle(x + w - r, y + r, r) {
+        pb.push_path(&cap);
+    }
     pb.finish()
 }
 
@@ -820,40 +875,39 @@ fn taper_factor(i: u32, count: u32) -> f32 {
     (-d * d).exp() // exp(-1) ≈ 0.367 at edges
 }
 
-/// Vertical padding inside the pill (top + bottom). Bars never reach the
-/// pill edge.
-const BAR_VPAD: f32 = 5.0;
-
 /// Recording bars: react to audio level, gaussian taper across the row,
-/// soft glow halo behind each bar at higher amplitudes.
+/// soft glow halo behind each bar at higher amplitudes. The audio level is
+/// the dominant driver — only ~15 % of the bar height comes from the
+/// per-bar phase animation, so silence reads as actually quiet and loud
+/// speech reaches near the pill edge.
 fn draw_bars(
     pixmap: &mut Pixmap,
     theme: &Theme,
     frame: u32,
     level: f32,
     anim: AnimState,
-    transform: Transform,
+    pill_cy: f32,
 ) {
-    let width = pixmap.width() as f32;
-    let height = pixmap.height() as f32;
-    let cy = height / 2.0;
-    let max_h = (height - BAR_VPAD * 2.0).max(BAR_BASELINE + 2.0);
-    let bar_x_start = (width - BAR_BLOCK_W) / 2.0;
+    let surface_w = pixmap.width() as f32;
+    // Track the *currently displayed* pill height so bars stay within the
+    // pill while it's still growing during the spawn animation.
+    let max_h = (anim.pill_height - BAR_VPAD * 2.0).max(BAR_BASELINE + 2.0);
+    let bar_x_start = (surface_w - BAR_BLOCK_W) / 2.0;
 
     for i in 0..BAR_COUNT {
         let taper = taper_factor(i, BAR_COUNT);
-        // Per-bar phase keeps movement organic instead of marching in lockstep.
+        // Audio-led: 85 % level + taper, only 15 % per-bar phase animation.
         let phase = ((frame as f32 / 5.0) + i as f32 * 0.7).sin().abs();
         let effective = (level * taper).clamp(0.0, 1.0);
-        let dynamic = effective * (0.7 + 0.3 * phase);
+        let dynamic = effective * (0.85 + 0.15 * phase);
         let h = (BAR_BASELINE + dynamic * (max_h - BAR_BASELINE)).max(BAR_BASELINE);
         let bx = bar_x_start + i as f32 * BAR_PITCH;
-        let by = cy - h / 2.0;
+        let by = pill_cy - h / 2.0;
 
         // Glow halo behind the bar — only visible above a small threshold.
         if effective > 0.02 {
             let glow_intensity = (effective * 0.9 + 0.1).clamp(0.0, 1.0);
-            let glow_a = theme.glow[0] as f32 / 255.0 * glow_intensity * anim.alpha;
+            let glow_a = theme.glow[0] as f32 / 255.0 * glow_intensity * anim.bar_alpha;
             let glow_color = Color::from_rgba(
                 theme.glow[1] as f32 / 255.0,
                 theme.glow[2] as f32 / 255.0,
@@ -863,25 +917,35 @@ fn draw_bars(
             .unwrap_or(Color::TRANSPARENT);
             let glow_w = BAR_W + 2.0;
             let glow_h = (h + 2.0).max(BAR_BASELINE + 2.0);
-            if let Some(path) =
-                build_round_rect(bx - 1.0, cy - glow_h / 2.0, glow_w, glow_h, glow_w / 2.0)
-            {
+            if let Some(path) = build_stadium(bx - 1.0, pill_cy - glow_h / 2.0, glow_w, glow_h) {
                 let mut paint = Paint {
                     anti_alias: true,
                     ..Default::default()
                 };
                 paint.set_color(glow_color);
-                pixmap.fill_path(&path, &paint, FillRule::Winding, transform, None);
+                pixmap.fill_path(
+                    &path,
+                    &paint,
+                    FillRule::Winding,
+                    Transform::identity(),
+                    None,
+                );
             }
         }
 
-        if let Some(path) = build_round_rect(bx, by, BAR_W, h, BAR_W / 2.0) {
+        if let Some(path) = build_stadium(bx, by, BAR_W, h) {
             let mut paint = Paint {
                 anti_alias: true,
                 ..Default::default()
             };
-            paint.set_color(theme_color(theme.rec_bar, anim.alpha));
-            pixmap.fill_path(&path, &paint, FillRule::Winding, transform, None);
+            paint.set_color(theme_color(theme.rec_bar, anim.bar_alpha));
+            pixmap.fill_path(
+                &path,
+                &paint,
+                FillRule::Winding,
+                Transform::identity(),
+                None,
+            );
         }
     }
 }
@@ -889,18 +953,10 @@ fn draw_bars(
 /// Transcribing state: no audio level, just a center-out shimmer that
 /// travels across the bar row to communicate "working on it" without
 /// flat staticness.
-fn draw_sweep(
-    pixmap: &mut Pixmap,
-    theme: &Theme,
-    frame: u32,
-    anim: AnimState,
-    transform: Transform,
-) {
-    let width = pixmap.width() as f32;
-    let height = pixmap.height() as f32;
-    let cy = height / 2.0;
-    let max_h = (height - BAR_VPAD * 2.0).max(BAR_BASELINE + 2.0);
-    let bar_x_start = (width - BAR_BLOCK_W) / 2.0;
+fn draw_sweep(pixmap: &mut Pixmap, theme: &Theme, frame: u32, anim: AnimState, pill_cy: f32) {
+    let surface_w = pixmap.width() as f32;
+    let max_h = (anim.pill_height - BAR_VPAD * 2.0).max(BAR_BASELINE + 2.0);
+    let bar_x_start = (surface_w - BAR_BLOCK_W) / 2.0;
 
     // Sliding focus point that pings back and forth across the row.
     let cycle = (BAR_COUNT as i32) * 2 - 2;
@@ -919,9 +975,9 @@ fn draw_sweep(
         let dynamic = intensity * taper;
         let h = (BAR_BASELINE + dynamic * (max_h - BAR_BASELINE) * 0.85).max(BAR_BASELINE);
         let bx = bar_x_start + i as f32 * BAR_PITCH;
-        let by = cy - h / 2.0;
+        let by = pill_cy - h / 2.0;
 
-        let bar_a = theme.trans_bar[0] as f32 / 255.0 * (0.3 + 0.7 * intensity) * anim.alpha;
+        let bar_a = theme.trans_bar[0] as f32 / 255.0 * (0.3 + 0.7 * intensity) * anim.bar_alpha;
         let bar_color = Color::from_rgba(
             theme.trans_bar[1] as f32 / 255.0,
             theme.trans_bar[2] as f32 / 255.0,
@@ -930,13 +986,19 @@ fn draw_sweep(
         )
         .unwrap_or(Color::TRANSPARENT);
 
-        if let Some(path) = build_round_rect(bx, by, BAR_W, h, BAR_W / 2.0) {
+        if let Some(path) = build_stadium(bx, by, BAR_W, h) {
             let mut paint = Paint {
                 anti_alias: true,
                 ..Default::default()
             };
             paint.set_color(bar_color);
-            pixmap.fill_path(&path, &paint, FillRule::Winding, transform, None);
+            pixmap.fill_path(
+                &path,
+                &paint,
+                FillRule::Winding,
+                Transform::identity(),
+                None,
+            );
         }
     }
 }
@@ -946,7 +1008,7 @@ mod tests {
     use super::*;
 
     const W: u32 = 100;
-    const H: u32 = 34;
+    const H: u32 = 64;
 
     fn fresh_pixmap() -> Pixmap {
         Pixmap::new(W, H).unwrap()
@@ -954,16 +1016,18 @@ mod tests {
 
     fn shown() -> AnimState {
         AnimState {
-            alpha: 1.0,
-            slide_y: 0.0,
-            scale: 1.0,
+            pill_height: H as f32,
+            pill_alpha: 1.0,
+            bar_alpha: 1.0,
+            bars_locked: false,
         }
     }
     fn hidden() -> AnimState {
         AnimState {
-            alpha: 0.0,
-            slide_y: 0.0,
-            scale: 1.0,
+            pill_height: SPAWN_PILL_MIN_H,
+            pill_alpha: 0.0,
+            bar_alpha: 0.0,
+            bars_locked: true,
         }
     }
 
@@ -1005,10 +1069,12 @@ mod tests {
 
     #[test]
     fn ease_curves_hit_endpoints() {
-        assert!((ease_out_cubic(0.0) - 0.0).abs() < 1e-6);
-        assert!((ease_out_cubic(1.0) - 1.0).abs() < 1e-6);
         assert!((ease_in_cubic(0.0) - 0.0).abs() < 1e-6);
         assert!((ease_in_cubic(1.0) - 1.0).abs() < 1e-6);
+        assert!((ease_out_back(0.0, 0.4) - 0.0).abs() < 1e-6);
+        assert!((ease_out_back(1.0, 0.4) - 1.0).abs() < 1e-6);
+        // The "back" curve is supposed to peak above 1 in the middle.
+        assert!(ease_out_back(0.85, 0.4) > 1.0);
     }
 
     #[test]

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -53,10 +53,10 @@ use crate::{OverlayConfig, State};
 
 const BOTTOM_MARGIN: i32 = 16;
 
-// Per-frame sleep matching the draw loop. ~24 ms ≈ 41 fps. Spawn animation
-// progress is wall-clock-driven (see `Overlay::spawn_t`), so this only
-// caps the redraw rate.
-const FRAME_MS: f32 = 24.0;
+// Per-frame sleep matching the draw loop. ~16 ms ≈ 60 fps for visibly
+// smoother motion. Spawn animation progress is wall-clock-driven (see
+// `Overlay::spawn_t`), so this only caps the redraw rate.
+const FRAME_MS: f32 = 16.0;
 
 // Spawn animation: the pill "draws out" from a 4-px sliver anchored at the
 // bottom of the surface up to its full configured height. Slight overshoot
@@ -76,15 +76,16 @@ const SPAWN_OVERSHOOT_C: f32 = 0.4;
 const BARS_GRACE_MS: f32 = 80.0;
 const BARS_FADE_MS: f32 = 80.0;
 
-// Bar layout. 5 bars × 4 px + 4 gaps × 3 px = 32 px wide, centered in the
-// pill. Max bar height = HEIGHT − 2·BAR_VPAD (e.g. 28 px on the default
-// 40 px pill). Bar height is purely level-driven — no per-bar phase
-// animation — so each bar stays anchored at the pill center and expands
-// symmetrically up and down with the audio amplitude, instead of
-// translating around frame-to-frame.
-const BAR_COUNT: u32 = 5;
-const BAR_W: f32 = 4.0;
-const BAR_GAP: f32 = 3.0;
+// Bar layout. 7 bars × 3 px + 6 gaps × 2 px = 33 px wide, centered in
+// the pill. More, thinner bars means motion reads as a continuous
+// equalizer ripple instead of a few chunky blocks. Max bar height =
+// HEIGHT − 2·BAR_VPAD (e.g. 28 px on the default 40 px pill). Bar height
+// is purely level-driven — no per-bar phase animation — so each bar
+// stays anchored at the pill center and expands symmetrically up and
+// down with the audio amplitude.
+const BAR_COUNT: u32 = 7;
+const BAR_W: f32 = 3.0;
+const BAR_GAP: f32 = 2.0;
 const BAR_PITCH: f32 = BAR_W + BAR_GAP;
 const BAR_BLOCK_W: f32 = BAR_COUNT as f32 * BAR_W + (BAR_COUNT - 1) as f32 * BAR_GAP;
 const BAR_BASELINE: f32 = 6.0;
@@ -378,6 +379,9 @@ fn run_overlay(
         spawn_in: false,
         frame: 0,
         level: 0.0,
+        level_target: 0.0,
+        level_velocity: 0.0,
+        last_update: Instant::now(),
         theme,
     };
 
@@ -416,7 +420,14 @@ struct Overlay {
     /// transitioning out. Determines easing direction and duration.
     spawn_in: bool,
     frame: u32,
+    /// Smoothed audio level driving bar heights. Advanced toward
+    /// `level_target` by a critically-damped spring stepped with the
+    /// real elapsed `dt` between calls — frame-rate-independent.
     level: f32,
+    level_target: f32,
+    level_velocity: f32,
+    /// Wall-clock instant of the previous spring step.
+    last_update: Instant,
     theme: Theme,
 }
 
@@ -462,20 +473,28 @@ impl Overlay {
                 self.spawn_started = Instant::now();
             }
         }
-        // Envelope follower: fast attack (track peaks instantly) + slow
-        // release (hold the loudness so the bars stay tall during speech
-        // instead of bouncing with every audio buffer's RMS variation).
-        // Without this the bars track raw RMS, which oscillates between
-        // 30 %–70 % several times per word and reads as "dots bouncing
-        // up and down" rather than "amplitude expanding".
+        // Drain incoming audio levels — keep only the latest as the
+        // spring target. The spring is stepped below using real elapsed
+        // `dt`, so it doesn't matter how many samples we drained.
         while let Ok(new) = self.level_rx.try_recv() {
-            let new = new.clamp(0.0, 1.0);
-            if new > self.level {
-                self.level = new;
-            } else {
-                // ~125 ms release at the typical 100 Hz audio callback rate.
-                self.level = self.level * 0.92 + new * 0.08;
-            }
+            self.level_target = new.clamp(0.0, 1.0);
+        }
+
+        // Critically-damped-ish spring on the displayed level. Stepped
+        // with wall-clock dt so the time constants are real-world ms,
+        // not "per dispatch tick". `STIFFNESS` and `DAMPING` are tuned
+        // to settle in ~150–200 ms with no perceptible overshoot — feels
+        // like the bars *track* the voice rather than chase it.
+        const STIFFNESS: f32 = 360.0;
+        const DAMPING: f32 = 32.0;
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_update).as_secs_f32().min(0.1);
+        self.last_update = now;
+        if dt > 0.0 {
+            let force = (self.level_target - self.level) * STIFFNESS;
+            let drag = self.level_velocity * DAMPING;
+            self.level_velocity += (force - drag) * dt;
+            self.level = (self.level + self.level_velocity * dt).clamp(0.0, 1.0);
         }
 
         // Once the despawn finishes, snap the renderer to Idle so the next

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -1,0 +1,705 @@
+//! Wayland layer-shell overlay shown while recording or transcribing.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use smithay_client_toolkit::{
+    compositor::{CompositorHandler, CompositorState},
+    delegate_compositor, delegate_layer, delegate_output, delegate_registry, delegate_shm,
+    output::{OutputHandler, OutputState},
+    registry::{ProvidesRegistryState, RegistryState},
+    registry_handlers,
+    shell::{
+        wlr_layer::{
+            Anchor, KeyboardInteractivity, Layer, LayerShell, LayerShellHandler, LayerSurface,
+            LayerSurfaceConfigure,
+        },
+        WaylandSurface,
+    },
+    shm::{slot::SlotPool, Shm, ShmHandler},
+};
+use tokio::sync::watch;
+use tracing::{info, warn};
+use wayland_client::{
+    globals::registry_queue_init,
+    protocol::{wl_output, wl_region, wl_shm, wl_surface},
+    Connection, Dispatch, QueueHandle,
+};
+
+use crate::State;
+
+const WIDTH: u32 = 420;
+const HEIGHT: u32 = 96;
+const BOTTOM_MARGIN: i32 = 34;
+
+/// Spawn the bottom recording overlay.
+///
+/// The Wayland event loop runs on a dedicated OS thread because it is a
+/// blocking client loop. A small Tokio task forwards daemon state changes into
+/// that thread.
+pub async fn spawn_overlay(mut state_rx: watch::Receiver<State>, mut level_rx: watch::Receiver<f32>) {
+    let gnome_state_rx = state_rx.clone();
+    let gnome_level_rx = level_rx.clone();
+    tokio::spawn(async move {
+        if let Err(e) = run_gnome_broadcaster(gnome_state_rx, gnome_level_rx).await {
+            warn!("GNOME overlay D-Bus broadcaster unavailable: {e:#}");
+        }
+    });
+
+    let (tx, rx) = mpsc::channel::<State>();
+    let (level_tx, level_rx_thread) = mpsc::channel::<f32>();
+
+    std::thread::Builder::new()
+        .name("whisrs-overlay".to_string())
+        .spawn(move || {
+            if let Err(e) = run_overlay(rx, level_rx_thread) {
+                warn!("overlay unavailable: {e:#}");
+            }
+        })
+        .map_err(|e| warn!("failed to spawn overlay thread: {e}"))
+        .ok();
+
+    tokio::spawn(async move {
+        let _ = tx.send(*state_rx.borrow());
+        let _ = level_tx.send(*level_rx.borrow());
+        loop {
+            tokio::select! {
+                changed = state_rx.changed() => {
+                    if changed.is_err() { break; }
+                    if tx.send(*state_rx.borrow()).is_err() { break; }
+                }
+                changed = level_rx.changed() => {
+                    if changed.is_err() { break; }
+                    let _ = level_tx.send(*level_rx.borrow());
+                }
+            }
+        }
+    });
+}
+
+async fn run_gnome_broadcaster(
+    mut state_rx: watch::Receiver<State>,
+    level_rx: watch::Receiver<f32>,
+) -> anyhow::Result<()> {
+    let conn = zbus::connection::Builder::session()?
+        .serve_at("/org/whisrs/Overlay", GnomeOverlayBus)?
+        .name("org.whisrs.Overlay")?
+        .build()
+        .await?;
+
+    info!("GNOME overlay D-Bus broadcaster started");
+    let initial_state = *state_rx.borrow();
+    emit_gnome_state(&conn, initial_state).await?;
+    let initial_level = *level_rx.borrow();
+    emit_gnome_level(&conn, initial_level).await?;
+
+    // Emit level at a steady ~30 Hz so the GNOME extension always has fresh
+    // data, regardless of how the watch channel coalesces updates.
+    let mut level_interval = tokio::time::interval(Duration::from_millis(33));
+    level_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            changed = state_rx.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                let state = *state_rx.borrow();
+                emit_gnome_state(&conn, state).await?;
+            }
+            _ = level_interval.tick() => {
+                let level = *level_rx.borrow();
+                emit_gnome_level(&conn, level).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn emit_gnome_state(conn: &zbus::Connection, state: State) -> zbus::Result<()> {
+    conn.emit_signal(
+        None::<&str>,
+        "/org/whisrs/Overlay",
+        "org.whisrs.Overlay",
+        "StateChanged",
+        &(state.to_string()),
+    )
+    .await
+}
+
+async fn emit_gnome_level(conn: &zbus::Connection, level: f32) -> zbus::Result<()> {
+    conn.emit_signal(
+        None::<&str>,
+        "/org/whisrs/Overlay",
+        "org.whisrs.Overlay",
+        "LevelChanged",
+        &level.clamp(0.0, 1.0),
+    )
+    .await
+}
+
+struct GnomeOverlayBus;
+
+#[zbus::interface(name = "org.whisrs.Overlay")]
+impl GnomeOverlayBus {
+    fn ping(&self) -> &'static str {
+        "ok"
+    }
+}
+
+fn run_overlay(state_rx: mpsc::Receiver<State>, level_rx: mpsc::Receiver<f32>) -> anyhow::Result<()> {
+    let conn = Connection::connect_to_env()?;
+    let (globals, mut event_queue) = registry_queue_init(&conn)?;
+    let qh = event_queue.handle();
+
+    let compositor = CompositorState::bind(&globals, &qh)?;
+    let layer_shell = LayerShell::bind(&globals, &qh)?;
+    let shm = Shm::bind(&globals, &qh)?;
+
+    let surface = compositor.create_surface(&qh);
+    let layer =
+        layer_shell.create_layer_surface(&qh, surface, Layer::Overlay, Some("whisrs"), None);
+    layer.set_anchor(Anchor::BOTTOM);
+    layer.set_margin(0, 0, BOTTOM_MARGIN, 0);
+    layer.set_exclusive_zone(0);
+    layer.set_keyboard_interactivity(KeyboardInteractivity::None);
+    layer.set_size(WIDTH, HEIGHT);
+
+    // Make the transparent overlay non-interactive so it never blocks clicks.
+    let input_region = compositor.wl_compositor().create_region(&qh, ());
+    layer.set_input_region(Some(&input_region));
+    input_region.destroy();
+
+    layer.commit();
+
+    let pool = SlotPool::new((WIDTH * HEIGHT * 4) as usize, &shm)?;
+    let mut overlay = Overlay {
+        registry_state: RegistryState::new(&globals),
+        output_state: OutputState::new(&globals, &qh),
+        shm,
+        pool,
+        layer,
+        state_rx,
+        level_rx,
+        exit: false,
+        first_configure: true,
+        width: WIDTH,
+        height: HEIGHT,
+        state: State::Idle,
+        frame: 0,
+        level: 0.0,
+    };
+
+    info!("recording overlay started");
+    while !overlay.exit {
+        overlay.apply_state_updates();
+        event_queue.blocking_dispatch(&mut overlay)?;
+    }
+
+    Ok(())
+}
+
+struct Overlay {
+    registry_state: RegistryState,
+    output_state: OutputState,
+    shm: Shm,
+    pool: SlotPool,
+    layer: LayerSurface,
+    state_rx: mpsc::Receiver<State>,
+    level_rx: mpsc::Receiver<f32>,
+    exit: bool,
+    first_configure: bool,
+    width: u32,
+    height: u32,
+    state: State,
+    frame: u32,
+    level: f32,
+}
+
+impl Overlay {
+    fn apply_state_updates(&mut self) {
+        while let Ok(state) = self.state_rx.try_recv() {
+            self.state = state;
+        }
+        while let Ok(level) = self.level_rx.try_recv() {
+            // Decay toward new value; take max to preserve peaks within a frame
+            self.level = level.clamp(0.0, 1.0);
+        }
+        // Decay level each frame so silence brings bars down
+        self.level = (self.level * 0.88).max(0.0);
+    }
+
+    fn draw(&mut self, qh: &QueueHandle<Self>) {
+        self.apply_state_updates();
+
+        let width = self.width;
+        let height = self.height;
+        let stride = width as i32 * 4;
+
+        let Ok((buffer, canvas)) = self.pool.create_buffer(
+            width as i32,
+            height as i32,
+            stride,
+            wl_shm::Format::Argb8888,
+        ) else {
+            warn!("failed to allocate overlay buffer");
+            return;
+        };
+
+        draw_overlay(canvas, width, height, self.state, self.frame, self.level);
+        self.frame = self.frame.wrapping_add(1);
+
+        self.layer
+            .wl_surface()
+            .damage_buffer(0, 0, width as i32, height as i32);
+        self.layer
+            .wl_surface()
+            .frame(qh, self.layer.wl_surface().clone());
+        if let Err(e) = buffer.attach_to(self.layer.wl_surface()) {
+            warn!("failed to attach overlay buffer: {e}");
+            return;
+        }
+        self.layer.commit();
+
+        std::thread::sleep(Duration::from_millis(24));
+    }
+}
+
+impl CompositorHandler for Overlay {
+    fn scale_factor_changed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _new_factor: i32,
+    ) {
+    }
+
+    fn transform_changed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _new_transform: wl_output::Transform,
+    ) {
+    }
+
+    fn frame(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _time: u32,
+    ) {
+        self.draw(qh);
+    }
+
+    fn surface_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+    }
+
+    fn surface_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _surface: &wl_surface::WlSurface,
+        _output: &wl_output::WlOutput,
+    ) {
+    }
+}
+
+impl OutputHandler for Overlay {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+
+    fn new_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn update_output(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+
+    fn output_destroyed(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _output: wl_output::WlOutput,
+    ) {
+    }
+}
+
+impl LayerShellHandler for Overlay {
+    fn closed(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _layer: &LayerSurface) {
+        self.exit = true;
+    }
+
+    fn configure(
+        &mut self,
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+        _layer: &LayerSurface,
+        configure: LayerSurfaceConfigure,
+        _serial: u32,
+    ) {
+        self.width = configure.new_size.0.max(WIDTH);
+        self.height = configure.new_size.1.max(HEIGHT);
+
+        if self.first_configure {
+            self.first_configure = false;
+            self.draw(qh);
+        }
+    }
+}
+
+impl ShmHandler for Overlay {
+    fn shm_state(&mut self) -> &mut Shm {
+        &mut self.shm
+    }
+}
+
+impl Dispatch<wl_region::WlRegion, ()> for Overlay {
+    fn event(
+        _state: &mut Self,
+        _proxy: &wl_region::WlRegion,
+        _event: wl_region::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+delegate_compositor!(Overlay);
+delegate_output!(Overlay);
+delegate_shm!(Overlay);
+delegate_layer!(Overlay);
+delegate_registry!(Overlay);
+
+impl ProvidesRegistryState for Overlay {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+
+    registry_handlers![OutputState];
+}
+
+fn draw_overlay(canvas: &mut [u8], width: u32, height: u32, state: State, frame: u32, level: f32) {
+    clear(canvas);
+
+    if state == State::Idle {
+        return;
+    }
+
+    let bg = [232, 18, 22, 28];
+    let border = [105, 255, 255, 255];
+    let accent = match state {
+        State::Recording => [255, 239, 68, 68],
+        State::Transcribing => [255, 245, 158, 11],
+        State::Idle => [0, 0, 0, 0],
+    };
+
+    let x = 8;
+    let y = 8;
+    let w = width.saturating_sub(16);
+    let h = height.saturating_sub(16);
+    rounded_rect(canvas, width, height, x, y, w, h, 18, bg);
+    rounded_stroke(canvas, width, height, x, y, w, h, 18, border);
+
+    draw_status_dot(canvas, width, height, 48, height / 2, accent, frame);
+    draw_wave(canvas, width, height, 92, height / 2, accent, frame, level);
+
+    let label = match state {
+        State::Recording => "RECORDING",
+        State::Transcribing => "TRANSCRIBING",
+        State::Idle => "",
+    };
+    draw_text(
+        canvas,
+        width,
+        height,
+        244,
+        (height / 2).saturating_sub(10),
+        label,
+        [245, 245, 245, 245],
+    );
+}
+
+fn clear(canvas: &mut [u8]) {
+    canvas.fill(0);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn rounded_rect(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    radius: u32,
+    color: [u8; 4],
+) {
+    for py in y..y + h {
+        for px in x..x + w {
+            if inside_rounded_rect(px, py, x, y, w, h, radius) {
+                blend_pixel(canvas, width, height, px, py, color);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn rounded_stroke(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    radius: u32,
+    color: [u8; 4],
+) {
+    for py in y..y + h {
+        for px in x..x + w {
+            if inside_rounded_rect(px, py, x, y, w, h, radius)
+                && !inside_rounded_rect(
+                    px,
+                    py,
+                    x + 1,
+                    y + 1,
+                    w - 2,
+                    h - 2,
+                    radius.saturating_sub(1),
+                )
+            {
+                blend_pixel(canvas, width, height, px, py, color);
+            }
+        }
+    }
+}
+
+fn inside_rounded_rect(px: u32, py: u32, x: u32, y: u32, w: u32, h: u32, radius: u32) -> bool {
+    let right = x + w - 1;
+    let bottom = y + h - 1;
+    let cx = if px < x + radius {
+        x + radius
+    } else if px > right.saturating_sub(radius) {
+        right.saturating_sub(radius)
+    } else {
+        px
+    };
+    let cy = if py < y + radius {
+        y + radius
+    } else if py > bottom.saturating_sub(radius) {
+        bottom.saturating_sub(radius)
+    } else {
+        py
+    };
+    let dx = px as i32 - cx as i32;
+    let dy = py as i32 - cy as i32;
+    dx * dx + dy * dy <= (radius as i32) * (radius as i32)
+}
+
+fn draw_status_dot(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    cx: u32,
+    cy: u32,
+    color: [u8; 4],
+    frame: u32,
+) {
+    let pulse = ((frame / 4) % 18) as i32;
+    circle(
+        canvas,
+        width,
+        height,
+        cx,
+        cy,
+        9 + pulse / 3,
+        [34, color[1], color[2], color[3]],
+    );
+    circle(canvas, width, height, cx, cy, 7, color);
+}
+
+fn draw_wave(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    x: u32,
+    cy: u32,
+    color: [u8; 4],
+    frame: u32,
+    level: f32,
+) {
+    for i in 0..10 {
+        let phase = ((frame + i * 5) % 32) as f32 / 32.0;
+        let animated = (phase * std::f32::consts::TAU).sin().abs();
+        let variance = 0.65 + (i % 3) as f32 * 0.18;
+        let effective = (level * variance).min(1.0);
+        let bar_h = 6 + ((animated * 0.3 + effective * 0.7) * 26.0) as u32;
+        let bx = x + i * 12;
+        rounded_rect(
+            canvas,
+            width,
+            height,
+            bx,
+            cy - bar_h / 2,
+            6,
+            bar_h,
+            3,
+            color,
+        );
+    }
+}
+
+fn circle(canvas: &mut [u8], width: u32, height: u32, cx: u32, cy: u32, r: i32, color: [u8; 4]) {
+    for y in cy.saturating_sub(r as u32)..=(cy + r as u32).min(height.saturating_sub(1)) {
+        for x in cx.saturating_sub(r as u32)..=(cx + r as u32).min(width.saturating_sub(1)) {
+            let dx = x as i32 - cx as i32;
+            let dy = y as i32 - cy as i32;
+            if dx * dx + dy * dy <= r * r {
+                blend_pixel(canvas, width, height, x, y, color);
+            }
+        }
+    }
+}
+
+fn draw_text(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+    text: &str,
+    color: [u8; 4],
+) {
+    let mut cursor = x;
+    for ch in text.chars() {
+        if ch == ' ' {
+            cursor += 8;
+        } else {
+            draw_char(canvas, width, height, cursor, y, ch, color);
+            cursor += 13;
+        }
+    }
+}
+
+fn draw_char(canvas: &mut [u8], width: u32, height: u32, x: u32, y: u32, ch: char, color: [u8; 4]) {
+    let glyph = glyph(ch);
+    for (row, bits) in glyph.iter().enumerate() {
+        for col in 0..5 {
+            if bits & (1 << (4 - col)) != 0 {
+                let px = x + col * 2;
+                let py = y + row as u32 * 2;
+                rect(canvas, width, height, px, py, 2, 2, color);
+            }
+        }
+    }
+}
+
+fn glyph(ch: char) -> [u8; 7] {
+    match ch {
+        'A' => [
+            0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001,
+        ],
+        'B' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10001, 0b10001, 0b11110,
+        ],
+        'C' => [
+            0b01111, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b01111,
+        ],
+        'D' => [
+            0b11110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11110,
+        ],
+        'E' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111,
+        ],
+        'G' => [
+            0b01111, 0b10000, 0b10000, 0b10111, 0b10001, 0b10001, 0b01111,
+        ],
+        'I' => [
+            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b11111,
+        ],
+        'N' => [
+            0b10001, 0b11001, 0b10101, 0b10011, 0b10001, 0b10001, 0b10001,
+        ],
+        'O' => [
+            0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110,
+        ],
+        'R' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001,
+        ],
+        'S' => [
+            0b01111, 0b10000, 0b10000, 0b01110, 0b00001, 0b00001, 0b11110,
+        ],
+        'T' => [
+            0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100,
+        ],
+        _ => [0; 7],
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn rect(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+    color: [u8; 4],
+) {
+    for py in y..(y + h).min(height) {
+        for px in x..(x + w).min(width) {
+            blend_pixel(canvas, width, height, px, py, color);
+        }
+    }
+}
+
+fn blend_pixel(canvas: &mut [u8], width: u32, height: u32, x: u32, y: u32, color: [u8; 4]) {
+    if x >= width || y >= height {
+        return;
+    }
+
+    let index = ((y * width + x) * 4) as usize;
+    canvas[index..index + 4].copy_from_slice(&u32::from_be_bytes(color).to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_draw_is_transparent() {
+        let mut canvas = vec![1; (WIDTH * HEIGHT * 4) as usize];
+        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Idle, 0, 0.0);
+        assert!(canvas.iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn active_draw_has_visible_pixels() {
+        let mut canvas = vec![0; (WIDTH * HEIGHT * 4) as usize];
+        draw_overlay(&mut canvas, WIDTH, HEIGHT, State::Recording, 0, 1.0);
+        assert!(canvas.chunks_exact(4).any(|px| px[3] != 0));
+    }
+}

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -19,6 +19,8 @@ enum OverlayError {
     DBus(#[from] zbus::Error),
     #[error("D-Bus signal error: {0}")]
     DBusSignal(#[from] zbus::fdo::Error),
+    #[error("tiny-skia pixmap allocation failed for {0}x{1}")]
+    Pixmap(u32, u32),
 }
 
 use smithay_client_toolkit::{
@@ -36,6 +38,9 @@ use smithay_client_toolkit::{
     },
     shm::{slot::SlotPool, Shm, ShmHandler},
 };
+use tiny_skia::{
+    Color, FillRule, Paint, PathBuilder, Pixmap, PremultipliedColorU8, Rect, Stroke, Transform,
+};
 use tokio::sync::watch;
 use tracing::{info, warn};
 use wayland_client::{
@@ -47,16 +52,33 @@ use wayland_client::{
 use crate::{OverlayConfig, State};
 
 const BOTTOM_MARGIN: i32 = 16;
-const FADE_STEP: f32 = 0.55;
 
-// Bar layout — fixed for visual consistency. 18 bars × 2 px + 17 gaps × 2 px
-// = 70 px wide, centered in the pill (15 px side margin at default 100 px).
-const BAR_COUNT: u32 = 18;
-const BAR_W: u32 = 2;
-const BAR_GAP: u32 = 2;
-const BAR_PITCH: u32 = BAR_W + BAR_GAP;
-const BAR_BLOCK_W: u32 = BAR_COUNT * BAR_W + (BAR_COUNT - 1) * BAR_GAP;
-const BAR_BASELINE: i32 = 2;
+// Per-frame sleep matching the draw loop. ~24 ms ≈ 41 fps. The spawn
+// animation timings below are expressed in milliseconds and converted to
+// per-frame steps using this constant.
+const FRAME_MS: f32 = 24.0;
+
+// Spawn animation durations (ms). Slightly faster going away than coming in
+// — the asymmetry reads as "intentional dismiss" rather than a glitch.
+const SPAWN_IN_MS: f32 = 180.0;
+const SPAWN_OUT_MS: f32 = 140.0;
+
+// On appear, hold the bars at their baseline for this many milliseconds so
+// the audio reactivity doesn't fire while the pill is still flying in.
+const BARS_GRACE_MS: f32 = 80.0;
+
+// Slide-up offset (px) and scale start used by the spawn animation.
+const SPAWN_SLIDE_PX: f32 = 8.0;
+const SPAWN_SCALE_FROM: f32 = 0.92;
+
+// Bar layout — fixed for visual consistency.
+// 5 bars × 6 px + 4 gaps × 4 px = 46 px wide, centered in the pill.
+const BAR_COUNT: u32 = 5;
+const BAR_W: f32 = 6.0;
+const BAR_GAP: f32 = 4.0;
+const BAR_PITCH: f32 = BAR_W + BAR_GAP;
+const BAR_BLOCK_W: f32 = BAR_COUNT as f32 * BAR_W + (BAR_COUNT - 1) as f32 * BAR_GAP;
+const BAR_BASELINE: f32 = 3.0;
 
 /// Color palette for one overlay theme. Bytes are stored as `[A, R, G, B]`,
 /// matching the canvas pixel layout used by [`blend_pixel`].
@@ -326,11 +348,13 @@ fn run_overlay(
     layer.commit();
 
     let pool = SlotPool::new((width * height * 4) as usize, &shm)?;
+    let pixmap = Pixmap::new(width, height).ok_or(OverlayError::Pixmap(width, height))?;
     let mut overlay = Overlay {
         registry_state: RegistryState::new(&globals),
         output_state: OutputState::new(&globals, &qh),
         shm,
         pool,
+        pixmap,
         layer,
         state_rx,
         level_rx,
@@ -340,7 +364,9 @@ fn run_overlay(
         height,
         target_state: State::Idle,
         visible_state: State::Idle,
-        alpha: 0.0,
+        spawn_t: 0.0,
+        spawn_in: false,
+        bars_grace_ms: 0.0,
         frame: 0,
         level: 0.0,
         theme,
@@ -360,6 +386,7 @@ struct Overlay {
     output_state: OutputState,
     shm: Shm,
     pool: SlotPool,
+    pixmap: Pixmap,
     layer: LayerSurface,
     state_rx: mpsc::Receiver<State>,
     level_rx: mpsc::Receiver<f32>,
@@ -369,18 +396,52 @@ struct Overlay {
     height: u32,
     target_state: State,
     visible_state: State,
-    alpha: f32,
+    /// Progress through the current spawn animation, 0..=1. Hits 1 when the
+    /// animation finishes; reset to 0 each time `target_state` flips between
+    /// idle and active.
+    spawn_t: f32,
+    /// `true` while transitioning into a visible state, `false` while
+    /// transitioning out. Determines easing direction and duration.
+    spawn_in: bool,
+    /// Remaining grace period (ms) before bars unlock from baseline. Set
+    /// when the pill is appearing so audio reactivity doesn't fire while
+    /// the pill is still flying in.
+    bars_grace_ms: f32,
     frame: u32,
     level: f32,
     theme: Theme,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct AnimState {
+    /// 0..=1
+    alpha: f32,
+    /// Vertical offset in px. Positive = drawn lower than rest position.
+    slide_y: f32,
+    /// Linear scale factor centered on the pill.
+    scale: f32,
+}
+
 impl Overlay {
     fn apply_state_updates(&mut self) {
         while let Ok(state) = self.state_rx.try_recv() {
+            let was_idle = self.target_state == State::Idle;
+            let now_idle = state == State::Idle;
             self.target_state = state;
-            if state != State::Idle {
+
+            if !now_idle {
                 self.visible_state = state;
+            }
+
+            // Trigger spawn / despawn only on the boundary between idle and
+            // visible. Recording ↔ Transcribing keeps the pill steady.
+            if was_idle && !now_idle {
+                self.spawn_in = true;
+                self.spawn_t = 0.0;
+                self.bars_grace_ms = BARS_GRACE_MS;
+            } else if !was_idle && now_idle {
+                self.spawn_in = false;
+                self.spawn_t = 0.0;
             }
         }
         while let Ok(level) = self.level_rx.try_recv() {
@@ -388,19 +449,47 @@ impl Overlay {
         }
         self.level = (self.level * 0.85).max(0.0);
 
-        let target_alpha = if self.target_state == State::Idle {
-            0.0
+        // Advance the spawn animation. `spawn_t` saturates at 1.0; at that
+        // point the pill is fully shown (`spawn_in = true`) or fully hidden
+        // (`spawn_in = false`).
+        let duration = if self.spawn_in {
+            SPAWN_IN_MS
         } else {
-            1.0
+            SPAWN_OUT_MS
         };
-        let diff = target_alpha - self.alpha;
-        if diff.abs() <= FADE_STEP {
-            self.alpha = target_alpha;
-        } else {
-            self.alpha += diff.signum() * FADE_STEP;
+        if self.spawn_t < 1.0 {
+            self.spawn_t = (self.spawn_t + FRAME_MS / duration).min(1.0);
         }
-        if self.alpha == 0.0 {
+
+        if !self.spawn_in && self.spawn_t >= 1.0 {
             self.visible_state = State::Idle;
+        }
+
+        if self.bars_grace_ms > 0.0 {
+            self.bars_grace_ms = (self.bars_grace_ms - FRAME_MS).max(0.0);
+        }
+    }
+
+    /// Compute the current animated transform: alpha for the cross-fade,
+    /// slide_y in px, and the centered scale factor. Uses `ease_out_cubic`
+    /// for the appear path so the pill decelerates into place, and
+    /// `ease_in_cubic` on the way out for a faster, more committed dismiss.
+    fn anim(&self) -> AnimState {
+        let t = self.spawn_t.clamp(0.0, 1.0);
+        if self.spawn_in {
+            let e = ease_out_cubic(t);
+            AnimState {
+                alpha: e,
+                slide_y: (1.0 - e) * SPAWN_SLIDE_PX,
+                scale: SPAWN_SCALE_FROM + e * (1.0 - SPAWN_SCALE_FROM),
+            }
+        } else {
+            let e = ease_in_cubic(t);
+            AnimState {
+                alpha: 1.0 - e,
+                slide_y: e * SPAWN_SLIDE_PX,
+                scale: 1.0 - e * 0.04,
+            }
         }
     }
 
@@ -411,6 +500,27 @@ impl Overlay {
         let height = self.height;
         let stride = width as i32 * 4;
 
+        // Render into our owned pixmap first so the buffer borrow on the
+        // shm pool doesn't conflict with the pixmap borrow.
+        let anim = self.anim();
+        // Audio reactivity is gated for the first few frames after
+        // appearing, so the bars don't react to speech while the pill is
+        // still flying in.
+        let level_gated = if self.bars_grace_ms > 0.0 {
+            0.0
+        } else {
+            self.level
+        };
+        draw_overlay(
+            &mut self.pixmap,
+            self.visible_state,
+            self.frame,
+            level_gated,
+            anim,
+            &self.theme,
+        );
+        self.frame = self.frame.wrapping_add(1);
+
         let Ok((buffer, canvas)) = self.pool.create_buffer(
             width as i32,
             height as i32,
@@ -420,18 +530,7 @@ impl Overlay {
             warn!("failed to allocate overlay buffer");
             return;
         };
-
-        draw_overlay(
-            canvas,
-            width,
-            height,
-            self.visible_state,
-            self.frame,
-            self.level,
-            self.alpha,
-            &self.theme,
-        );
-        self.frame = self.frame.wrapping_add(1);
+        copy_pixmap_to_argb8888(&self.pixmap, canvas);
 
         self.layer
             .wl_surface()
@@ -445,7 +544,32 @@ impl Overlay {
         }
         self.layer.commit();
 
-        std::thread::sleep(Duration::from_millis(24));
+        std::thread::sleep(Duration::from_millis(FRAME_MS as u64));
+    }
+}
+
+fn ease_out_cubic(t: f32) -> f32 {
+    let inv = 1.0 - t;
+    1.0 - inv * inv * inv
+}
+
+fn ease_in_cubic(t: f32) -> f32 {
+    t * t * t
+}
+
+/// tiny-skia stores premultiplied RGBA bytes; the wl_shm Argb8888 format on
+/// little-endian systems is BGRA in memory. Convert by swapping R and B.
+/// Both formats use premultiplied alpha so no math is needed beyond the swap.
+fn copy_pixmap_to_argb8888(pixmap: &Pixmap, canvas: &mut [u8]) {
+    let src = pixmap.pixels();
+    debug_assert_eq!(src.len() * 4, canvas.len());
+    for (i, px) in src.iter().enumerate() {
+        let dst = &mut canvas[i * 4..i * 4 + 4];
+        let pre: PremultipliedColorU8 = *px;
+        dst[0] = pre.blue();
+        dst[1] = pre.green();
+        dst[2] = pre.red();
+        dst[3] = pre.alpha();
     }
 }
 
@@ -582,62 +706,106 @@ impl ProvidesRegistryState for Overlay {
     registry_handlers![OutputState];
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Render one frame of the overlay into `pixmap` using tiny-skia. The pixmap
+/// is the same size as the surface; coordinates are in pixels.
+///
+/// The animation transform (`anim`) controls a slide-up + scale + fade
+/// applied uniformly to the pill — implemented as a tiny-skia `Transform`
+/// so anti-aliasing handles the sub-pixel motion without us having to round.
 fn draw_overlay(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
+    pixmap: &mut Pixmap,
     state: State,
     frame: u32,
     level: f32,
-    alpha: f32,
+    anim: AnimState,
     theme: &Theme,
 ) {
-    clear(canvas);
+    pixmap.fill(Color::TRANSPARENT);
 
-    if alpha <= 0.0 || state == State::Idle {
+    if anim.alpha <= 0.0 || state == State::Idle {
         return;
     }
 
-    let bg = scale_alpha(theme.bg, alpha);
-    let ring = scale_alpha(theme.ring, alpha);
+    let width = pixmap.width() as f32;
+    let height = pixmap.height() as f32;
+
+    // Translate-then-scale around the pill center so the spawn animation
+    // expands from the center, then translate again to apply the slide-up.
+    let cx = width / 2.0;
+    let cy = height / 2.0;
+    let transform = Transform::from_translate(cx, cy)
+        .pre_scale(anim.scale, anim.scale)
+        .post_translate(-cx, -cy)
+        .post_translate(0.0, anim.slide_y);
 
     // Pill background.
-    let radius = height / 2;
-    rounded_rect(canvas, width, height, 0, 0, width, height, radius, bg);
-    // 1 px inner ring: paint a slightly inset rect in the ring color, then
-    // re-paint the further-inset interior with the bg color. The result is a
-    // thin colored band hugging the pill edge.
-    if width > 4 && height > 4 {
-        rounded_rect(
-            canvas,
-            width,
-            height,
-            1,
-            1,
-            width - 2,
-            height - 2,
-            radius.saturating_sub(1).max(1),
-            ring,
-        );
-        rounded_rect(
-            canvas,
-            width,
-            height,
-            2,
-            2,
-            width - 4,
-            height - 4,
-            radius.saturating_sub(2).max(1),
-            bg,
-        );
+    let radius = height / 2.0;
+    let pill_path = build_round_rect(0.0, 0.0, width, height, radius);
+    let mut paint = Paint {
+        anti_alias: true,
+        ..Default::default()
+    };
+    paint.set_color(theme_color(theme.bg, anim.alpha));
+    if let Some(path) = &pill_path {
+        pixmap.fill_path(path, &paint, FillRule::Winding, transform, None);
+    }
+
+    // Hairline ring — drawn as a 1 px stroked pill.
+    let stroke = Stroke {
+        width: 1.0,
+        ..Default::default()
+    };
+    paint.set_color(theme_color(theme.ring, anim.alpha));
+    if let Some(path) = &pill_path {
+        pixmap.stroke_path(path, &paint, &stroke, transform, None);
     }
 
     match state {
-        State::Recording => draw_bars(canvas, width, height, theme, frame, level, alpha),
-        State::Transcribing => draw_sweep(canvas, width, height, theme, frame, alpha),
+        State::Recording => draw_bars(pixmap, theme, frame, level, anim, transform),
+        State::Transcribing => draw_sweep(pixmap, theme, frame, anim, transform),
         State::Idle => {}
     }
+}
+
+/// Build a centered rounded-rect path. tiny-skia doesn't ship a rounded-rect
+/// helper, so we approximate the corner arcs with cubic Bezier curves using
+/// the standard 0.5523 control-point offset.
+fn build_round_rect(x: f32, y: f32, w: f32, h: f32, r: f32) -> Option<tiny_skia::Path> {
+    if w <= 0.0 || h <= 0.0 {
+        return None;
+    }
+    let r = r.min(w / 2.0).min(h / 2.0).max(0.0);
+    if r <= 0.0 {
+        return PathBuilder::from_rect(Rect::from_xywh(x, y, w, h)?).into();
+    }
+    // Standard "kappa" cubic-bezier circle approximation: 4·(√2 − 1)/3.
+    let k = 0.552_284_8_f32 * r;
+
+    let mut pb = PathBuilder::new();
+    pb.move_to(x + r, y);
+    pb.line_to(x + w - r, y);
+    pb.cubic_to(x + w - r + k, y, x + w, y + r - k, x + w, y + r);
+    pb.line_to(x + w, y + h - r);
+    pb.cubic_to(x + w, y + h - r + k, x + w - r + k, y + h, x + w - r, y + h);
+    pb.line_to(x + r, y + h);
+    pb.cubic_to(x + r - k, y + h, x, y + h - r + k, x, y + h - r);
+    pb.line_to(x, y + r);
+    pb.cubic_to(x, y + r - k, x + r - k, y, x + r, y);
+    pb.close();
+    pb.finish()
+}
+
+/// Convert a `[A, R, G, B]` byte array to a tiny-skia non-premultiplied
+/// `Color`, with the alpha channel further scaled by `extra_alpha`.
+fn theme_color(bytes: [u8; 4], extra_alpha: f32) -> Color {
+    let a = (bytes[0] as f32 / 255.0 * extra_alpha.clamp(0.0, 1.0)).clamp(0.0, 1.0);
+    Color::from_rgba(
+        bytes[1] as f32 / 255.0,
+        bytes[2] as f32 / 255.0,
+        bytes[3] as f32 / 255.0,
+        a,
+    )
+    .unwrap_or(Color::TRANSPARENT)
 }
 
 /// Gaussian taper across the bar row — center bars draw at ~100 % of their
@@ -652,76 +820,25 @@ fn taper_factor(i: u32, count: u32) -> f32 {
     (-d * d).exp() // exp(-1) ≈ 0.367 at edges
 }
 
-fn clear(canvas: &mut [u8]) {
-    canvas.fill(0);
-}
-
-#[allow(clippy::too_many_arguments)]
-fn rounded_rect(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
-    x: u32,
-    y: u32,
-    w: u32,
-    h: u32,
-    radius: u32,
-    color: [u8; 4],
-) {
-    for py in y..y + h {
-        for px in x..x + w {
-            if inside_rounded_rect(px, py, x, y, w, h, radius) {
-                blend_pixel(canvas, width, height, px, py, color);
-            }
-        }
-    }
-}
-
-fn inside_rounded_rect(px: u32, py: u32, x: u32, y: u32, w: u32, h: u32, radius: u32) -> bool {
-    let right = x + w - 1;
-    let bottom = y + h - 1;
-    let cx = if px < x + radius {
-        x + radius
-    } else if px > right.saturating_sub(radius) {
-        right.saturating_sub(radius)
-    } else {
-        px
-    };
-    let cy = if py < y + radius {
-        y + radius
-    } else if py > bottom.saturating_sub(radius) {
-        bottom.saturating_sub(radius)
-    } else {
-        py
-    };
-    let dx = px as i32 - cx as i32;
-    let dy = py as i32 - cy as i32;
-    dx * dx + dy * dy <= (radius as i32) * (radius as i32)
-}
-
-fn scale_alpha(color: [u8; 4], alpha: f32) -> [u8; 4] {
-    let a = (color[0] as f32 * alpha.clamp(0.0, 1.0)).round() as u8;
-    [a, color[1], color[2], color[3]]
-}
-
 /// Vertical padding inside the pill (top + bottom). Bars never reach the
 /// pill edge.
-const BAR_VPAD: i32 = 5;
+const BAR_VPAD: f32 = 5.0;
 
-/// Recording bars: react to audio level, gaussian taper across the row, soft
-/// glow halo behind each bar at higher amplitudes.
+/// Recording bars: react to audio level, gaussian taper across the row,
+/// soft glow halo behind each bar at higher amplitudes.
 fn draw_bars(
-    canvas: &mut [u8],
-    width: u32,
-    height: u32,
+    pixmap: &mut Pixmap,
     theme: &Theme,
     frame: u32,
     level: f32,
-    alpha: f32,
+    anim: AnimState,
+    transform: Transform,
 ) {
-    let cy = (height / 2) as i32;
-    let max_h = (height as i32 - BAR_VPAD * 2).max(BAR_BASELINE + 2);
-    let bar_x_start = (width.saturating_sub(BAR_BLOCK_W)) / 2;
+    let width = pixmap.width() as f32;
+    let height = pixmap.height() as f32;
+    let cy = height / 2.0;
+    let max_h = (height - BAR_VPAD * 2.0).max(BAR_BASELINE + 2.0);
+    let bar_x_start = (width - BAR_BLOCK_W) / 2.0;
 
     for i in 0..BAR_COUNT {
         let taper = taper_factor(i, BAR_COUNT);
@@ -729,55 +846,61 @@ fn draw_bars(
         let phase = ((frame as f32 / 5.0) + i as f32 * 0.7).sin().abs();
         let effective = (level * taper).clamp(0.0, 1.0);
         let dynamic = effective * (0.7 + 0.3 * phase);
-        let h = (BAR_BASELINE as f32 + dynamic * (max_h - BAR_BASELINE) as f32)
-            .round()
-            .max(BAR_BASELINE as f32) as i32;
-        let bx = bar_x_start + i * BAR_PITCH;
-        let by = (cy - h / 2).max(0) as u32;
+        let h = (BAR_BASELINE + dynamic * (max_h - BAR_BASELINE)).max(BAR_BASELINE);
+        let bx = bar_x_start + i as f32 * BAR_PITCH;
+        let by = cy - h / 2.0;
 
         // Glow halo behind the bar — only visible above a small threshold.
         if effective > 0.02 {
             let glow_intensity = (effective * 0.9 + 0.1).clamp(0.0, 1.0);
-            let glow_a = (theme.glow[0] as f32 * glow_intensity * alpha).round() as u8;
-            let glow_color = [glow_a, theme.glow[1], theme.glow[2], theme.glow[3]];
-            let glow_w = BAR_W + 2;
-            let glow_h = (h + 2).max(BAR_BASELINE + 2) as u32;
-            let glow_x = bx.saturating_sub(1);
-            let glow_y = ((cy - glow_h as i32 / 2).max(0)) as u32;
-            rounded_rect(
-                canvas,
-                width,
-                height,
-                glow_x,
-                glow_y,
-                glow_w,
-                glow_h,
-                glow_w / 2,
-                glow_color,
-            );
+            let glow_a = theme.glow[0] as f32 / 255.0 * glow_intensity * anim.alpha;
+            let glow_color = Color::from_rgba(
+                theme.glow[1] as f32 / 255.0,
+                theme.glow[2] as f32 / 255.0,
+                theme.glow[3] as f32 / 255.0,
+                glow_a.clamp(0.0, 1.0),
+            )
+            .unwrap_or(Color::TRANSPARENT);
+            let glow_w = BAR_W + 2.0;
+            let glow_h = (h + 2.0).max(BAR_BASELINE + 2.0);
+            if let Some(path) =
+                build_round_rect(bx - 1.0, cy - glow_h / 2.0, glow_w, glow_h, glow_w / 2.0)
+            {
+                let mut paint = Paint {
+                    anti_alias: true,
+                    ..Default::default()
+                };
+                paint.set_color(glow_color);
+                pixmap.fill_path(&path, &paint, FillRule::Winding, transform, None);
+            }
         }
 
-        let bar_color = scale_alpha(theme.rec_bar, alpha);
-        rounded_rect(
-            canvas,
-            width,
-            height,
-            bx,
-            by,
-            BAR_W,
-            h as u32,
-            BAR_W / 2,
-            bar_color,
-        );
+        if let Some(path) = build_round_rect(bx, by, BAR_W, h, BAR_W / 2.0) {
+            let mut paint = Paint {
+                anti_alias: true,
+                ..Default::default()
+            };
+            paint.set_color(theme_color(theme.rec_bar, anim.alpha));
+            pixmap.fill_path(&path, &paint, FillRule::Winding, transform, None);
+        }
     }
 }
 
-/// Transcribing state: no audio level, just a center-out shimmer that travels
-/// across the bar row to communicate "working on it" without flat staticness.
-fn draw_sweep(canvas: &mut [u8], width: u32, height: u32, theme: &Theme, frame: u32, alpha: f32) {
-    let cy = (height / 2) as i32;
-    let max_h = (height as i32 - BAR_VPAD * 2).max(BAR_BASELINE + 2);
-    let bar_x_start = (width.saturating_sub(BAR_BLOCK_W)) / 2;
+/// Transcribing state: no audio level, just a center-out shimmer that
+/// travels across the bar row to communicate "working on it" without
+/// flat staticness.
+fn draw_sweep(
+    pixmap: &mut Pixmap,
+    theme: &Theme,
+    frame: u32,
+    anim: AnimState,
+    transform: Transform,
+) {
+    let width = pixmap.width() as f32;
+    let height = pixmap.height() as f32;
+    let cy = height / 2.0;
+    let max_h = (height - BAR_VPAD * 2.0).max(BAR_BASELINE + 2.0);
+    let bar_x_start = (width - BAR_BLOCK_W) / 2.0;
 
     // Sliding focus point that pings back and forth across the row.
     let cycle = (BAR_COUNT as i32) * 2 - 2;
@@ -794,40 +917,28 @@ fn draw_sweep(canvas: &mut [u8], width: u32, height: u32, theme: &Theme, frame: 
         // Bell-shaped intensity centered on `active`, ~3 bars wide.
         let intensity = (-dist * dist / 4.0).exp().max(0.15);
         let dynamic = intensity * taper;
-        let h = (BAR_BASELINE as f32 + dynamic * (max_h - BAR_BASELINE) as f32 * 0.85)
-            .round()
-            .max(BAR_BASELINE as f32) as i32;
-        let bx = bar_x_start + i * BAR_PITCH;
-        let by = (cy - h / 2).max(0) as u32;
+        let h = (BAR_BASELINE + dynamic * (max_h - BAR_BASELINE) * 0.85).max(BAR_BASELINE);
+        let bx = bar_x_start + i as f32 * BAR_PITCH;
+        let by = cy - h / 2.0;
 
-        let bar_a = (theme.trans_bar[0] as f32 * (0.3 + 0.7 * intensity) * alpha).round() as u8;
-        let bar_color = [
-            bar_a,
-            theme.trans_bar[1],
-            theme.trans_bar[2],
-            theme.trans_bar[3],
-        ];
-        rounded_rect(
-            canvas,
-            width,
-            height,
-            bx,
-            by,
-            BAR_W,
-            h as u32,
-            BAR_W / 2,
-            bar_color,
-        );
+        let bar_a = theme.trans_bar[0] as f32 / 255.0 * (0.3 + 0.7 * intensity) * anim.alpha;
+        let bar_color = Color::from_rgba(
+            theme.trans_bar[1] as f32 / 255.0,
+            theme.trans_bar[2] as f32 / 255.0,
+            theme.trans_bar[3] as f32 / 255.0,
+            bar_a.clamp(0.0, 1.0),
+        )
+        .unwrap_or(Color::TRANSPARENT);
+
+        if let Some(path) = build_round_rect(bx, by, BAR_W, h, BAR_W / 2.0) {
+            let mut paint = Paint {
+                anti_alias: true,
+                ..Default::default()
+            };
+            paint.set_color(bar_color);
+            pixmap.fill_path(&path, &paint, FillRule::Winding, transform, None);
+        }
     }
-}
-
-fn blend_pixel(canvas: &mut [u8], width: u32, height: u32, x: u32, y: u32, color: [u8; 4]) {
-    if x >= width || y >= height {
-        return;
-    }
-
-    let index = ((y * width + x) * 4) as usize;
-    canvas[index..index + 4].copy_from_slice(&u32::from_be_bytes(color).to_le_bytes());
 }
 
 #[cfg(test)]
@@ -837,28 +948,48 @@ mod tests {
     const W: u32 = 100;
     const H: u32 = 34;
 
+    fn fresh_pixmap() -> Pixmap {
+        Pixmap::new(W, H).unwrap()
+    }
+
+    fn shown() -> AnimState {
+        AnimState {
+            alpha: 1.0,
+            slide_y: 0.0,
+            scale: 1.0,
+        }
+    }
+    fn hidden() -> AnimState {
+        AnimState {
+            alpha: 0.0,
+            slide_y: 0.0,
+            scale: 1.0,
+        }
+    }
+
     #[test]
     fn idle_draw_is_transparent() {
-        let mut canvas = vec![1; (W * H * 4) as usize];
+        let mut pm = fresh_pixmap();
         let t = Theme::ember();
-        draw_overlay(&mut canvas, W, H, State::Idle, 0, 0.0, 0.0, &t);
-        assert!(canvas.iter().all(|b| *b == 0));
+        draw_overlay(&mut pm, State::Idle, 0, 0.0, hidden(), &t);
+        assert!(pm.data().iter().all(|b| *b == 0));
     }
 
     #[test]
     fn faded_out_draw_is_transparent() {
-        let mut canvas = vec![1; (W * H * 4) as usize];
+        let mut pm = fresh_pixmap();
         let t = Theme::ember();
-        draw_overlay(&mut canvas, W, H, State::Recording, 0, 1.0, 0.0, &t);
-        assert!(canvas.iter().all(|b| *b == 0));
+        draw_overlay(&mut pm, State::Recording, 0, 1.0, hidden(), &t);
+        assert!(pm.data().iter().all(|b| *b == 0));
     }
 
     #[test]
     fn active_draw_has_visible_pixels() {
-        let mut canvas = vec![0; (W * H * 4) as usize];
+        let mut pm = fresh_pixmap();
         let t = Theme::ember();
-        draw_overlay(&mut canvas, W, H, State::Recording, 0, 1.0, 1.0, &t);
-        assert!(canvas.chunks_exact(4).any(|px| px[3] != 0));
+        draw_overlay(&mut pm, State::Recording, 0, 1.0, shown(), &t);
+        // tiny-skia stores premultiplied RGBA; alpha lives in the 4th byte.
+        assert!(pm.data().chunks_exact(4).any(|px| px[3] != 0));
     }
 
     #[test]
@@ -873,25 +1004,32 @@ mod tests {
     }
 
     #[test]
+    fn ease_curves_hit_endpoints() {
+        assert!((ease_out_cubic(0.0) - 0.0).abs() < 1e-6);
+        assert!((ease_out_cubic(1.0) - 1.0).abs() < 1e-6);
+        assert!((ease_in_cubic(0.0) - 0.0).abs() < 1e-6);
+        assert!((ease_in_cubic(1.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
     fn silence_draws_minimal_baseline() {
-        // Recording bars in the ember theme are amber (#F97316); count
-        // amber-dominant pixels to measure bar area independent of the bg
-        // pill. ARGB on disk is little-endian B,G,R,A — each pixel is
-        // [B, G, R, A].
-        fn amber_pixels(canvas: &[u8]) -> usize {
-            canvas
-                .chunks_exact(4)
-                .filter(|px| px[2] > 220 && px[1] > 80 && px[1] < 180 && px[0] < 60)
+        // Recording bars in the ember theme are amber (#F97316). tiny-skia
+        // pixmap pixels are premultiplied RGBA in memory order [R, G, B, A];
+        // count amber-dominant pixels (high R, mid G, low B) to measure
+        // bar area independent of the bg pill.
+        fn amber_pixels(data: &[u8]) -> usize {
+            data.chunks_exact(4)
+                .filter(|px| px[0] > 200 && px[1] > 70 && px[1] < 180 && px[2] < 60)
                 .count()
         }
 
         let t = Theme::ember();
-        let mut quiet = vec![0; (W * H * 4) as usize];
-        let mut loud = vec![0; (W * H * 4) as usize];
-        draw_overlay(&mut quiet, W, H, State::Recording, 0, 0.0, 1.0, &t);
-        draw_overlay(&mut loud, W, H, State::Recording, 0, 1.0, 1.0, &t);
-        let count_quiet = amber_pixels(&quiet);
-        let count_loud = amber_pixels(&loud);
+        let mut quiet = fresh_pixmap();
+        let mut loud = fresh_pixmap();
+        draw_overlay(&mut quiet, State::Recording, 0, 0.0, shown(), &t);
+        draw_overlay(&mut loud, State::Recording, 0, 1.0, shown(), &t);
+        let count_quiet = amber_pixels(quiet.data());
+        let count_loud = amber_pixels(loud.data());
         assert!(
             count_loud > count_quiet,
             "loud audio should fill more bar area than silence (silence={count_quiet}, loud={count_loud})"

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -1,7 +1,7 @@
 //! Wayland layer-shell overlay shown while recording or transcribing.
 
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, thiserror::Error)]
 enum OverlayError {
@@ -53,9 +53,9 @@ use crate::{OverlayConfig, State};
 
 const BOTTOM_MARGIN: i32 = 16;
 
-// Per-frame sleep matching the draw loop. ~24 ms ≈ 41 fps. The spawn
-// animation timings below are expressed in milliseconds and converted to
-// per-frame steps using this constant.
+// Per-frame sleep matching the draw loop. ~24 ms ≈ 41 fps. Spawn animation
+// progress is wall-clock-driven (see `Overlay::spawn_t`), so this only
+// caps the redraw rate.
 const FRAME_MS: f32 = 24.0;
 
 // Spawn animation: the pill "draws out" from a 4-px sliver anchored at the
@@ -87,7 +87,7 @@ const BAR_W: f32 = 4.0;
 const BAR_GAP: f32 = 3.0;
 const BAR_PITCH: f32 = BAR_W + BAR_GAP;
 const BAR_BLOCK_W: f32 = BAR_COUNT as f32 * BAR_W + (BAR_COUNT - 1) as f32 * BAR_GAP;
-const BAR_BASELINE: f32 = 3.0;
+const BAR_BASELINE: f32 = 6.0;
 const BAR_VPAD: f32 = 6.0;
 
 /// Color palette for one overlay theme. Bytes are stored as `[A, R, G, B]`,
@@ -374,9 +374,8 @@ fn run_overlay(
         height,
         target_state: State::Idle,
         visible_state: State::Idle,
-        spawn_t: 0.0,
+        spawn_started: Instant::now(),
         spawn_in: false,
-        bars_grace_ms: 0.0,
         frame: 0,
         level: 0.0,
         theme,
@@ -406,17 +405,16 @@ struct Overlay {
     height: u32,
     target_state: State,
     visible_state: State,
-    /// Progress through the current spawn animation, 0..=1. Hits 1 when the
-    /// animation finishes; reset to 0 each time `target_state` flips between
-    /// idle and active.
-    spawn_t: f32,
+    /// Wall-clock instant when the current spawn animation started. The
+    /// animation progress `t` is derived from `(now - spawn_started) /
+    /// duration`, so the timing is honest regardless of how often the
+    /// dispatch loop ticks. (Previously this was a per-call increment that
+    /// over-advanced when the loop fired multiple times per rendered
+    /// frame, making the animation visually pop instead of ease.)
+    spawn_started: Instant,
     /// `true` while transitioning into a visible state, `false` while
     /// transitioning out. Determines easing direction and duration.
     spawn_in: bool,
-    /// Remaining grace period (ms) before bars unlock from baseline. Set
-    /// when the pill is appearing so audio reactivity doesn't fire while
-    /// the pill is still flying in.
-    bars_grace_ms: f32,
     frame: u32,
     level: f32,
     theme: Theme,
@@ -458,11 +456,10 @@ impl Overlay {
             // visible. Recording ↔ Transcribing keeps the pill steady.
             if was_idle && !now_idle {
                 self.spawn_in = true;
-                self.spawn_t = 0.0;
-                self.bars_grace_ms = BARS_GRACE_MS;
+                self.spawn_started = Instant::now();
             } else if !was_idle && now_idle {
                 self.spawn_in = false;
-                self.spawn_t = 0.0;
+                self.spawn_started = Instant::now();
             }
         }
         // Envelope follower: fast attack (track peaks instantly) + slow
@@ -481,25 +478,22 @@ impl Overlay {
             }
         }
 
-        // Advance the spawn animation. `spawn_t` saturates at 1.0; at that
-        // point the pill is fully shown (`spawn_in = true`) or fully hidden
-        // (`spawn_in = false`).
+        // Once the despawn finishes, snap the renderer to Idle so the next
+        // appearance starts from a clean state.
+        if !self.spawn_in && self.spawn_t() >= 1.0 {
+            self.visible_state = State::Idle;
+        }
+    }
+
+    /// Wall-clock progress through the current spawn animation, 0..=1.
+    fn spawn_t(&self) -> f32 {
         let duration = if self.spawn_in {
             SPAWN_IN_MS
         } else {
             SPAWN_OUT_MS
         };
-        if self.spawn_t < 1.0 {
-            self.spawn_t = (self.spawn_t + FRAME_MS / duration).min(1.0);
-        }
-
-        if !self.spawn_in && self.spawn_t >= 1.0 {
-            self.visible_state = State::Idle;
-        }
-
-        if self.bars_grace_ms > 0.0 {
-            self.bars_grace_ms = (self.bars_grace_ms - FRAME_MS).max(0.0);
-        }
+        let elapsed_ms = self.spawn_started.elapsed().as_secs_f32() * 1000.0;
+        (elapsed_ms / duration).clamp(0.0, 1.0)
     }
 
     /// Compute the current animated transform.
@@ -520,7 +514,7 @@ impl Overlay {
     ///   `easeInCubic` accelerate — sharper exit than entry.
     /// - Pill and bar alpha fade in lockstep with the height collapse.
     fn anim(&self, full_height: f32) -> AnimState {
-        let t = self.spawn_t.clamp(0.0, 1.0);
+        let t = self.spawn_t();
         if self.spawn_in {
             let h_curve = ease_out_back(t, SPAWN_OVERSHOOT_C).clamp(0.0, 1.4);
             let pill_height = SPAWN_PILL_MIN_H + h_curve * (full_height - SPAWN_PILL_MIN_H);
@@ -824,7 +818,13 @@ fn draw_overlay(
         return;
     }
 
-    let pill_cy = pill_y + pill_h / 2.0;
+    // Bars sit at the *final* pill center — the surface midpoint — not at
+    // the currently animating pill_cy. While the pill is still growing
+    // upward from the bottom edge, this keeps the bars planted at one fixed
+    // y so they read as "expanding amplitude" rather than "translating up
+    // with the pill". The pill's bottom-anchored grow still happens
+    // visually; the bars just don't follow its center-of-mass.
+    let pill_cy = surface_h / 2.0;
     match state {
         State::Recording => draw_bars(pixmap, theme, level, anim, pill_cy),
         State::Transcribing => draw_sweep(pixmap, theme, frame, anim, pill_cy),
@@ -837,31 +837,44 @@ fn draw_overlay(
 /// approximation — so the silhouette has no minor inward dents at the
 /// corner joins, which were visible against colored rings.
 ///
-/// When `w == h` it falls back to a single circle. When `h <= 0` or
-/// `w <= 0` it returns `None`.
+/// Handles both orientations: horizontal pills (`w > h`) get end caps on
+/// the left/right; vertical pills (`h > w`) get end caps on the top/bottom.
+/// Square (or near-square) input collapses to a single circle. Returns
+/// `None` for non-positive dimensions.
 fn build_stadium(x: f32, y: f32, w: f32, h: f32) -> Option<tiny_skia::Path> {
     if w <= 0.0 || h <= 0.0 {
         return None;
     }
-    let r = (h / 2.0).min(w / 2.0);
-    if (w - 2.0 * r).abs() < 0.01 {
-        // Square (or near-square) input ⇒ pure circle.
-        return PathBuilder::from_circle(x + r, y + r, r);
+    if w >= h {
+        let r = h / 2.0;
+        if (w - 2.0 * r).abs() < 0.01 {
+            return PathBuilder::from_circle(x + r, y + r, r);
+        }
+        let mut pb = PathBuilder::new();
+        if let Some(rect) = Rect::from_xywh(x + r, y, w - 2.0 * r, h) {
+            pb.push_rect(rect);
+        }
+        if let Some(cap) = PathBuilder::from_circle(x + r, y + r, r) {
+            pb.push_path(&cap);
+        }
+        if let Some(cap) = PathBuilder::from_circle(x + w - r, y + r, r) {
+            pb.push_path(&cap);
+        }
+        pb.finish()
+    } else {
+        let r = w / 2.0;
+        let mut pb = PathBuilder::new();
+        if let Some(rect) = Rect::from_xywh(x, y + r, w, h - 2.0 * r) {
+            pb.push_rect(rect);
+        }
+        if let Some(cap) = PathBuilder::from_circle(x + r, y + r, r) {
+            pb.push_path(&cap);
+        }
+        if let Some(cap) = PathBuilder::from_circle(x + r, y + h - r, r) {
+            pb.push_path(&cap);
+        }
+        pb.finish()
     }
-    let mut pb = PathBuilder::new();
-    // Middle rectangle, between the two end-cap centers.
-    if let Some(rect) = Rect::from_xywh(x + r, y, w - 2.0 * r, h) {
-        pb.push_rect(rect);
-    }
-    // Left end-cap.
-    if let Some(cap) = PathBuilder::from_circle(x + r, y + r, r) {
-        pb.push_path(&cap);
-    }
-    // Right end-cap.
-    if let Some(cap) = PathBuilder::from_circle(x + w - r, y + r, r) {
-        pb.push_path(&cap);
-    }
-    pb.finish()
 }
 
 /// Convert a `[A, R, G, B]` byte array to a tiny-skia non-premultiplied

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -76,16 +76,19 @@ const SPAWN_OVERSHOOT_C: f32 = 0.4;
 const BARS_GRACE_MS: f32 = 80.0;
 const BARS_FADE_MS: f32 = 80.0;
 
-// Bar layout — thin and dense. 5 bars × 3 px + 4 gaps × 3 px = 27 px wide,
-// centered in the pill. Max bar height = HEIGHT − 2·BAR_VPAD (e.g. 50 px on
-// the default 64 px pill), giving real vertical expansion under speech.
+// Bar layout. 5 bars × 4 px + 4 gaps × 3 px = 32 px wide, centered in the
+// pill. Max bar height = HEIGHT − 2·BAR_VPAD (e.g. 28 px on the default
+// 40 px pill). Bar height is purely level-driven — no per-bar phase
+// animation — so each bar stays anchored at the pill center and expands
+// symmetrically up and down with the audio amplitude, instead of
+// translating around frame-to-frame.
 const BAR_COUNT: u32 = 5;
-const BAR_W: f32 = 3.0;
+const BAR_W: f32 = 4.0;
 const BAR_GAP: f32 = 3.0;
 const BAR_PITCH: f32 = BAR_W + BAR_GAP;
 const BAR_BLOCK_W: f32 = BAR_COUNT as f32 * BAR_W + (BAR_COUNT - 1) as f32 * BAR_GAP;
-const BAR_BASELINE: f32 = 2.0;
-const BAR_VPAD: f32 = 7.0;
+const BAR_BASELINE: f32 = 3.0;
+const BAR_VPAD: f32 = 6.0;
 
 /// Color palette for one overlay theme. Bytes are stored as `[A, R, G, B]`,
 /// matching the canvas pixel layout used by [`blend_pixel`].
@@ -812,7 +815,7 @@ fn draw_overlay(
 
     let pill_cy = pill_y + pill_h / 2.0;
     match state {
-        State::Recording => draw_bars(pixmap, theme, frame, level, anim, pill_cy),
+        State::Recording => draw_bars(pixmap, theme, level, anim, pill_cy),
         State::Transcribing => draw_sweep(pixmap, theme, frame, anim, pill_cy),
         State::Idle => {}
     }
@@ -880,14 +883,7 @@ fn taper_factor(i: u32, count: u32) -> f32 {
 /// the dominant driver — only ~15 % of the bar height comes from the
 /// per-bar phase animation, so silence reads as actually quiet and loud
 /// speech reaches near the pill edge.
-fn draw_bars(
-    pixmap: &mut Pixmap,
-    theme: &Theme,
-    frame: u32,
-    level: f32,
-    anim: AnimState,
-    pill_cy: f32,
-) {
+fn draw_bars(pixmap: &mut Pixmap, theme: &Theme, level: f32, anim: AnimState, pill_cy: f32) {
     let surface_w = pixmap.width() as f32;
     // Track the *currently displayed* pill height so bars stay within the
     // pill while it's still growing during the spawn animation.
@@ -896,11 +892,13 @@ fn draw_bars(
 
     for i in 0..BAR_COUNT {
         let taper = taper_factor(i, BAR_COUNT);
-        // Audio-led: 85 % level + taper, only 15 % per-bar phase animation.
-        let phase = ((frame as f32 / 5.0) + i as f32 * 0.7).sin().abs();
+        // Pure level-driven height. Each bar's center is anchored to
+        // `pill_cy` and the bar grows symmetrically up and down. No
+        // per-bar phase animation — that creates the illusion of bars
+        // translating instead of expanding, which reads as "moving up
+        // and down" rather than "amplitude".
         let effective = (level * taper).clamp(0.0, 1.0);
-        let dynamic = effective * (0.85 + 0.15 * phase);
-        let h = (BAR_BASELINE + dynamic * (max_h - BAR_BASELINE)).max(BAR_BASELINE);
+        let h = (BAR_BASELINE + effective * (max_h - BAR_BASELINE)).max(BAR_BASELINE);
         let bx = bar_x_start + i as f32 * BAR_PITCH;
         let by = pill_cy - h / 2.0;
 


### PR DESCRIPTION
## Summary

Adds a visual recording overlay to whisrs. A Wayland layer-shell overlay appears at the bottom of the screen during recording and transcription, showing animated audio bars and a live timer while recording, and a spinner while transcribing. Also ships a GNOME Shell extension that provides the same overlay via D-Bus for GNOME users who can't use the Wayland layer-shell path.

## Changes

- Add `src/overlay/` module with a Wayland layer-shell overlay rendered via `smithay-client-toolkit`
- Add animated audio level bars and elapsed recording timer to the overlay
- Add spinner indicator for the transcribing state
- Add GNOME Shell extension (`contrib/gnome-shell-extension/`) with matching UI, driven by a D-Bus broadcaster in the daemon
- Wire overlay service into daemon startup via `spawn_overlay`
- Expose audio level from `AudioCaptureHandle` via a `watch` channel for real-time bar animation
- Add `[overlay]` config section with `enabled` flag (defaults to `false` for existing configs)
- Update README with overlay feature documentation and GNOME extension install instructions

## Testing

Tested on Ubuntu 24.04 (Wayland and Xorg). Steps:
1. Enable overlay in `config.toml`: `[overlay] enabled = true`
2. Start `whisrsd`
3. Trigger recording — overlay appears at bottom center with animated bars and timer
4. Release — overlay switches to spinner while transcribing, then disappears

For GNOME: install the extension from `contrib/gnome-shell-extension/`, enable it in GNOME Extensions, then follow the same steps.

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (182 tests)
- [x] Tested on at least one compositor