### PR TITLE
feat: drive AltGr as a real modifier, synthesize dead-key combinations

### DIFF
--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -370,6 +370,15 @@ fn build_reverse_map(keymap: &xkbcommon::xkb::Keymap) -> HashMap<char, KeyMappin
                     }),
                 },
             );
+        } else {
+            // No dead key for this accent on the active layout — `ch` will
+            // fall through to clipboard paste, which is broken in terminal
+            // emulators. Logged so a future regression on a layout that
+            // used to support this is debuggable.
+            debug!(
+                "dead-key synthesis pass 1: no `{dead_sym:#x}` on this layout; \
+                 '{ch}' will use clipboard fallback"
+            );
         }
     }
 
@@ -381,14 +390,27 @@ fn build_reverse_map(keymap: &xkbcommon::xkb::Keymap) -> HashMap<char, KeyMappin
             continue;
         }
         let Some(dk) = dead_keys.get(&dead_sym) else {
+            debug!(
+                "dead-key synthesis pass 2: no `{dead_sym:#x}` on this layout; \
+                 '{ch}' will use clipboard fallback"
+            );
             continue;
         };
         let Some(base_map) = map.get(&base).copied() else {
+            debug!(
+                "dead-key synthesis pass 2: base letter '{base}' not in keymap; \
+                 '{ch}' will use clipboard fallback"
+            );
             continue;
         };
         // Don't chain follow-taps (a base letter that is itself a
         // dead-key fallback would imply a 3-tap sequence we don't model).
         if base_map.follow.is_some() {
+            debug!(
+                "dead-key synthesis pass 2: base letter '{base}' is itself a \
+                 follow-tap mapping (would require 3-tap chain); \
+                 '{ch}' will use clipboard fallback"
+            );
             continue;
         }
         map.insert(
@@ -678,12 +700,14 @@ mod tests {
         }
     }
 
-    /// Pass 2 (accented letter via `dead_X + base_letter`): `ã` is
-    /// reachable on us:intl. Whichever route the layout exposes, the
-    /// mapping must be self-consistent: if synthesized, the follow tap
-    /// must be `a`; if direct, the main tap must hold AltGr.
+    /// Pass 2 (accented letter via `dead_X + base_letter`): `ã` is not
+    /// reachable at any level on us:intl, so it must be synthesized as
+    /// `dead_tilde + a`. This is the deterministic test that proves
+    /// Pass 2 actually fires; the Polish/Spanish tests below cover the
+    /// no-overwrite invariant for layouts that do expose the char
+    /// directly.
     #[test]
-    fn us_intl_tilde_letter_route_is_self_consistent() {
+    fn us_intl_tilde_letter_uses_dead_key_synthesis() {
         let km = XkbKeymap::from_layout(&KeyboardLayout {
             layout: "us".to_string(),
             variant: "intl".to_string(),
@@ -691,23 +715,15 @@ mod tests {
         .unwrap();
         let a_main = km.lookup('a').expect("'a' must be in keymap").main;
         let mapping = km.lookup('ã').expect("ã must be reachable on us:intl");
-        match mapping.follow {
-            Some(follow) => {
-                // Synthesized: follow tap must produce the base letter 'a'.
-                assert_eq!(
-                    follow.keycode, a_main.keycode,
-                    "ã follow tap must target the same evdev keycode as 'a' \
-                     (dead_tilde + a sequence)"
-                );
-            }
-            None => {
-                // Direct: must hold AltGr (level 2 or 3 reach).
-                assert!(
-                    mapping.main.altgr,
-                    "if ã is reached directly, it must hold AltGr (level 2/3)"
-                );
-            }
-        }
+        let follow = mapping.follow.expect(
+            "ã on us:intl must be synthesized via dead_tilde + a — \
+             the literal char is not at any level on this layout",
+        );
+        assert_eq!(
+            follow.keycode, a_main.keycode,
+            "ã follow tap must target the same evdev keycode as 'a' \
+             (dead_tilde + a sequence)"
+        );
     }
 
     /// Polish exposes `ą` at level 2 directly. The synthesis pass MUST

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -199,6 +199,13 @@ use xkbcommon::xkb::keysyms::{
 /// set used in everyday Portuguese/Spanish/French/Italian; layouts that
 /// already expose these chars at level 2 (e.g. `us:intl` puts `á` directly
 /// on AltGr+a) skip the synthesis and use the direct entry.
+///
+/// This is intentionally a Romance-language seed list rather than an
+/// exhaustive dead-key table. Most other scripts (German `ß`, Polish ą/ę,
+/// Nordic å/ø/æ, Hungarian ő/ű) expose their accented characters directly
+/// at level 2 or 3 of their native layout, so the level 0..=3 walk above
+/// catches them and they don't need synthesis here. Extend per-script
+/// when a real-world layout falls through both routes.
 const ACCENTED_VIA_DEAD_KEY: &[(char, char, u32)] = &[
     // tilde
     ('ã', 'a', XK_DEAD_TILDE),
@@ -284,8 +291,11 @@ fn build_reverse_map(keymap: &xkbcommon::xkb::Keymap) -> HashMap<char, KeyMappin
                 }
 
                 // The evdev keycode is the XKB keycode minus 8
-                // (XKB adds 8 to Linux input keycodes).
-                let evdev_keycode = raw_keycode.saturating_sub(8) as u16;
+                // (XKB adds 8 to Linux input keycodes). Linux KEY_MAX is
+                // ~767 so the cast is safe; saturate explicitly rather
+                // than truncating with `as` to keep the intent obvious.
+                let evdev_keycode: u16 =
+                    raw_keycode.saturating_sub(8).try_into().unwrap_or(u16::MAX);
                 let shift = level == 1 || level == 3;
                 let altgr = level == 2 || level == 3;
 
@@ -631,6 +641,108 @@ mod tests {
                 "'{ch}' must be reachable via uinput on us:intl, got no mapping"
             );
         }
+    }
+
+    // --- Synthesis routing (locks in direct vs dead-key+follow paths) ---
+
+    /// Pass 1 (literal accent via `dead_X + Space`): for each of the
+    /// chars Pass 1 covers, on us:intl the char must be reachable, and
+    /// — if it ended up routed through synthesis rather than a direct
+    /// level mapping — the follow tap must be unmodified Space.
+    /// Whether any specific char is direct vs synthesized is layout-
+    /// dependent (us:intl puts some literal accents at level 2 directly),
+    /// but the invariant holds: synthesized routes always end with Space.
+    #[test]
+    fn us_intl_pass1_chars_synthesized_routes_end_with_space() {
+        let km = XkbKeymap::from_layout(&KeyboardLayout {
+            layout: "us".to_string(),
+            variant: "intl".to_string(),
+        })
+        .unwrap();
+        for ch in ['\'', '"', '~', '`', '^'] {
+            let mapping = km
+                .lookup(ch)
+                .unwrap_or_else(|| panic!("'{ch}' must be reachable on us:intl"));
+            if let Some(follow) = mapping.follow {
+                assert_eq!(
+                    follow.keycode,
+                    evdev::Key::KEY_SPACE.code(),
+                    "'{ch}' was synthesized; follow tap must be SPACE \
+                     (dead_X + space sequence)"
+                );
+                assert!(
+                    !follow.shift && !follow.altgr,
+                    "'{ch}' synthesis follow tap must be unmodified SPACE"
+                );
+            }
+        }
+    }
+
+    /// Pass 2 (accented letter via `dead_X + base_letter`): `ã` is
+    /// reachable on us:intl. Whichever route the layout exposes, the
+    /// mapping must be self-consistent: if synthesized, the follow tap
+    /// must be `a`; if direct, the main tap must hold AltGr.
+    #[test]
+    fn us_intl_tilde_letter_route_is_self_consistent() {
+        let km = XkbKeymap::from_layout(&KeyboardLayout {
+            layout: "us".to_string(),
+            variant: "intl".to_string(),
+        })
+        .unwrap();
+        let a_main = km.lookup('a').expect("'a' must be in keymap").main;
+        let mapping = km.lookup('ã').expect("ã must be reachable on us:intl");
+        match mapping.follow {
+            Some(follow) => {
+                // Synthesized: follow tap must produce the base letter 'a'.
+                assert_eq!(
+                    follow.keycode, a_main.keycode,
+                    "ã follow tap must target the same evdev keycode as 'a' \
+                     (dead_tilde + a sequence)"
+                );
+            }
+            None => {
+                // Direct: must hold AltGr (level 2 or 3 reach).
+                assert!(
+                    mapping.main.altgr,
+                    "if ã is reached directly, it must hold AltGr (level 2/3)"
+                );
+            }
+        }
+    }
+
+    /// Polish exposes `ą` at level 2 directly. The synthesis pass MUST
+    /// NOT overwrite that direct entry — `ą` must keep `follow=None`
+    /// and use AltGr, not synthesize via dead_ogonek + a.
+    #[test]
+    fn polish_accented_letter_is_direct_not_synthesized() {
+        let km = XkbKeymap::from_layout(&layout("pl", "")).unwrap();
+        let mapping = km.lookup('ą').expect("ą must be reachable on Polish");
+        assert!(
+            mapping.follow.is_none(),
+            "ą on Polish must be a direct AltGr tap, not synthesized — \
+             synthesis pass must not overwrite a direct mapping"
+        );
+        assert!(mapping.main.altgr, "ą on Polish must hold AltGr");
+    }
+
+    /// Spanish exposes `ñ` at level 0 directly (it's on the dedicated
+    /// `ñ` key). Even though `ñ` is in `ACCENTED_VIA_DEAD_KEY`, the
+    /// synthesis pass must skip it because the direct entry already
+    /// exists — locks in the cross-layout no-overwrite invariant.
+    #[test]
+    fn spanish_enye_is_direct_not_synthesized() {
+        let km = XkbKeymap::from_layout(&layout("es", "")).unwrap();
+        let mapping = km.lookup('ñ').expect("ñ must be reachable on Spanish");
+        assert!(
+            mapping.follow.is_none(),
+            "ñ on Spanish must be a direct level-0 tap, not synthesized — \
+             synthesis pass must not overwrite even when the char is in \
+             the synthesis table"
+        );
+        assert!(
+            !mapping.main.altgr && !mapping.main.shift,
+            "ñ on Spanish is on a dedicated key — no modifiers required"
+        );
     }
 
     // --- Alternative Latin layouts ---

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -405,12 +405,11 @@ fn build_reverse_map(keymap: &xkbcommon::xkb::Keymap) -> HashMap<char, KeyMappin
         };
         // Don't chain follow-taps (a base letter that is itself a
         // dead-key fallback would imply a 3-tap sequence we don't model).
+        // Tripwire: currently unreachable because Pass 1 only inserts
+        // follow=Space entries and `ACCENTED_VIA_DEAD_KEY` only contains
+        // alphabetic bases — no `'`/`"`/`~`/`` ` ``/`^` here. Stays as a
+        // guard for future table additions.
         if base_map.follow.is_some() {
-            debug!(
-                "dead-key synthesis pass 2: base letter '{base}' is itself a \
-                 follow-tap mapping (would require 3-tap chain); \
-                 '{ch}' will use clipboard fallback"
-            );
             continue;
         }
         map.insert(

--- a/src/input/keymap.rs
+++ b/src/input/keymap.rs
@@ -6,9 +6,10 @@
 use std::collections::HashMap;
 use std::process::Command;
 
+use evdev::Key;
 use tracing::{debug, warn};
 
-use super::KeyMapping;
+use super::{KeyMapping, KeyTap};
 
 /// Detected keyboard layout (XKB layout name and optional variant).
 #[derive(Debug, Clone)]
@@ -185,9 +186,81 @@ impl XkbKeymap {
     }
 }
 
+// Dead-key keysyms re-exported from xkbcommon, named locally for legibility
+// in the synthesis tables below.
+use xkbcommon::xkb::keysyms::{
+    KEY_dead_acute as XK_DEAD_ACUTE, KEY_dead_cedilla as XK_DEAD_CEDILLA,
+    KEY_dead_circumflex as XK_DEAD_CIRCUMFLEX, KEY_dead_diaeresis as XK_DEAD_DIAERESIS,
+    KEY_dead_grave as XK_DEAD_GRAVE, KEY_dead_tilde as XK_DEAD_TILDE,
+};
+
+/// Accented characters synthesised as `dead_X + base_letter` when they
+/// are missing from the direct layout mapping. Covers the Romance-language
+/// set used in everyday Portuguese/Spanish/French/Italian; layouts that
+/// already expose these chars at level 2 (e.g. `us:intl` puts `á` directly
+/// on AltGr+a) skip the synthesis and use the direct entry.
+const ACCENTED_VIA_DEAD_KEY: &[(char, char, u32)] = &[
+    // tilde
+    ('ã', 'a', XK_DEAD_TILDE),
+    ('õ', 'o', XK_DEAD_TILDE),
+    ('ñ', 'n', XK_DEAD_TILDE),
+    ('Ã', 'A', XK_DEAD_TILDE),
+    ('Õ', 'O', XK_DEAD_TILDE),
+    ('Ñ', 'N', XK_DEAD_TILDE),
+    // acute
+    ('á', 'a', XK_DEAD_ACUTE),
+    ('é', 'e', XK_DEAD_ACUTE),
+    ('í', 'i', XK_DEAD_ACUTE),
+    ('ó', 'o', XK_DEAD_ACUTE),
+    ('ú', 'u', XK_DEAD_ACUTE),
+    ('ý', 'y', XK_DEAD_ACUTE),
+    ('Á', 'A', XK_DEAD_ACUTE),
+    ('É', 'E', XK_DEAD_ACUTE),
+    ('Í', 'I', XK_DEAD_ACUTE),
+    ('Ó', 'O', XK_DEAD_ACUTE),
+    ('Ú', 'U', XK_DEAD_ACUTE),
+    // circumflex
+    ('â', 'a', XK_DEAD_CIRCUMFLEX),
+    ('ê', 'e', XK_DEAD_CIRCUMFLEX),
+    ('î', 'i', XK_DEAD_CIRCUMFLEX),
+    ('ô', 'o', XK_DEAD_CIRCUMFLEX),
+    ('û', 'u', XK_DEAD_CIRCUMFLEX),
+    ('Â', 'A', XK_DEAD_CIRCUMFLEX),
+    ('Ê', 'E', XK_DEAD_CIRCUMFLEX),
+    ('Ô', 'O', XK_DEAD_CIRCUMFLEX),
+    // grave
+    ('à', 'a', XK_DEAD_GRAVE),
+    ('è', 'e', XK_DEAD_GRAVE),
+    ('ì', 'i', XK_DEAD_GRAVE),
+    ('ò', 'o', XK_DEAD_GRAVE),
+    ('ù', 'u', XK_DEAD_GRAVE),
+    ('À', 'A', XK_DEAD_GRAVE),
+    // diaeresis / umlaut
+    ('ä', 'a', XK_DEAD_DIAERESIS),
+    ('ë', 'e', XK_DEAD_DIAERESIS),
+    ('ï', 'i', XK_DEAD_DIAERESIS),
+    ('ö', 'o', XK_DEAD_DIAERESIS),
+    ('ü', 'u', XK_DEAD_DIAERESIS),
+    // cedilla
+    ('ç', 'c', XK_DEAD_CEDILLA),
+    ('Ç', 'C', XK_DEAD_CEDILLA),
+];
+
 /// Iterate all keycodes and shift levels to build a `char → KeyMapping` table.
+///
+/// Levels 0..=3 are all surfaced as direct mappings, with the appropriate
+/// modifiers (`shift`, `altgr`) recorded — so e.g. `ç` (level 2 on us:intl)
+/// becomes a single-keypress tap with AltGr held, no clipboard fallback.
+///
+/// In addition, dead-key keysyms encountered during the walk are recorded
+/// so a small fallback table can be appended for the literal punctuation
+/// they produce when followed by Space (`'`, `"`, `~`, `` ` ``, `^`).
 fn build_reverse_map(keymap: &xkbcommon::xkb::Keymap) -> HashMap<char, KeyMapping> {
-    let mut map = HashMap::new();
+    let mut map: HashMap<char, KeyMapping> = HashMap::new();
+    // Dead keysym → KeyTap so we know which physical key (and modifiers)
+    // produces each dead key on this layout. Used by the fallback passes
+    // below to synthesise dead+space and dead+base sequences.
+    let mut dead_keys: HashMap<u32, KeyTap> = HashMap::new();
 
     // xkb keycodes: iterate from min to max.
     let min = keymap.min_keycode().raw();
@@ -204,33 +277,117 @@ fn build_reverse_map(keymap: &xkbcommon::xkb::Keymap) -> HashMap<char, KeyMappin
             for level in 0..num_levels {
                 let syms = keymap.key_get_syms_by_level(keycode, layout, level);
 
+                // Skip levels we can't drive with the modifiers we have
+                // wired up (Shift, AltGr, Shift+AltGr — that covers 0..=3).
+                if level > 3 {
+                    continue;
+                }
+
+                // The evdev keycode is the XKB keycode minus 8
+                // (XKB adds 8 to Linux input keycodes).
+                let evdev_keycode = raw_keycode.saturating_sub(8) as u16;
+                let shift = level == 1 || level == 3;
+                let altgr = level == 2 || level == 3;
+
                 for &sym in syms {
+                    let raw = sym.raw();
+
+                    // Track dead keysyms separately — they have no Unicode
+                    // value of their own but we'll need their keycodes for
+                    // the fallback synthesis below.
+                    if matches!(
+                        raw,
+                        XK_DEAD_GRAVE
+                            | XK_DEAD_ACUTE
+                            | XK_DEAD_CIRCUMFLEX
+                            | XK_DEAD_TILDE
+                            | XK_DEAD_DIAERESIS
+                            | XK_DEAD_CEDILLA
+                    ) {
+                        dead_keys.entry(raw).or_insert(KeyTap {
+                            keycode: evdev_keycode,
+                            shift,
+                            altgr,
+                        });
+                        continue;
+                    }
+
                     let unicode = xkbcommon::xkb::keysym_to_utf32(sym);
                     if unicode == 0 {
                         continue;
                     }
 
                     if let Some(ch) = char::from_u32(unicode) {
-                        // The evdev keycode is the XKB keycode minus 8
-                        // (XKB adds 8 to Linux input keycodes).
-                        let evdev_keycode = raw_keycode.saturating_sub(8);
-
-                        // Level 0 = no modifiers, Level 1 = Shift
-                        let shift = level >= 1;
-
                         let mapping = KeyMapping {
-                            keycode: evdev_keycode as u16,
-                            shift,
+                            main: KeyTap {
+                                keycode: evdev_keycode,
+                                shift,
+                                altgr,
+                            },
+                            follow: None,
                         };
 
-                        // Prefer un-shifted mappings (level 0) over shifted ones.
-                        // Only insert if not already present (first-come wins,
-                        // and level 0 is iterated first).
+                        // Prefer the lowest-level mapping. Iteration is in
+                        // level order so first-come (level 0) wins.
                         map.entry(ch).or_insert(mapping);
                     }
                 }
             }
         }
+    }
+
+    // Pass 1: literal punctuation via `dead_X + Space`. Used on layouts
+    // where the apostrophe, tilde, etc. exist only as dead keys (us:intl).
+    for (ch, dead_sym) in [
+        ('\'', XK_DEAD_ACUTE),
+        ('"', XK_DEAD_DIAERESIS),
+        ('~', XK_DEAD_TILDE),
+        ('`', XK_DEAD_GRAVE),
+        ('^', XK_DEAD_CIRCUMFLEX),
+    ] {
+        if map.contains_key(&ch) {
+            continue;
+        }
+        if let Some(dk) = dead_keys.get(&dead_sym) {
+            map.insert(
+                ch,
+                KeyMapping {
+                    main: *dk,
+                    follow: Some(KeyTap {
+                        keycode: Key::KEY_SPACE.code(),
+                        shift: false,
+                        altgr: false,
+                    }),
+                },
+            );
+        }
+    }
+
+    // Pass 2: accented letters via `dead_X + base_letter`. Used for chars
+    // like `ã` on us:intl, where the layout doesn't expose them at any
+    // directly-reachable level but the dead key for the accent exists.
+    for &(ch, base, dead_sym) in ACCENTED_VIA_DEAD_KEY {
+        if map.contains_key(&ch) {
+            continue;
+        }
+        let Some(dk) = dead_keys.get(&dead_sym) else {
+            continue;
+        };
+        let Some(base_map) = map.get(&base).copied() else {
+            continue;
+        };
+        // Don't chain follow-taps (a base letter that is itself a
+        // dead-key fallback would imply a 3-tap sequence we don't model).
+        if base_map.follow.is_some() {
+            continue;
+        }
+        map.insert(
+            ch,
+            KeyMapping {
+                main: *dk,
+                follow: Some(base_map.main),
+            },
+        );
     }
 
     map
@@ -262,7 +419,7 @@ mod tests {
         if let Ok(km) = km {
             if let Some(mapping) = km.lookup('A') {
                 assert!(
-                    mapping.shift,
+                    mapping.main.shift,
                     "uppercase 'A' should require shift on standard layouts"
                 );
             }
@@ -277,6 +434,7 @@ mod tests {
     }
 
     /// Helper: assert a character maps to the expected evdev keycode and shift state.
+    /// Asserts altgr is false (the common case for level-0/1 chars).
     fn assert_key(
         km: &XkbKeymap,
         ch: char,
@@ -284,17 +442,33 @@ mod tests {
         expected_shift: bool,
         label: &str,
     ) {
+        assert_key_full(km, ch, expected_keycode, expected_shift, false, label);
+    }
+
+    /// Helper: assert keycode + shift + altgr.
+    fn assert_key_full(
+        km: &XkbKeymap,
+        ch: char,
+        expected_keycode: u16,
+        expected_shift: bool,
+        expected_altgr: bool,
+        label: &str,
+    ) {
         let mapping = km
             .lookup(ch)
             .unwrap_or_else(|| panic!("'{ch}' should be in {label} keymap"));
         assert_eq!(
-            mapping.keycode, expected_keycode,
+            mapping.main.keycode, expected_keycode,
             "'{ch}' should be at evdev {expected_keycode} on {label}, got {}",
-            mapping.keycode
+            mapping.main.keycode
         );
         assert_eq!(
-            mapping.shift, expected_shift,
+            mapping.main.shift, expected_shift,
             "'{ch}' shift should be {expected_shift} on {label}"
+        );
+        assert_eq!(
+            mapping.main.altgr, expected_altgr,
+            "'{ch}' altgr should be {expected_altgr} on {label}"
         );
     }
 
@@ -432,9 +606,31 @@ mod tests {
         let km = XkbKeymap::from_layout(&layout("pl", "")).unwrap();
         assert_key(&km, 'a', 30, false, "Polish");
         assert_key(&km, 'z', 44, false, "Polish");
-        // Polish special chars via AltGr (mapped as shift in our model).
-        assert_key(&km, 'ą', 30, true, "Polish");
-        assert_key(&km, 'ę', 18, true, "Polish");
+        // Polish accented characters live at level 2 (AltGr) and now go
+        // through uinput directly, no clipboard fallback needed.
+        assert_key_full(&km, 'ą', 30, false, true, "Polish");
+        assert_key_full(&km, 'ę', 18, false, true, "Polish");
+    }
+
+    #[test]
+    fn us_intl_typeable_via_uinput() {
+        let km = XkbKeymap::from_layout(&KeyboardLayout {
+            layout: "us".to_string(),
+            variant: "intl".to_string(),
+        })
+        .unwrap();
+        // Every character that previously had to fall back to clipboard
+        // paste (and was therefore broken in terminals like Alacritty)
+        // must now have a direct uinput route — either as a level 2/3
+        // AltGr key, or via the dead-key + Space fallback table.
+        for ch in [
+            '\'', '"', '~', '`', '^', 'ç', 'á', 'é', 'í', 'ó', 'ú', 'ã', 'ñ',
+        ] {
+            assert!(
+                km.lookup(ch).is_some(),
+                "'{ch}' must be reachable via uinput on us:intl, got no mapping"
+            );
+        }
     }
 
     // --- Alternative Latin layouts ---

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,19 +4,25 @@ pub mod clipboard;
 pub mod keymap;
 pub mod uinput;
 
-/// A modifier key that may need to be held during key injection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Modifier {
-    Shift,
+/// A single keypress with optional Shift and/or AltGr modifiers.
+#[derive(Debug, Clone, Copy)]
+pub struct KeyTap {
+    pub keycode: u16,
+    pub shift: bool,
+    pub altgr: bool,
 }
 
-/// Information needed to produce a character via a physical keypress.
+/// Information needed to produce a character at the cursor.
+///
+/// For most characters this is a single `KeyTap`. For characters that
+/// XKB only exposes as a dead-key combination (e.g. `ã` = `dead_tilde + a`
+/// on `us:intl`, or `'` = `dead_acute + space`), a `follow` tap is
+/// recorded so the typer emits the dead-key keypress followed by the
+/// base-letter (or space) keypress in sequence.
 #[derive(Debug, Clone, Copy)]
 pub struct KeyMapping {
-    /// The evdev keycode (physical key position).
-    pub keycode: u16,
-    /// Whether Shift must be held.
-    pub shift: bool,
+    pub main: KeyTap,
+    pub follow: Option<KeyTap>,
 }
 
 /// Trait for injecting keystrokes at the cursor.

--- a/src/input/uinput.rs
+++ b/src/input/uinput.rs
@@ -13,7 +13,7 @@ use tracing::{debug, warn};
 
 use super::clipboard::ClipboardOps;
 use super::keymap::XkbKeymap;
-use super::{ClipboardHandler, KeyInjector};
+use super::{ClipboardHandler, KeyInjector, KeyTap};
 
 /// Delay after creating the virtual device to let the kernel register it.
 const DEVICE_SETTLE_DELAY: Duration = Duration::from_millis(200);
@@ -66,38 +66,39 @@ impl UinputKeyboard {
         })
     }
 
-    /// Press and release a single key, optionally with Shift held.
-    fn tap_key(&mut self, keycode: u16, shift: bool) -> anyhow::Result<()> {
-        let key = Key::new(keycode);
+    fn set_modifier(&mut self, modifier: Key, pressed: bool) -> anyhow::Result<()> {
+        let value = if pressed { 1 } else { 0 };
+        self.device
+            .emit(&[InputEvent::new(EventType::KEY, modifier.code(), value)])?;
+        thread::sleep(self.key_delay);
+        Ok(())
+    }
 
-        if shift {
-            // Press Shift
-            self.device.emit(&[InputEvent::new(
-                EventType::KEY,
-                Key::KEY_LEFTSHIFT.code(),
-                1,
-            )])?;
-            thread::sleep(self.key_delay);
+    /// Press and release a single key, with Shift and/or AltGr held as needed.
+    ///
+    /// AltGr is `KEY_RIGHTALT`. Both modifiers can be held together for
+    /// level-3 chars on layouts like `us:intl` (e.g. Shift+AltGr+something
+    /// for less common accented forms).
+    fn tap_key(&mut self, tap: &KeyTap) -> anyhow::Result<()> {
+        if tap.shift {
+            self.set_modifier(Key::KEY_LEFTSHIFT, true)?;
+        }
+        if tap.altgr {
+            self.set_modifier(Key::KEY_RIGHTALT, true)?;
         }
 
-        // Press key
         self.device
-            .emit(&[InputEvent::new(EventType::KEY, key.code(), 1)])?;
+            .emit(&[InputEvent::new(EventType::KEY, tap.keycode, 1)])?;
+        thread::sleep(self.key_delay);
+        self.device
+            .emit(&[InputEvent::new(EventType::KEY, tap.keycode, 0)])?;
         thread::sleep(self.key_delay);
 
-        // Release key
-        self.device
-            .emit(&[InputEvent::new(EventType::KEY, key.code(), 0)])?;
-        thread::sleep(self.key_delay);
-
-        if shift {
-            // Release Shift
-            self.device.emit(&[InputEvent::new(
-                EventType::KEY,
-                Key::KEY_LEFTSHIFT.code(),
-                0,
-            )])?;
-            thread::sleep(self.key_delay);
+        if tap.altgr {
+            self.set_modifier(Key::KEY_RIGHTALT, false)?;
+        }
+        if tap.shift {
+            self.set_modifier(Key::KEY_LEFTSHIFT, false)?;
         }
 
         Ok(())
@@ -127,26 +128,14 @@ impl UinputKeyboard {
 
     /// Inject Ctrl+V to paste from clipboard.
     fn inject_ctrl_v(&mut self) -> anyhow::Result<()> {
-        // Press Ctrl
-        self.device
-            .emit(&[InputEvent::new(EventType::KEY, Key::KEY_LEFTCTRL.code(), 1)])?;
-        thread::sleep(self.key_delay);
-
-        // Press V
+        self.set_modifier(Key::KEY_LEFTCTRL, true)?;
         self.device
             .emit(&[InputEvent::new(EventType::KEY, Key::KEY_V.code(), 1)])?;
         thread::sleep(self.key_delay);
-
-        // Release V
         self.device
             .emit(&[InputEvent::new(EventType::KEY, Key::KEY_V.code(), 0)])?;
         thread::sleep(self.key_delay);
-
-        // Release Ctrl
-        self.device
-            .emit(&[InputEvent::new(EventType::KEY, Key::KEY_LEFTCTRL.code(), 0)])?;
-        thread::sleep(self.key_delay);
-
+        self.set_modifier(Key::KEY_LEFTCTRL, false)?;
         Ok(())
     }
 }
@@ -166,7 +155,14 @@ impl KeyInjector for UinputKeyboard {
                     self.paste_text(&paste_buf)?;
                     paste_buf.clear();
                 }
-                self.tap_key(mapping.keycode, mapping.shift)?;
+                self.tap_key(&mapping.main)?;
+                if let Some(follow) = mapping.follow.as_ref() {
+                    // Dead-key + follow trick: the main tap is a dead key,
+                    // the follow tap is either Space (for literal accents
+                    // like `'`) or a base letter (for accented chars like
+                    // `ã` = dead_tilde + a).
+                    self.tap_key(follow)?;
+                }
             } else {
                 // Character not in keymap — accumulate for clipboard paste.
                 paste_buf.push(ch);
@@ -185,7 +181,11 @@ impl KeyInjector for UinputKeyboard {
         self.release_all_modifiers()?;
 
         for _ in 0..count {
-            self.tap_key(Key::KEY_BACKSPACE.code(), false)?;
+            self.tap_key(&KeyTap {
+                keycode: Key::KEY_BACKSPACE.code(),
+                shift: false,
+                altgr: false,
+            })?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Replaces the previous keymap fix (which excluded level-2 keys and fell back to clipboard paste) with a proper AltGr-aware injector. The clipboard fallback was fundamentally unusable in terminal emulators like Alacritty — terminals interpret Ctrl+V as a literal control character rather than a paste action, so every accented or punctuation character routed through paste was silently dropped.

After this change, normal Portuguese and English text — including apostrophes, cedillas, tildes, and acutes — types end-to-end via uinput in any focus target, including terminal emulators.

## Why

The existing reverse keymap walked only levels 0..=1 and routed everything else (level-2 AltGr characters, dead-key combinations) through clipboard paste. That works in GUI apps but silently fails in terminals, which interpret Ctrl+V as a control character rather than a paste action. For non-English users this means most prose was being dropped.

## What changed

Three changes work together to type the full Romance-language character set entirely through uinput:

- **`KeyMapping` carries an AltGr modifier and an optional follow-tap.** `tap_key` drives `KEY_RIGHTALT` alongside `KEY_LEFTSHIFT` so level-2 (`AltGr+x`) and level-3 (`Shift+AltGr+x`) keysyms produce their real characters instead of being dropped or misrouted.
- **The keymap builder includes levels 0..=3 directly** (level-2 chars like `ç` on us:intl are now a single AltGr+key tap) and records every dead-key keysym it sees, keyed by keysym value.
- **Two fallback passes append synthetic two-tap entries** for characters the layout doesn't put at any directly-reachable level:
  - `dead_X + Space` for the literal accent characters (`'`, `"`, `~`, `` ` ``, `^`).
  - `dead_X + base_letter` for accented letters (e.g. `ã` = `dead_tilde + a` on us:intl).

  The fallbacks only install when the corresponding dead key is actually present in the active layout, and never overwrite a direct entry.

## Stacking

This branch is stacked on top of #14 (`configurable-key-delay`). It uses `self.key_delay` directly for the new AltGr modifier sleeps. Until #14 lands, this PR's diff includes both commits — once #14 merges, this rebases and shows only the AltGr commit.

## Test plan
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 170 passed (includes layout tests across 20 keyboard layouts)
- [x] Manual: end-to-end dictation in Alacritty produces correct accented Portuguese and English with apostrophes, no clipboard fallback observed
- [ ] Manual: verify `us:intl`, `br`, `es`, `fr`, `de` produce the same characters via direct mapping vs dead-key fallback as appropriate