### PR TITLE
feat: make uinput key delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ tray = true                 # system tray icon (requires SNI host like waybar)
 [audio]
 device = "default"
 
+[input]
+# Inter-key delay for the virtual keyboard (uinput). Raise this if a TUI
+# drops characters while whisrs is typing — e.g. Node/Ink-based apps like
+# Claude Code in raw mode. Default: 2.
+key_delay_ms = 2
+
 [groq]
 api_key = "gsk_..."
 model = "whisper-large-v3-turbo"

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -13,8 +13,8 @@ use dialoguer::{Confirm, Input, Password, Select};
 
 use crate::llm::LlmConfig;
 use crate::{
-    AudioConfig, Config, DeepgramConfig, GeneralConfig, GroqConfig, LocalWhisperConfig,
-    OpenAiConfig,
+    AudioConfig, Config, DeepgramConfig, GeneralConfig, GroqConfig, InputConfig,
+    LocalWhisperConfig, OpenAiConfig,
 };
 
 // ANSI color codes.
@@ -134,6 +134,7 @@ pub fn run_setup() -> Result<()> {
         audio: AudioConfig {
             device: "default".to_string(),
         },
+        input: InputConfig::default(),
         deepgram: deepgram_config,
         groq: groq_config,
         openai: openai_config,

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -112,6 +112,7 @@ fn load_config() -> (Config, Option<String>) {
                         Config {
                             general: Default::default(),
                             audio: Default::default(),
+                            input: Default::default(),
                             deepgram: None,
                             groq: None,
                             openai: None,
@@ -135,6 +136,7 @@ fn load_config() -> (Config, Option<String>) {
                     Config {
                         general: Default::default(),
                         audio: Default::default(),
+                        input: Default::default(),
                         deepgram: None,
                         groq: None,
                         openai: None,
@@ -158,6 +160,7 @@ fn load_config() -> (Config, Option<String>) {
         Config {
             general: Default::default(),
             audio: Default::default(),
+            input: Default::default(),
             deepgram: None,
             groq: None,
             openai: None,
@@ -744,6 +747,8 @@ async fn handle_toggle(
                 let pipeline_backend_name = context.config.general.backend.clone();
                 let pipeline_language = context.config.general.language.clone();
                 let pipeline_state_tx = context.state_tx.clone();
+                let pipeline_key_delay =
+                    std::time::Duration::from_millis(context.config.input.key_delay_ms);
 
                 let task = tokio::spawn(async move {
                     run_streaming_pipeline(
@@ -762,6 +767,7 @@ async fn handle_toggle(
                         pipeline_backend_name,
                         pipeline_language,
                         pipeline_state_tx,
+                        pipeline_key_delay,
                     )
                     .await
                 });
@@ -920,6 +926,7 @@ async fn run_streaming_pipeline(
     backend_name: String,
     language: String,
     state_tx: tokio::sync::watch::Sender<State>,
+    key_delay: std::time::Duration,
 ) -> Result<String> {
     let pipeline_start = std::time::Instant::now();
     let (audio_tx, backend_rx) = tokio::sync::mpsc::channel::<Vec<i16>>(256);
@@ -992,7 +999,8 @@ async fn run_streaming_pipeline(
 
             info!("typing: {:?}", text_to_type);
             if let Err(e) =
-                tokio::task::spawn_blocking(move || type_text_at_cursor(&text_to_type)).await
+                tokio::task::spawn_blocking(move || type_text_at_cursor(&text_to_type, key_delay))
+                    .await
             {
                 warn!("failed to type text: {e}");
             }
@@ -1197,7 +1205,10 @@ async fn process_recording_batch(
 
     // Type the text at the cursor.
     let text_clone = text.clone();
-    if let Err(e) = tokio::task::spawn_blocking(move || type_text_at_cursor(&text_clone)).await? {
+    let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
+    if let Err(e) =
+        tokio::task::spawn_blocking(move || type_text_at_cursor(&text_clone, key_delay)).await?
+    {
         warn!("failed to type text: {e}");
     }
 
@@ -1245,7 +1256,7 @@ fn format_api_error(err: &anyhow::Error) -> String {
 }
 
 /// Type text at the cursor using uinput (keyboard injection) or clipboard paste.
-fn type_text_at_cursor(text: &str) -> Result<()> {
+fn type_text_at_cursor(text: &str, key_delay: std::time::Duration) -> Result<()> {
     use whisrs::input::clipboard::ClipboardOps;
     use whisrs::input::keymap::XkbKeymap;
     use whisrs::input::uinput::UinputKeyboard;
@@ -1254,7 +1265,7 @@ fn type_text_at_cursor(text: &str) -> Result<()> {
     let detected_layout = whisrs::input::keymap::KeyboardLayout::detect();
     let keymap = XkbKeymap::from_layout(&detected_layout).context("failed to build XKB keymap")?;
     let clipboard = ClipboardOps::detect();
-    let mut keyboard = match UinputKeyboard::new(keymap, clipboard) {
+    let mut keyboard = match UinputKeyboard::new(keymap, clipboard, key_delay) {
         Ok(kb) => kb,
         Err(e) => {
             let msg = format!("{e:#}");

--- a/src/input/uinput.rs
+++ b/src/input/uinput.rs
@@ -15,9 +15,6 @@ use super::clipboard::ClipboardOps;
 use super::keymap::XkbKeymap;
 use super::{ClipboardHandler, KeyInjector};
 
-/// Delay between individual key events to prevent dropped characters.
-const KEY_DELAY: Duration = Duration::from_millis(2);
-
 /// Delay after creating the virtual device to let the kernel register it.
 const DEVICE_SETTLE_DELAY: Duration = Duration::from_millis(200);
 
@@ -26,6 +23,7 @@ pub struct UinputKeyboard {
     device: evdev::uinput::VirtualDevice,
     keymap: XkbKeymap,
     clipboard: ClipboardOps,
+    key_delay: Duration,
 }
 
 impl UinputKeyboard {
@@ -33,7 +31,14 @@ impl UinputKeyboard {
     ///
     /// Requires write access to `/dev/uinput` (user must be in the `input`
     /// group or have the appropriate udev rule installed).
-    pub fn new(keymap: XkbKeymap, clipboard: ClipboardOps) -> anyhow::Result<Self> {
+    ///
+    /// `key_delay` is the inter-event delay. Raise it for TUIs that drop
+    /// characters in raw mode (e.g. Node/Ink-based apps like Claude Code).
+    pub fn new(
+        keymap: XkbKeymap,
+        clipboard: ClipboardOps,
+        key_delay: Duration,
+    ) -> anyhow::Result<Self> {
         // Register all key codes we might need.
         let mut keys = AttributeSet::<Key>::new();
         for code in 1..=247 {
@@ -57,6 +62,7 @@ impl UinputKeyboard {
             device,
             keymap,
             clipboard,
+            key_delay,
         })
     }
 
@@ -71,18 +77,18 @@ impl UinputKeyboard {
                 Key::KEY_LEFTSHIFT.code(),
                 1,
             )])?;
-            thread::sleep(KEY_DELAY);
+            thread::sleep(self.key_delay);
         }
 
         // Press key
         self.device
             .emit(&[InputEvent::new(EventType::KEY, key.code(), 1)])?;
-        thread::sleep(KEY_DELAY);
+        thread::sleep(self.key_delay);
 
         // Release key
         self.device
             .emit(&[InputEvent::new(EventType::KEY, key.code(), 0)])?;
-        thread::sleep(KEY_DELAY);
+        thread::sleep(self.key_delay);
 
         if shift {
             // Release Shift
@@ -91,7 +97,7 @@ impl UinputKeyboard {
                 Key::KEY_LEFTSHIFT.code(),
                 0,
             )])?;
-            thread::sleep(KEY_DELAY);
+            thread::sleep(self.key_delay);
         }
 
         Ok(())
@@ -114,7 +120,7 @@ impl UinputKeyboard {
             self.device
                 .emit(&[InputEvent::new(EventType::KEY, modifier.code(), 0)])?;
         }
-        thread::sleep(KEY_DELAY);
+        thread::sleep(self.key_delay);
 
         Ok(())
     }
@@ -124,22 +130,22 @@ impl UinputKeyboard {
         // Press Ctrl
         self.device
             .emit(&[InputEvent::new(EventType::KEY, Key::KEY_LEFTCTRL.code(), 1)])?;
-        thread::sleep(KEY_DELAY);
+        thread::sleep(self.key_delay);
 
         // Press V
         self.device
             .emit(&[InputEvent::new(EventType::KEY, Key::KEY_V.code(), 1)])?;
-        thread::sleep(KEY_DELAY);
+        thread::sleep(self.key_delay);
 
         // Release V
         self.device
             .emit(&[InputEvent::new(EventType::KEY, Key::KEY_V.code(), 0)])?;
-        thread::sleep(KEY_DELAY);
+        thread::sleep(self.key_delay);
 
         // Release Ctrl
         self.device
             .emit(&[InputEvent::new(EventType::KEY, Key::KEY_LEFTCTRL.code(), 0)])?;
-        thread::sleep(KEY_DELAY);
+        thread::sleep(self.key_delay);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,8 @@ pub struct Config {
     #[serde(default)]
     pub audio: AudioConfig,
     #[serde(default)]
+    pub input: InputConfig,
+    #[serde(default)]
     pub deepgram: Option<DeepgramConfig>,
     #[serde(default)]
     pub groq: Option<GroqConfig>,
@@ -167,6 +169,24 @@ pub struct AudioConfig {
     pub device: String,
 }
 
+/// Keyboard injection (uinput) tuning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputConfig {
+    /// Delay between individual key events, in milliseconds. Raise this if
+    /// characters are dropped by TUIs that read stdin in raw mode (e.g.
+    /// Node/Ink-based apps like Claude Code).
+    #[serde(default = "default_key_delay_ms")]
+    pub key_delay_ms: u64,
+}
+
+impl Default for InputConfig {
+    fn default() -> Self {
+        Self {
+            key_delay_ms: default_key_delay_ms(),
+        }
+    }
+}
+
 impl Default for AudioConfig {
     fn default() -> Self {
         Self {
@@ -228,6 +248,9 @@ fn default_device() -> String {
 }
 fn default_audio_feedback_volume() -> f32 {
     0.5
+}
+fn default_key_delay_ms() -> u64 {
+    2
 }
 fn default_deepgram_model() -> String {
     "nova-3".to_string()
@@ -634,6 +657,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            input: Default::default(),
             deepgram: None,
             groq: None,
             openai: None,
@@ -657,6 +681,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            input: Default::default(),
             deepgram: None,
             groq: None,
             openai: None,
@@ -678,6 +703,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            input: Default::default(),
             deepgram: None,
             groq: Some(GroqConfig {
                 api_key: "test-key".to_string(),
@@ -703,6 +729,7 @@ mod tests {
                 ..Default::default()
             },
             audio: Default::default(),
+            input: Default::default(),
             deepgram: None,
             groq: Some(GroqConfig {
                 api_key: "test-key".to_string(),


### PR DESCRIPTION
Closes #12.

## Summary

Replaces the hardcoded 2 ms `KEY_DELAY` in `UinputKeyboard` with a configurable `input.key_delay_ms` setting. Defaults to 2 ms, so existing setups behave identically.

## Why

At 2 ms, TUIs that read stdin in raw mode and rely on single-threaded UI loops — most visibly Node/Ink-based apps such as Claude Code — drop characters when whisrs types into them. The kernel delivers events faster than the app can drain them. Raising the delay to ~30 ms is the established workaround; making it configurable means users can opt in without forking or patching.

## What changed

- `KEY_DELAY` is removed; the default 2 ms lives as a `default_key_delay_ms()` serde default, matching the existing `default_backend` / `default_silence_timeout` pattern.
- `UinputKeyboard::new` takes `key_delay: Duration` directly and stores it on the instance.
- Daemon reads `config.input.key_delay_ms` and threads it through both the streaming and batch typing paths.
- New `[input]` config section documented in README.

## Test plan
- [x] `cargo check` clean
- [x] `cargo test` — 179 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Verified default behaviour (no config) matches the previous 2 ms timing
- [x] Live test with Claude Code at `key_delay_ms = 30` to confirm dropped characters resolved

## Update — simplification pass

Collapsed the `Option<u64>` → `Option<Duration>` → `unwrap_or(DEFAULT)` chain to a plain `u64` with a serde default, matching the existing `default_X` pattern in `lib.rs`. Net effect:

- `InputConfig.key_delay_ms` is `u64` (not `Option<u64>`).
- `UinputKeyboard::new` and `type_text_at_cursor` take `Duration` (not `Option<Duration>`).
- Daemon call sites compute `Duration::from_millis(...)` in one line instead of an `Option`-mapping chain.
- Dropped the now-redundant `DEFAULT_KEY_DELAY` const and trimmed the `UinputKeyboard::new` doc comment (no more `None`-fallback hand-waving).