### PR TITLE
ci: build Linux release tarballs on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,26 @@ jobs:
 
       - name: Test
         run: cargo test
+
+  release-build:
+    name: Release build — ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: full (default features)
+            features: ""
+          - name: minimal (--no-default-features)
+            features: "--no-default-features"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libxkbcommon-dev pkg-config
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Release build
+        run: cargo build --release ${{ matrix.features }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build — ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: Linux x86_64
+            target: x86_64-unknown-linux-gnu
+            artifact: whisrs-linux-x86_64
+            features: ""
+          - name: Linux x86_64 (no local-whisper)
+            target: x86_64-unknown-linux-gnu
+            artifact: whisrs-linux-x86_64-minimal
+            features: "--no-default-features"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libxkbcommon-dev pkg-config
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}
+
+      - name: Package
+        run: |
+          mkdir -p staging
+          cp target/${{ matrix.target }}/release/whisrs staging/
+          cp target/${{ matrix.target }}/release/whisrsd staging/
+          cp README.md LICENSE staging/
+          cp -r contrib staging/
+          cd staging
+          tar czf ../${{ matrix.artifact }}.tar.gz *
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*

--- a/README.md
+++ b/README.md
@@ -44,7 +44,31 @@ The install script handles everything: detects your distro, installs system depe
 After install, **press your hotkey** to start recording, **press again** to stop. Text appears at your cursor.
 
 <details>
-<summary><b>Other install methods (AUR, Cargo, Nix, manual)</b></summary>
+<summary><b>Other install methods (pre-built binary, AUR, Cargo, Nix, manual)</b></summary>
+
+### Pre-built binary (Linux x86_64)
+
+Each tagged release publishes a tarball on [GitHub Releases](https://github.com/y0sif/whisrs/releases/latest) with both `whisrs` and `whisrsd` plus the contrib files (udev rule, systemd unit, man pages).
+
+```bash
+# Full build (cloud + local whisper.cpp)
+curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-x86_64.tar.gz
+
+# Or the minimal build (cloud backends only — smaller, no whisper.cpp)
+curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-x86_64-minimal.tar.gz
+
+tar xzf whisrs.tar.gz
+sudo install -m755 whisrs whisrsd /usr/local/bin/
+sudo install -m644 contrib/99-whisrs.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules && sudo udevadm trigger
+sudo usermod -aG input $USER   # log out / back in for the group change
+whisrs setup
+```
+
+| Variant | Includes local whisper.cpp | Tarball |
+|---|---|---|
+| `whisrs-linux-x86_64.tar.gz` | yes | full build |
+| `whisrs-linux-x86_64-minimal.tar.gz` | no (cloud backends only) | minimal build |
 
 ### Arch Linux (AUR)
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` that fires on `v*` tags and publishes a GitHub Release with two prebuilt Linux x86_64 tarballs:
  - `whisrs-linux-x86_64.tar.gz` — full build (default features, includes local whisper.cpp)
  - `whisrs-linux-x86_64-minimal.tar.gz` — `--no-default-features`, cloud backends only
- Each tarball bundles both binaries (`whisrs`, `whisrsd`), `README.md`, `LICENSE`, and the entire `contrib/` tree (udev rule, systemd unit, man pages, GNOME Shell extension) so a fresh install is `install` → udev reload → `whisrs setup`.
- Adapted from the postponed `feat/cross-platform` branch — Linux-only for now; the Windows / macOS matrix entries stay parked there until cross-platform work is revived.
- README install section gains a **Pre-built binary (Linux x86_64)** entry inside the existing collapsible block, with a `curl` one-liner per variant and the post-install steps.

## Test plan

- [ ] Push the next `v0.1.x` tag and confirm both tarballs land on the release page
- [ ] Download `whisrs-linux-x86_64.tar.gz` on a clean host, run the README's curl-then-install flow, and verify `whisrs setup` completes
- [ ] Repeat the smoke test with the `-minimal` tarball and confirm cloud backends work without a C++ toolchain present
- [ ] Verify the workflow does not run on regular branch pushes (tag-only trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)