### PR TITLE
docs: refresh user-facing docs for v0.1.8 and compact the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
-/docs
+/docs/*
+!/docs/comparison.md
+!/docs/faq.md
+!/docs/troubleshooting.md
+!/docs/version-roadmap.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /docs/*
 !/docs/comparison.md
+!/docs/configuration.md
 !/docs/faq.md
 !/docs/troubleshooting.md
 !/docs/version-roadmap.md

--- a/README.md
+++ b/README.md
@@ -289,10 +289,13 @@ whisrs is functional and usable for daily dictation. The core features work:
 - [x] Audio capture and WAV encoding
 - [x] Groq, Deepgram (REST + streaming), OpenAI REST, and OpenAI Realtime backends
 - [x] Local whisper.cpp backend (sliding window, prompt conditioning, model download)
-- [x] Layout-aware keyboard injection (uinput + XKB)
+- [x] Layout-aware keyboard injection (uinput + XKB; AltGr as a real modifier, dead-key synthesis, 20 layouts tested)
+- [x] Configurable inter-key delay for the virtual keyboard (`[input] key_delay_ms`)
 - [x] Wayland/X11 clipboard with save/restore
 - [x] Window tracking (Hyprland, Sway, X11, GNOME, KDE)
 - [x] Desktop notifications and audio feedback
+- [x] OSD overlay (themed bottom-screen pill, envelope-follower bar visualizer; bundled GNOME Shell extension for GNOME Wayland)
+- [x] Free-form transcription prompt (`prompt = "..."` in config, combined with vocabulary)
 - [x] Interactive setup with LLM provider selection
 - [x] Filler word removal
 - [x] Transcription history (`whisrs log`)

--- a/README.md
+++ b/README.md
@@ -133,120 +133,27 @@ bindsym $mod+w exec whisrs toggle
 | **OpenAI REST** | Cloud | Batch | Paid | Simple fallback |
 | **Local whisper.cpp** | Local (CPU/GPU) | Sliding window | Free | Privacy, offline use |
 
-Groq is the default. Fast, free tier, good accuracy with `whisper-large-v3-turbo`.
-
-Deepgram offers $200 in free credits on signup (no credit card required) and supports 60+ languages with the Nova-3 model. The streaming backend provides true real-time transcription over WebSocket.
-
-OpenAI Realtime is the premium option: true streaming over WebSocket means text appears at your cursor while you're still speaking.
-
-### Local whisper.cpp
-
-Run transcription entirely on your machine. No API key, no internet, no data leaves your device. Included in every build.
-
-```bash
-whisrs setup   # select Local > whisper.cpp, pick a model, download automatically
-```
-
-| Model | Size | RAM | Speed (CPU) | Accuracy |
-|---|---|---|---|---|
-| tiny.en | 75 MB | ~273 MB | Real-time | Decent |
-| base.en | 142 MB | ~388 MB | Real-time | Good (recommended) |
-| small.en | 466 MB | ~852 MB | Borderline | Very good |
+Groq is the default. For fully offline use, run `whisrs setup` and select **Local > whisper.cpp** — `base.en` (142 MB, ~388 MB RAM) is recommended; `tiny.en` (75 MB) for low-end hardware, `small.en` (466 MB) for higher accuracy.
 
 ---
 
 ## Configuration
 
-Config file: `~/.config/whisrs/config.toml`
+Config file: `~/.config/whisrs/config.toml` — `whisrs setup` writes a working file. A minimal example:
 
 ```toml
 [general]
-backend = "groq"            # groq | deepgram-streaming | deepgram | openai-realtime | openai | local-whisper
-language = "en"             # ISO 639-1 or "auto"
-silence_timeout_ms = 2000   # auto-stop after silence (streaming only)
-notify = true               # desktop notifications
-remove_filler_words = true  # strip "um", "uh", "you know", etc.
-filler_words = []           # custom list (empty = use built-in defaults)
-audio_feedback = true       # play tones on record start/stop/done
-audio_feedback_volume = 0.5 # 0.0 to 1.0
-vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription accuracy
-prompt = "Speech is in English or Spanish. Transcribe in the language spoken; never translate."  # optional sentence-style context, prepended to vocabulary
-tray = true                 # system tray icon (requires SNI host like waybar)
-overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
-
-# Optional — controls overlay appearance when enabled.
-# Defaults to a 100×40 pill with the "carbon" theme.
-# When the overlay is on, recording/transcribing toast notifications are
-# auto-suppressed (errors still pop) so the same event isn't double-signaled.
-[overlay]
-theme = "carbon"            # "carbon" (default) | "ember" | "cyan" | "custom"
-width = 100                 # 90..=120 (clamped)
-height = 40                 # 36..=48 (clamped)
-
-# When theme = "custom", these override the named theme. Hex strings:
-# #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to carbon.
-# [overlay.colors]
-# background   = "#0E0E10EB"
-# ring         = "#3A3A4050"
-# recording    = "#F0EDF5"
-# transcribing = "#9CA3AF"
-# glow         = "#F0EDF5"
-
-[audio]
-device = "default"
-
-[input]
-# Inter-key delay for the virtual keyboard (uinput). Raise this if a TUI
-# drops characters while whisrs is typing — e.g. Node/Ink-based apps like
-# Claude Code in raw mode. Default: 2.
-key_delay_ms = 2
+backend = "groq"   # groq | deepgram-streaming | deepgram | openai-realtime | openai | local-whisper
+language = "en"    # ISO 639-1 or "auto"
+overlay = false    # bottom-screen recording overlay
 
 [groq]
 api_key = "gsk_..."
-model = "whisper-large-v3-turbo"
-
-[deepgram]
-api_key = "..."
-model = "nova-3"
-
-[openai]
-api_key = "sk-..."
-model = "gpt-4o-mini-transcribe"
-
-[local-whisper]
-model_path = "~/.local/share/whisrs/models/ggml-base.en.bin"
-
-# Command mode: LLM for voice-driven text rewriting
-[llm]
-api_key = "sk-..."
-model = "gpt-4o-mini"
-api_url = "https://api.openai.com/v1/chat/completions"
-
-# Built-in global hotkeys (optional, works without WM keybinds)
-[hotkeys]
-toggle = "Super+Shift+W"
-cancel = "Super+Shift+D"
-command = "Super+Shift+G"
 ```
 
-Environment variable overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, `WHISRS_OPENAI_API_KEY`
+Env-var overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, `WHISRS_OPENAI_API_KEY`.
 
-### GNOME overlay
-
-GNOME Wayland does not support the wlroots layer-shell protocol used by Hyprland
-and Sway. To use `overlay = true` on GNOME, install the bundled GNOME Shell
-extension:
-
-```bash
-mkdir -p ~/.local/share/gnome-shell/extensions
-cp -r contrib/gnome-shell-extension/whisrs-overlay@eresende.github \
-  ~/.local/share/gnome-shell/extensions/
-gnome-extensions enable whisrs-overlay@eresende.github
-systemctl --user restart whisrs.service
-```
-
-If GNOME has not discovered the extension yet, log out and back in, then run the
-`gnome-extensions enable` command again.
+For the full reference (overlay, `[input]`, `[llm]`, `[hotkeys]`, GNOME extension setup), see [docs/configuration.md](docs/configuration.md).
 
 ---
 
@@ -272,7 +179,7 @@ whisrs log --clear  # Clear all history
 | **Hyprland** | Tested, full support |
 | **Sway / i3** | Implemented, needs community testing |
 | **X11 (any WM)** | Implemented, needs community testing |
-| **GNOME Wayland** | Limited window tracking; overlay requires bundled GNOME Shell extension |
+| **GNOME Wayland** | Limited window tracking; overlay requires the bundled [GNOME Shell extension](contrib/gnome-shell-extension/README.md) |
 | **KDE Wayland** | Implemented via D-Bus, needs community testing |
 | **Audio** | PipeWire, PulseAudio, ALSA (auto-detected via cpal) |
 | **Distros** | Any Linux with the system dependencies above |
@@ -283,30 +190,9 @@ whisrs log --clear  # Clear all history
 
 ## Project Status
 
-whisrs is functional and usable for daily dictation. The core features work:
+whisrs is functional and usable for daily dictation. Streaming transcription, command mode, multi-language support, system tray, OSD overlay, layout-aware injection (incl. AltGr + dead keys), and packaging for AUR / Nix / crates.io all ship today. Local Vosk and Parakeet backends are next.
 
-- [x] Daemon + CLI architecture
-- [x] Audio capture and WAV encoding
-- [x] Groq, Deepgram (REST + streaming), OpenAI REST, and OpenAI Realtime backends
-- [x] Local whisper.cpp backend (sliding window, prompt conditioning, model download)
-- [x] Layout-aware keyboard injection (uinput + XKB; AltGr as a real modifier, dead-key synthesis, 20 layouts tested)
-- [x] Configurable inter-key delay for the virtual keyboard (`[input] key_delay_ms`)
-- [x] Wayland/X11 clipboard with save/restore
-- [x] Window tracking (Hyprland, Sway, X11, GNOME, KDE)
-- [x] Desktop notifications and audio feedback
-- [x] OSD overlay (themed bottom-screen pill, envelope-follower bar visualizer; bundled GNOME Shell extension for GNOME Wayland)
-- [x] Free-form transcription prompt (`prompt = "..."` in config, combined with vocabulary)
-- [x] Interactive setup with LLM provider selection
-- [x] Filler word removal
-- [x] Transcription history (`whisrs log`)
-- [x] Multi-language support (18 languages + auto-detect)
-- [x] Custom vocabulary for improved transcription accuracy
-- [x] LLM command mode (select text + voice instruction → rewrite)
-- [x] System tray indicator (idle/recording/transcribing)
-- [x] Configurable global hotkeys via evdev
-- [x] Packaging ([AUR](https://aur.archlinux.org/packages/whisrs-git), Nix flake, crates.io)
-- [ ] Local Vosk backend
-- [ ] Local Parakeet backend (NVIDIA)
+Per-release details: [docs/version-roadmap.md](docs/version-roadmap.md).
 
 ---
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -5,7 +5,7 @@
 | **Platform** | Linux | Linux | Linux | macOS only |
 | **Wayland support** | Yes (native) | Partial (xdotool) | Yes (GUI app) | N/A |
 | **Offline transcription** | Yes (whisper.cpp) | Yes (VOSK) | Yes (multiple) | No |
-| **Cloud transcription** | Groq, OpenAI, OpenAI Realtime | No | No | Proprietary |
+| **Cloud transcription** | Groq, Deepgram (REST + streaming), OpenAI, OpenAI Realtime | No | No | Proprietary |
 | **True streaming** | Yes (OpenAI Realtime) | No | No | Yes |
 | **Keyboard injection** | uinput + XKB (layout-aware) | xdotool | Clipboard paste | Native |
 | **Window tracking** | Hyprland, Sway, X11, GNOME, KDE | No | No | Native |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,94 @@
+# Configuration
+
+Config file: `~/.config/whisrs/config.toml` (permissions: `0600`).
+
+The interactive `whisrs setup` will write a working file for you. The reference below documents every section.
+
+## Full config reference
+
+```toml
+[general]
+backend = "groq"            # groq | deepgram-streaming | deepgram | openai-realtime | openai | local-whisper
+language = "en"             # ISO 639-1 or "auto"
+silence_timeout_ms = 2000   # auto-stop after silence (streaming only)
+notify = true               # desktop notifications
+remove_filler_words = true  # strip "um", "uh", "you know", etc.
+filler_words = []           # custom list (empty = use built-in defaults)
+audio_feedback = true       # play tones on record start/stop/done
+audio_feedback_volume = 0.5 # 0.0 to 1.0
+vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription accuracy
+prompt = "Speech is in English or Spanish. Transcribe in the language spoken; never translate."
+                            # optional sentence-style context, prepended to vocabulary
+                            # (passed to Groq, OpenAI REST/Realtime, and local whisper.cpp;
+                            # Deepgram does not accept a prompt)
+tray = true                 # system tray icon (requires SNI host like waybar)
+overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
+
+# Optional — controls overlay appearance when enabled.
+# Defaults to a 100×40 pill with the "carbon" theme.
+# When the overlay is on, recording/transcribing toast notifications are
+# auto-suppressed (errors still pop) so the same event isn't double-signaled.
+[overlay]
+theme = "carbon"            # "carbon" (default) | "ember" | "cyan" | "custom"
+width = 100                 # 90..=120 (clamped)
+height = 40                 # 36..=48 (clamped)
+
+# When theme = "custom", these override the named theme. Hex strings:
+# #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to carbon.
+# [overlay.colors]
+# background   = "#0E0E10EB"
+# ring         = "#3A3A4050"
+# recording    = "#F0EDF5"
+# transcribing = "#9CA3AF"
+# glow         = "#F0EDF5"
+
+[audio]
+device = "default"
+
+[input]
+# Inter-key delay for the virtual keyboard (uinput). Raise this if a TUI
+# drops characters while whisrs is typing — e.g. Node/Ink-based apps like
+# Claude Code in raw mode. Default: 2.
+key_delay_ms = 2
+
+[groq]
+api_key = "gsk_..."
+model = "whisper-large-v3-turbo"
+
+[deepgram]
+api_key = "..."
+model = "nova-3"
+
+[openai]
+api_key = "sk-..."
+model = "gpt-4o-mini-transcribe"
+
+[local-whisper]
+model_path = "~/.local/share/whisrs/models/ggml-base.en.bin"
+
+# Command mode: LLM for voice-driven text rewriting
+[llm]
+api_key = "sk-..."
+model = "gpt-4o-mini"
+api_url = "https://api.openai.com/v1/chat/completions"
+
+# Built-in global hotkeys (optional, works without WM keybinds)
+[hotkeys]
+toggle = "Super+Shift+W"
+cancel = "Super+Shift+D"
+command = "Super+Shift+G"
+```
+
+## Environment variables
+
+The following variables override the matching `api_key` in `config.toml`:
+
+- `WHISRS_GROQ_API_KEY`
+- `WHISRS_DEEPGRAM_API_KEY`
+- `WHISRS_OPENAI_API_KEY`
+
+`RUST_LOG` controls daemon log verbosity (e.g. `RUST_LOG=debug whisrsd`).
+
+## GNOME overlay
+
+GNOME Wayland does not support the wlroots layer-shell protocol used by Hyprland and Sway. To use `overlay = true` on GNOME, install the bundled GNOME Shell extension — see [`contrib/gnome-shell-extension/README.md`](../contrib/gnome-shell-extension/README.md) for install and update instructions.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,7 +7,7 @@ Yes. whisrs has native support for Wayland compositors including Hyprland, Sway,
 Yes. The local whisper.cpp backend runs transcription entirely on your machine. No API key, no internet connection, and no audio data leaves your device. Run `whisrs setup` and select the local backend to get started.
 
 **What speech recognition backends does whisrs support?**
-Four backends: Groq (cloud, free tier), OpenAI REST (cloud), OpenAI Realtime (cloud, true streaming over WebSocket), and local whisper.cpp (offline, CPU/GPU). More local backends (Vosk, Parakeet) are planned.
+Six backends: Groq (cloud, free tier), Deepgram Nova REST and Streaming (cloud, 60+ languages, $200 free credit on signup), OpenAI REST (cloud), OpenAI Realtime (cloud, true streaming over WebSocket), and local whisper.cpp (offline, CPU/GPU). More local backends (Vosk, Parakeet) are planned.
 
 **How does whisrs type text into applications?**
 whisrs creates a virtual keyboard using Linux's uinput subsystem and performs XKB reverse lookups to find the correct keycode and modifier combination for each character. This means it respects your keyboard layout and works in any application, including terminals, editors, and browsers.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,57 @@
+# Troubleshooting
+
+## /dev/uinput permission denied
+
+Copy the udev rule and add yourself to the `input` group:
+
+```bash
+sudo cp contrib/99-whisrs.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules && sudo udevadm trigger
+sudo usermod -aG input $USER
+```
+
+Log out and back in for the group change to take effect.
+
+## No microphone detected
+
+Verify your mic is recognized: `arecord -l`. If nothing shows up, make sure ALSA or PulseAudio/PipeWire is installed and your mic is not muted. On PipeWire systems, install `pipewire-alsa` for ALSA compatibility.
+
+## API key errors (401 Unauthorized)
+
+Double-check your key is valid and not expired. Ensure the correct environment variable is set (`WHISRS_GROQ_API_KEY` or `WHISRS_OPENAI_API_KEY`), or that the key in `~/.config/whisrs/config.toml` is correct. Re-run `whisrs setup` to reconfigure.
+
+## Text goes to the wrong window
+
+whisrs captures the focused window when recording starts and restores focus before typing. This requires compositor support. See the [Supported Environments](../README.md#supported-environments) table. On GNOME Wayland, the `window-calls` extension is required.
+
+## TUI drops characters while whisrs types
+
+Some Node/Ink-based terminal UIs (e.g. Claude Code in raw mode) can drop characters when whisrs injects text quickly. Raise the inter-key delay in `~/.config/whisrs/config.toml`:
+
+```toml
+[input]
+key_delay_ms = 6   # default is 2; try 4–10 if characters get dropped
+```
+
+Restart the daemon for the change to take effect.
+
+## Daemon not running
+
+Start the daemon manually (`whisrsd`) or via systemd:
+
+```bash
+systemctl --user start whisrs.service
+systemctl --user status whisrs.service
+```
+
+If it fails, check logs with `journalctl --user -u whisrs.service` or run `RUST_LOG=debug whisrsd` in the foreground.
+
+## Model download fails (local whisper)
+
+If automatic download during `whisrs setup` fails, download the model manually from HuggingFace:
+
+```
+https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+```
+
+Place it in `~/.local/share/whisrs/models/` and update `model_path` in your config.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ Verify your mic is recognized: `arecord -l`. If nothing shows up, make sure ALSA
 
 ## API key errors (401 Unauthorized)
 
-Double-check your key is valid and not expired. Ensure the correct environment variable is set (`WHISRS_GROQ_API_KEY` or `WHISRS_OPENAI_API_KEY`), or that the key in `~/.config/whisrs/config.toml` is correct. Re-run `whisrs setup` to reconfigure.
+Double-check your key is valid and not expired. Ensure the correct environment variable is set (`WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, or `WHISRS_OPENAI_API_KEY`), or that the key in `~/.config/whisrs/config.toml` is correct. Re-run `whisrs setup` to reconfigure.
 
 ## Text goes to the wrong window
 

--- a/docs/version-roadmap.md
+++ b/docs/version-roadmap.md
@@ -1,6 +1,7 @@
-# whisrs — Version Roadmap (0.1.2 → 0.1.5)
+# whisrs — Version Roadmap
 
-Incremental feature releases building toward v1.5.
+Incremental feature releases. Earlier entries (v0.1.2 → v0.1.5) are kept here as a
+historical record; current development happens against the v0.1.x patch line.
 
 ---
 
@@ -40,17 +41,34 @@ Incremental feature releases building toward v1.5.
 
 ---
 
-## v0.1.6 — Local Vosk Backend
+## v0.1.6 — Stability fixes ✓
 
-- [ ] **Vosk backend**: CPU-only local speech recognition via `vosk` crate — true streaming, small models (~40 MB), works on Intel (no GPU required)
-- [ ] Final polish pass
+- [x] **Tray icon on boot fix** (#1): Tray icon now appears reliably when the daemon starts at session login.
+- [x] **Text injection on systems with brltty** (#2): Resolved a uinput ACL conflict that prevented text injection when brltty was active.
+- [x] **Hotkeys / command mode on boot fix** (#3): Hotkey listener and command mode now retry/wait for input devices to be available at session start instead of failing silently.
 
 ---
 
-## Deferred
+## v0.1.7 — Deepgram + Unicode safety ✓
 
-- **Parakeet backend** — requires NVIDIA GPU
-- **Cross-compositor testing** — community/contributor effort
-- **Non-QWERTY layout testing** — later
-- **Demo GIF** — later
-- **Anthropic LLM support** — Anthropic uses a different API format (`/v1/messages` instead of `/v1/chat/completions`). Need to add an adapter in `llm.rs` to support the Messages API. Users can access Anthropic models via OpenRouter in the meantime.
+- [x] **Deepgram backend** (#8): New cloud transcription backend with both REST (Nova) and true WebSocket streaming variants. 60+ languages, $200 free credit on signup. Configured via `backend = "deepgram"` / `backend = "deepgram-streaming"`.
+- [x] **Cyrillic / non-ASCII notification panic fix** (#7): Notifications no longer panic when transcribed text contains multi-byte UTF-8 characters; truncation is now codepoint-aware. Tests cover Arabic, CJK, Cyrillic, emoji, and mixed scripts.
+
+---
+
+## v0.1.8 — Overlay, AltGr typing, configurable injection ✓
+
+- [x] **OSD overlay & GNOME Shell extension** (#11): Themed Wispr-Flow-inspired pill overlay (carbon / ember / cyan / custom) with envelope-follower bar visualizer, spring smoothing at 60fps, and a bundled GNOME Shell extension for GNOME Wayland (which lacks layer-shell). Configured via `overlay = true` and the `[overlay]` section. Toast notifications are auto-suppressed when the overlay is on.
+- [x] **AltGr as a real modifier + dead-key synthesis** (#15): The keyboard injector now drives AltGr as a true modifier and synthesizes dead-key combinations, so layouts that depend on AltGr (e.g., proper diacritics in many European layouts) type correctly.
+- [x] **Free-form transcription prompt** (#13): New `prompt = "..."` field in `[general]`, prepended to vocabulary and wired into the OpenAI Realtime backend. Refactored `build_transcription_config` helper.
+- [x] **Configurable uinput key delay** (#14): New `[input] key_delay_ms = 2` setting — raise it for TUIs (Node/Ink-based apps in raw mode like Claude Code) that drop characters during fast injection.
+- [x] **Keyboard layout detection fix + tests** (#10): Fixed layout detection for non-US layouts; added comprehensive layout tests covering 20 layouts (French, Dvorak, Colemak, Spanish, and more).
+
+---
+
+## Upcoming
+
+- [ ] **Local Vosk backend**: CPU-only local speech recognition via `vosk` crate — true streaming, small models (~40 MB), works on Intel (no GPU required)
+- [ ] **Parakeet backend** — requires NVIDIA GPU
+- [ ] **Cross-compositor testing** — community/contributor effort
+- [ ] **Anthropic LLM support** — Anthropic uses a different API format (`/v1/messages` instead of `/v1/chat/completions`). Need to add an adapter in `llm.rs` to support the Messages API. Users can access Anthropic models via OpenRouter in the meantime.

--- a/docs/version-roadmap.md
+++ b/docs/version-roadmap.md
@@ -60,7 +60,7 @@ historical record; current development happens against the v0.1.x patch line.
 
 - [x] **OSD overlay & GNOME Shell extension** (#11): Themed Wispr-Flow-inspired pill overlay (carbon / ember / cyan / custom) with envelope-follower bar visualizer, spring smoothing at 60fps, and a bundled GNOME Shell extension for GNOME Wayland (which lacks layer-shell). Configured via `overlay = true` and the `[overlay]` section. Toast notifications are auto-suppressed when the overlay is on.
 - [x] **AltGr as a real modifier + dead-key synthesis** (#15): The keyboard injector now drives AltGr as a true modifier and synthesizes dead-key combinations, so layouts that depend on AltGr (e.g., proper diacritics in many European layouts) type correctly.
-- [x] **Free-form transcription prompt** (#13): New `prompt = "..."` field in `[general]`, prepended to vocabulary and wired into the OpenAI Realtime backend. Refactored `build_transcription_config` helper.
+- [x] **Free-form transcription prompt** (#13): New `prompt = "..."` field in `[general]`, prepended to vocabulary and wired through `build_transcription_config` into Groq, OpenAI REST, OpenAI Realtime, and local whisper.cpp (Deepgram does not accept a prompt). Refactored `build_transcription_config` helper.
 - [x] **Configurable uinput key delay** (#14): New `[input] key_delay_ms = 2` setting — raise it for TUIs (Node/Ink-based apps in raw mode like Claude Code) that drop characters during fast injection.
 - [x] **Keyboard layout detection fix + tests** (#10): Fixed layout detection for non-US layouts; added comprehensive layout tests covering 20 layouts (French, Dvorak, Colemak, Spanish, and more).
 


### PR DESCRIPTION
## Summary

- **Catch up the docs to v0.1.8.** README Project Status, `docs/version-roadmap.md`, `docs/comparison.md`, and `docs/faq.md` now reflect everything shipped through v0.1.8 (Deepgram REST + streaming, OSD overlay + GNOME Shell extension, AltGr-as-modifier with dead-key synthesis, free-form transcription prompt, configurable uinput key delay, 20-layout keyboard tests).
- **Fix a broken README link.** `docs/troubleshooting.md` was referenced from the README but excluded by `.gitignore`. Switched the gitignore to `/docs/*` with an explicit allowlist for the four user-facing docs, so the link now resolves on GitHub. Internal planning notes (`architecture.md`, `features.md`, `plan.md`, etc.) stay local-only as intended.
- **Compact the README.** Down from ~339 to ~225 lines (-34%): dropped duplicated Backends prose, replaced the ~70-line config block with a 5-key example + link to the new `docs/configuration.md`, replaced the 22-bullet Project Status checklist with a one-paragraph summary + link to the per-release roadmap, and moved the GNOME overlay install snippet out of README into the existing `contrib/gnome-shell-extension/README.md`.
- **Add `docs/configuration.md`** as the full TOML reference (every section and key, env-var overrides, GNOME overlay pointer). Cross-checked field-by-field against the `Config` struct in `src/lib.rs`.
- **Two follow-up corrections from review:** clarify that the v0.1.8 transcription prompt flows through Groq, OpenAI REST/Realtime, and local whisper.cpp (Deepgram skips it); add `WHISRS_DEEPGRAM_API_KEY` to the troubleshooting env-var list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)