### PR TITLE
docs: optimize README and Cargo metadata for SEO + LLM discoverability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 name = "whisrs"
 version = "0.1.9"
 edition = "2021"
-description = "Linux-first voice-to-text dictation tool with Groq, OpenAI, and local Whisper backends"
+description = "Open source Wispr Flow alternative for Linux — voice dictation for Wayland, X11, Hyprland, Sway, GNOME, KDE with offline whisper.cpp and cloud backends"
 license = "MIT"
 repository = "https://github.com/y0sif/whisrs"
 homepage = "https://y0sif.github.io/whisrs/"
-keywords = ["voice", "dictation", "speech-to-text", "whisper", "linux"]
+keywords = ["dictation", "speech-to-text", "whisper", "linux", "wayland"]
 categories = ["multimedia::audio", "accessibility", "command-line-utilities"]
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 [![Crates.io](https://img.shields.io/crates/v/whisrs)](https://crates.io/crates/whisrs)
 [![docs.rs](https://img.shields.io/docsrs/whisrs)](https://docs.rs/whisrs)
 
-**Linux-first voice-to-text dictation tool, written in Rust.**
+**The open source Wispr Flow alternative for Linux.** Voice-to-text dictation for Wayland, X11, Hyprland, Sway, GNOME, and KDE — written in Rust.
 
-Speech-to-text for Wayland, X11, Hyprland, Sway, GNOME, and KDE. Press a hotkey, speak, and your words appear at the cursor. Works with any app, any window manager, any desktop environment. Supports cloud transcription (Groq, Deepgram, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source.
+Press a hotkey, speak, and your words appear at the cursor in any focused app. Supports cloud transcription (Groq, Deepgram, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source.
 
 ---
 
@@ -238,7 +238,24 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and project structu
 
 ---
 
-## [How whisrs Compares](docs/comparison.md)
+## How whisrs Compares to Wispr Flow and Other Dictation Tools
+
+whisrs is the open source alternative to closed-source dictation apps like **Wispr Flow** and **Superwhisper**, neither of which ships a Linux client. The closest open-source equivalents include [nerd-dictation](https://github.com/ideasman42/nerd-dictation), [Speech Note](https://github.com/mkiol/dsnote), and the cross-platform [Handy](https://github.com/cjpais/Handy). Head-to-head against the Linux-native options:
+
+| Feature | whisrs | [nerd-dictation](https://github.com/ideasman42/nerd-dictation) | [Speech Note](https://github.com/mkiol/dsnote) | [Wispr Flow](https://wisprflow.ai/) |
+|---|---|---|---|---|
+| **Platform** | Linux | Linux | Linux | macOS, Windows (no Linux) |
+| **Wayland support** | Yes (native) | Partial (xdotool) | Yes (GUI app) | N/A |
+| **Offline transcription** | Yes (whisper.cpp) | Yes (Vosk) | Yes (multiple) | No |
+| **Cloud transcription** | Groq, Deepgram (REST + streaming), OpenAI, OpenAI Realtime | No | No | Proprietary |
+| **True streaming** | Yes (OpenAI Realtime) | No | No | Yes |
+| **Keyboard injection** | uinput + XKB (layout-aware) | xdotool | Clipboard paste | Native |
+| **Window tracking** | Hyprland, Sway, X11, GNOME, KDE | No | No | Native |
+| **Architecture** | Daemon + CLI (bind to any hotkey) | Script | GUI app | GUI app |
+| **Language** | Rust | Python | C++/Qt | Closed source |
+| **Setup** | Interactive (`whisrs setup`) | Manual config | GUI | Installer |
+
+For the full comparison, see [docs/comparison.md](docs/comparison.md).
 
 ## [FAQ](docs/faq.md)
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,11 @@ whisrs log --clear  # Clear all history
 
 ---
 
+<a id="supported-environments"></a>
+
 ## Does whisrs work on Wayland, GNOME, KDE, Hyprland, and Sway?
 
-Yes. whisrs runs natively on both Wayland and X11 across 5 desktop environments — Hyprland, Sway/i3, GNOME Wayland, KDE Wayland, and any X11 window manager — with daily-driver coverage on Hyprland and community-confirmed reports on GNOME Wayland and Xorg. Audio capture works on PipeWire, PulseAudio, and ALSA via cpal.
+Yes. whisrs runs natively on both Wayland and X11 across Hyprland, Sway, i3, GNOME Wayland, KDE Wayland, and any X11 window manager — with daily-driver coverage on Hyprland and community-confirmed reports on GNOME Wayland and Xorg. Audio capture works on PipeWire, PulseAudio, and ALSA via cpal.
 
 | Component | Support |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 [![Crates.io](https://img.shields.io/crates/v/whisrs)](https://crates.io/crates/whisrs)
 [![docs.rs](https://img.shields.io/docsrs/whisrs)](https://docs.rs/whisrs)
 
-**The open source Wispr Flow alternative for Linux.** Voice-to-text dictation for Wayland, X11, Hyprland, Sway, GNOME, and KDE — written in Rust.
+**whisrs is a Linux voice-to-text dictation tool written in Rust that transcribes speech via 6 backends — Groq, Deepgram REST, Deepgram Streaming, OpenAI REST, OpenAI Realtime, and local whisper.cpp — and types it into the focused window. It is the open-source Wispr Flow alternative for Linux.**
 
-Press a hotkey, speak, and your words appear at the cursor in any focused app. Supports cloud transcription (Groq, Deepgram, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source.
+Press a hotkey, speak, and your words appear at the cursor in any focused app on Wayland, X11, Hyprland, Sway, GNOME, or KDE. Audio is captured via cpal across PipeWire, PulseAudio, and ALSA. Fully offline local transcription runs in under 500 MB of RAM with `base.en`. Fast, private, open source.
 
 ---
 
-## Why whisrs?
+## How does whisrs differ from Wispr Flow and Superwhisper?
 
-Dictation tools like Wispr Flow and Superwhisper are not available on Linux. [xhisper](https://github.com/imaginalnika/xhisper) proved the concept works, but I kept running into limitations. whisrs takes that idea and rebuilds it in Rust as a single async process with native keyboard layout support, window tracking, and multiple transcription backends.
+Wispr Flow and Superwhisper are closed-source dictation apps that don't run on Linux. whisrs is open source (MIT), Linux-native, and ships as a single async Rust process with native keyboard layout support (uinput + XKB), window tracking across Hyprland, Sway, X11, GNOME, and KDE, and 6 swappable transcription backends — both cloud (Groq, Deepgram, OpenAI) and fully offline (whisper.cpp). [xhisper](https://github.com/imaginalnika/xhisper) proved the concept on Linux; whisrs rebuilds it from scratch in Rust with broader compositor support and a daemon/CLI architecture you can bind to any hotkey.
 
 ---
 
@@ -146,7 +146,7 @@ bindsym $mod+w exec whisrs toggle
 
 ---
 
-## Transcription Backends
+## What transcription backends does whisrs support?
 
 | Backend | Type | Streaming | Cost | Best for |
 |---|---|---|---|---|
@@ -196,7 +196,9 @@ whisrs log --clear  # Clear all history
 
 ---
 
-## Supported Environments
+## Does whisrs work on Wayland, GNOME, KDE, Hyprland, and Sway?
+
+Yes. whisrs runs natively on both Wayland and X11 across 5 desktop environments — Hyprland, Sway/i3, GNOME Wayland, KDE Wayland, and any X11 window manager — with daily-driver coverage on Hyprland and community-confirmed reports on GNOME Wayland and Xorg. Audio capture works on PipeWire, PulseAudio, and ALSA via cpal.
 
 | Component | Support |
 |---|---|

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,7 +13,7 @@ Six backends: Groq (cloud, free tier), Deepgram Nova REST and Streaming (cloud, 
 whisrs creates a virtual keyboard using Linux's uinput subsystem and performs XKB reverse lookups to find the correct keycode and modifier combination for each character. This means it respects your keyboard layout and works in any application, including terminals, editors, and browsers.
 
 **Is whisrs a replacement for Wispr Flow or Superwhisper on Linux?**
-Yes. Wispr Flow and Superwhisper are macOS-only dictation tools. whisrs brings the same workflow to Linux: press a hotkey, speak, and text appears at your cursor. It supports both cloud and local transcription backends.
+Yes. Wispr Flow ships clients for macOS and Windows; Superwhisper is macOS-only. Neither has a Linux client. whisrs brings the same workflow to Linux: press a hotkey, speak, and text appears at your cursor. It supports both cloud and local transcription backends.
 
 **What Linux distributions does whisrs support?**
 whisrs works on any Linux distribution with the required system dependencies (alsa-lib, libxkbcommon, clang, cmake). It has been primarily tested on Arch Linux but also supports Debian/Ubuntu, Fedora, NixOS, and others. Install methods include AUR, cargo, Nix flake, and a universal install script.


### PR DESCRIPTION
## Summary

Improves how whisrs surfaces in Google searches and LLM (ChatGPT / Claude / Perplexity / Gemini) recommendations for queries like *"Wispr Flow alternative for Linux"* or *"voice dictation for Wayland"*. All changes are docs/metadata only — no Rust source touched.

The branch lands in three commits:

1. **`d29b5f6` — Wispr Flow positioning.** README headline and Cargo description now lead with *"open source Wispr Flow alternative for Linux"*. The comparison table is inlined under a keyword-dense H2 (`How whisrs Compares to Wispr Flow and Other Dictation Tools`) so retrieval engines see the alternative names co-occur with whisrs in the same chunk. Cargo description trimmed to 151 chars (fits the ~150–160 SERP truncation window). `voice` keyword swapped for `wayland` — more discriminating for the Linux audience while *voice dictation* still appears verbatim in the description.

2. **`882297e` — Definition-first lead and question-shaped H2s.** Applies 2026 GEO/AEO patterns derived from empirical citation studies (Princeton GEO arxiv, ChatGPT/Perplexity citation breakdowns, RAG retriever chunking behavior):
   - Opening sentence rewritten as a single entity-dense definition LLMs lift verbatim.
   - Three H2s reframed as natural-language questions — *"How does whisrs differ from Wispr Flow and Superwhisper?"*, *"What transcription backends does whisrs support?"*, *"Does whisrs work on Wayland, GNOME, KDE, Hyprland, and Sway?"* — so RAG retrievers chunk on heading boundaries with a Q+A pair in each chunk.
   - Each new question H2 opens with a 2–3 sentence direct answer before any supporting table.
   - Concrete numerical claims added (6 backends, 3 audio stacks, sub-500 MB offline RAM footprint with `base.en`); per the Princeton study, statistics increase citation likelihood by ~37%.

3. **`d4dd08e` — Internal review feedback.** Restored the `#supported-environments` HTML anchor above the renamed compositor H2 so `docs/troubleshooting.md` (and any external bookmarks) keep resolving. Tightened the compositor list (dropped a brittle "5 desktop environments" count). Corrected `docs/faq.md`: Wispr Flow ships macOS *and* Windows clients (not macOS-only); Superwhisper is macOS-only.

## What is *not* in this PR (handled separately)

- GitHub repo description + topics — set via `gh repo edit`, not part of the file diff.
- OpenGraph social card image — uploaded via repo Settings → Social preview.
- External actions: PRs to awesome-voice-typing and awesome-alternatives-in-rust are already open as separate community PRs.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (16/16)
- [x] `cargo build` succeeds
- [ ] Verify the rendered README on GitHub: definition-first lead is the first body paragraph, question H2s appear in the right-hand outline, comparison table renders correctly
- [ ] Verify `docs/troubleshooting.md` link to `../README.md#supported-environments` still resolves
- [ ] Confirm Cargo.toml description renders cleanly on the next crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)