### PR TITLE
feat: add ASR sidecar backends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ src/
 │   ├── groq.rs             # Groq Whisper API (chunked HTTP, timestamp dedup)
 │   ├── openai_realtime.rs  # OpenAI Realtime API (WebSocket, true streaming)
 │   ├── openai_rest.rs      # OpenAI REST API (simple HTTP POST)
+│   ├── asr_sidecar.rs      # Generic HTTP ASR sidecar backend
 │   ├── local_whisper.rs    # Local whisper.cpp via whisper-rs (feature-gated)
 │   ├── local_vosk.rs       # Vosk backend stub (coming soon)
 │   ├── local_parakeet.rs   # Parakeet/NVIDIA backend stub (coming soon)
@@ -122,7 +123,7 @@ Responses: `{"status": "ok", "state": "idle"}`, `{"status": "error", "message": 
 
 Path: `~/.config/whisrs/config.toml` (permissions: 0600)
 
-Backends: `deepgram`, `deepgram-streaming`, `groq`, `openai-realtime`, `openai`, `local-whisper`, `local-vosk`, `local-parakeet`
+Backends: `deepgram`, `deepgram-streaming`, `groq`, `openai-realtime`, `openai`, `local-whisper`, `local-vosk`, `local-parakeet`, `asr-sidecar`
 
 Environment variable overrides:
 - `WHISRS_DEEPGRAM_API_KEY` — overrides `[deepgram] api_key`

--- a/README.md
+++ b/README.md
@@ -132,12 +132,15 @@ bindsym $mod+w exec whisrs toggle
 | **OpenAI Realtime** | Cloud (WebSocket) | True streaming | Paid | Best UX, text as you speak |
 | **OpenAI REST** | Cloud | Batch | Paid | Simple fallback |
 | **Local whisper.cpp** | Local (CPU/GPU) | Sliding window | Free | Privacy, offline use |
+| **ASR sidecar** | Local sidecar | Batch | Free | Custom local ASR models |
 
 Groq is the default. Fast, free tier, good accuracy with `whisper-large-v3-turbo`.
 
 Deepgram offers $200 in free credits on signup (no credit card required) and supports 60+ languages with the Nova-3 model. The streaming backend provides true real-time transcription over WebSocket.
 
 OpenAI Realtime is the premium option: true streaming over WebSocket means text appears at your cursor while you're still speaking.
+
+The ASR sidecar backend sends the recorded WAV to a local HTTP service and types the plain text it returns. This keeps Python/PyTorch/vLLM dependencies out of the Rust daemon and lets you use models such as VibeVoice-ASR, Moonshine, Distil-Whisper, or faster-whisper.
 
 ### Local whisper.cpp
 
@@ -153,6 +156,29 @@ whisrs setup   # select Local > whisper.cpp, pick a model, download automaticall
 | base.en | 142 MB | ~388 MB | Real-time | Good (recommended) |
 | small.en | 466 MB | ~852 MB | Borderline | Very good |
 
+### ASR sidecar
+
+The `asr-sidecar` backend expects a local HTTP endpoint that accepts multipart form data:
+
+- `file`: WAV audio
+- `model`: model id, default `microsoft/VibeVoice-ASR-HF`
+- `language`: ISO 639-1 language code when not set to `auto`
+- `hotwords`: optional vocabulary/context prompt
+
+The sidecar should return JSON:
+
+```json
+{ "text": "transcribed text" }
+```
+
+Example sidecars are available under `contrib/asr-sidecars/`; each one has its
+own setup and GPU notes.
+
+| Sidecar | Default model | Best for |
+|---|---|---|
+| `moonshine` | `UsefulSensors/moonshine-base` | Fast lightweight English dictation |
+| `vibevoice` | `microsoft/VibeVoice-ASR-HF` | Long-form local transcription experiments |
+
 ---
 
 ## Configuration
@@ -161,7 +187,7 @@ Config file: `~/.config/whisrs/config.toml`
 
 ```toml
 [general]
-backend = "groq"            # groq | deepgram-streaming | deepgram | openai-realtime | openai | local-whisper
+backend = "groq"            # groq | deepgram-streaming | deepgram | openai-realtime | openai | local-whisper | asr-sidecar
 language = "en"             # ISO 639-1 or "auto"
 silence_timeout_ms = 2000   # auto-stop after silence (streaming only)
 notify = true               # desktop notifications
@@ -215,6 +241,10 @@ model = "gpt-4o-mini-transcribe"
 
 [local-whisper]
 model_path = "~/.local/share/whisrs/models/ggml-base.en.bin"
+
+[asr-sidecar]
+url = "http://127.0.0.1:8765/transcribe"
+model = "microsoft/VibeVoice-ASR-HF"
 
 # Command mode: LLM for voice-driven text rewriting
 [llm]
@@ -287,7 +317,7 @@ whisrs is functional and usable for daily dictation. The core features work:
 
 - [x] Daemon + CLI architecture
 - [x] Audio capture and WAV encoding
-- [x] Groq, Deepgram (REST + streaming), OpenAI REST, and OpenAI Realtime backends
+- [x] Groq, Deepgram (REST + streaming), OpenAI REST, OpenAI Realtime, and ASR sidecar backends
 - [x] Local whisper.cpp backend (sliding window, prompt conditioning, model download)
 - [x] Layout-aware keyboard injection (uinput + XKB)
 - [x] Wayland/X11 clipboard with save/restore

--- a/contrib/asr-sidecars/README.md
+++ b/contrib/asr-sidecars/README.md
@@ -1,0 +1,51 @@
+# ASR sidecars
+
+`whisrs` can call any local HTTP ASR service through the generic
+`asr-sidecar` backend. Sidecars accept WAV audio as multipart form data and
+return a JSON response with a `text` field.
+
+## Contract
+
+Endpoint:
+
+```text
+POST /transcribe
+```
+
+Multipart fields:
+
+- `file`: WAV audio
+- `model`: model identifier
+- `language`: ISO 639-1 language code, or `auto`
+- `hotwords`: optional vocabulary/context prompt
+
+Response:
+
+```json
+{ "text": "transcribed text" }
+```
+
+## Implementations
+
+## Recommended choices
+
+- `moonshine`: fastest lightweight CPU/low-memory English sidecar.
+- `parakeet`: recommended local GPU sidecar for high-quality multilingual
+  dictation.
+- `vibevoice`: heavier long-form transcription sidecar.
+
+| Sidecar | Default model | Best for |
+|---|---|---|
+| `moonshine` | `UsefulSensors/moonshine-base` | Fast lightweight English dictation |
+| `parakeet` | `nvidia/parakeet-tdt-0.6b-v3` | High-quality local GPU dictation |
+| `vibevoice` | `microsoft/VibeVoice-ASR-HF` | Long-form local transcription experiments |
+
+Each sidecar has its own README with installation and GPU notes, plus a
+`config.toml.example` snippet for whisrs.
+
+## AMD ROCm note
+
+For AMD/ROCm, PyTorch still uses `cuda:0` device spelling, but NVIDIA CUDA
+driver libraries are not present. NeMo's CUDA graph decoder expects
+`libcuda.so.1`, so the Parakeet sidecar disables that decoder by default. Do
+not pass `--use-cuda-graph-decoder` on ROCm.

--- a/contrib/asr-sidecars/moonshine/.gitignore
+++ b/contrib/asr-sidecars/moonshine/.gitignore
@@ -1,0 +1,4 @@
+.venv
+venv
+__pycache__
+*.pyc

--- a/contrib/asr-sidecars/moonshine/README.md
+++ b/contrib/asr-sidecars/moonshine/README.md
@@ -1,0 +1,117 @@
+# Moonshine ASR sidecar
+
+This helper exposes Useful Sensors Moonshine as the local HTTP endpoint expected
+by whisrs:
+
+```text
+POST http://127.0.0.1:8765/transcribe
+```
+
+Moonshine is a lightweight ASR family designed for fast local transcription.
+The default model is `UsefulSensors/moonshine-base` for English. You can also
+use `UsefulSensors/moonshine-tiny` for lower memory and faster startup.
+
+## Requirements
+
+- Python 3.11+
+- `ffmpeg` available on `PATH`
+- PyTorch for your CPU/GPU runtime
+
+Moonshine is much smaller than VibeVoice-ASR. The English models are:
+
+| Model | Parameters | Notes |
+|---|---:|---|
+| `UsefulSensors/moonshine-tiny` | 27M | Fastest, lowest memory |
+| `UsefulSensors/moonshine-base` | 61M | Better accuracy, still lightweight |
+
+## Install
+
+Create an isolated Python environment:
+
+```bash
+cd contrib/asr-sidecars/moonshine
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+If the generic `torch` wheel is not appropriate for your GPU, install the
+correct PyTorch build first, then run:
+
+```bash
+pip install -r requirements.txt
+```
+
+For AMD ROCm, verify PyTorch sees the GPU:
+
+```bash
+python3 - <<'PY'
+import torch
+print("torch:", torch.__version__)
+print("cuda available:", torch.cuda.is_available())
+print("device count:", torch.cuda.device_count())
+if torch.cuda.is_available():
+    print("device:", torch.cuda.get_device_name(0))
+PY
+```
+
+## Run
+
+```bash
+python server.py --host 127.0.0.1 --port 8765
+```
+
+Useful options:
+
+```bash
+python server.py \
+  --model UsefulSensors/moonshine-base \
+  --device cuda:0 \
+  --dtype float16
+```
+
+CPU mode:
+
+```bash
+python server.py --device cpu --dtype float32
+```
+
+If you see truncation or repetition on unusual inputs, override the generation
+limit:
+
+```bash
+python server.py --max-length 128
+```
+
+## Configure whisrs
+
+Set:
+
+```toml
+[general]
+backend = "asr-sidecar"
+language = "en"
+
+[asr-sidecar]
+url = "http://127.0.0.1:8765/transcribe"
+model = "UsefulSensors/moonshine-base"
+```
+
+The same example is available in `config.toml.example`.
+
+Then restart `whisrsd`.
+
+## Test the sidecar
+
+```bash
+curl -F file=@/path/to/audio.wav \
+  -F model=UsefulSensors/moonshine-base \
+  -F language=en \
+  http://127.0.0.1:8765/transcribe
+```
+
+Expected response:
+
+```json
+{ "text": "transcribed text" }
+```

--- a/contrib/asr-sidecars/moonshine/config.toml.example
+++ b/contrib/asr-sidecars/moonshine/config.toml.example
@@ -1,0 +1,7 @@
+[general]
+backend = "asr-sidecar"
+language = "en"
+
+[asr-sidecar]
+url = "http://127.0.0.1:8765/transcribe"
+model = "UsefulSensors/moonshine-base"

--- a/contrib/asr-sidecars/moonshine/requirements.txt
+++ b/contrib/asr-sidecars/moonshine/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.115
+librosa>=0.10
+python-multipart>=0.0.20
+torch
+transformers>=5.3.0
+uvicorn[standard]>=0.30

--- a/contrib/asr-sidecars/moonshine/server.py
+++ b/contrib/asr-sidecars/moonshine/server.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""HTTP sidecar for Useful Sensors Moonshine ASR.
+
+The whisrs `asr-sidecar` backend posts WAV audio to `/transcribe` as multipart
+form data. This sidecar loads a Moonshine model once at startup and returns a
+plain transcript as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import librosa
+import torch
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from transformers import AutoProcessor, MoonshineForConditionalGeneration
+
+
+DEFAULT_MODEL = "UsefulSensors/moonshine-base"
+
+
+def _torch_dtype(name: str) -> torch.dtype:
+    try:
+        return getattr(torch, name)
+    except AttributeError as exc:
+        raise ValueError(f"unknown torch dtype: {name}") from exc
+
+
+class MoonshineSidecar:
+    def __init__(
+        self,
+        model_id: str,
+        device: str,
+        dtype: torch.dtype,
+        max_length: int | None,
+    ) -> None:
+        self.model_id = model_id
+        self.device = torch.device(device)
+        self.dtype = dtype if self.device.type != "cpu" else torch.float32
+        self.max_length = max_length
+
+        self.processor = AutoProcessor.from_pretrained(model_id)
+        self.model = MoonshineForConditionalGeneration.from_pretrained(model_id)
+        self.model.to(self.device)
+        self.model.to(self.dtype)
+        self.model.eval()
+
+    @torch.inference_mode()
+    def transcribe(self, audio_path: Path) -> str:
+        sampling_rate = self.processor.feature_extractor.sampling_rate
+        audio, _ = librosa.load(audio_path, sr=sampling_rate, mono=True)
+        inputs = self.processor(
+            audio,
+            return_tensors="pt",
+            sampling_rate=sampling_rate,
+        )
+        inputs = inputs.to(self.device, self.dtype)
+
+        generate_kwargs: dict[str, int] = {}
+        if self.max_length is not None:
+            generate_kwargs["max_length"] = self.max_length
+        elif "attention_mask" in inputs:
+            # Moonshine recommends capping generated length based on input
+            # duration to avoid hallucination loops on short audio.
+            token_limit_factor = 6.5 / sampling_rate
+            seq_lens = inputs.attention_mask.sum(dim=-1)
+            generate_kwargs["max_length"] = max(
+                1,
+                int((seq_lens * token_limit_factor).max().item()),
+            )
+
+        generated_ids = self.model.generate(**inputs, **generate_kwargs)
+        return self.processor.decode(generated_ids[0], skip_special_tokens=True).strip()
+
+
+def create_app(sidecar: MoonshineSidecar) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.sidecar = sidecar
+        yield
+
+    app = FastAPI(title="whisrs Moonshine ASR sidecar", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok", "model": app.state.sidecar.model_id}
+
+    @app.post("/transcribe")
+    async def transcribe(
+        file: UploadFile = File(...),
+        model: str = Form(DEFAULT_MODEL),
+        language: str | None = Form(None),
+        hotwords: str | None = Form(None),
+        prompt: str | None = Form(None),
+    ) -> dict[str, str]:
+        if model != app.state.sidecar.model_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"sidecar loaded {app.state.sidecar.model_id}, "
+                    f"but request asked for {model}"
+                ),
+            )
+        if language and language not in {"auto", "en"}:
+            raise HTTPException(
+                status_code=400,
+                detail="Moonshine English models only support language=en or auto",
+            )
+        # The generic sidecar contract includes hotwords/prompt, but Moonshine
+        # does not currently consume them through the Transformers API.
+        _ = hotwords or prompt
+
+        suffix = Path(file.filename or "audio.wav").suffix or ".wav"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(await file.read())
+
+        try:
+            text = app.state.sidecar.transcribe(tmp_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        return {"text": text}
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.getenv("MOONSHINE_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("MOONSHINE_PORT", "8765")))
+    parser.add_argument("--model", default=os.getenv("MOONSHINE_MODEL", DEFAULT_MODEL))
+    parser.add_argument(
+        "--device",
+        default=os.getenv(
+            "MOONSHINE_DEVICE",
+            "cuda:0" if torch.cuda.is_available() else "cpu",
+        ),
+    )
+    parser.add_argument("--dtype", default=os.getenv("MOONSHINE_DTYPE", "float16"))
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=(
+            int(os.environ["MOONSHINE_MAX_LENGTH"])
+            if "MOONSHINE_MAX_LENGTH" in os.environ
+            else None
+        ),
+        help="Override generated token limit. By default this is derived from audio length.",
+    )
+    args = parser.parse_args()
+
+    import uvicorn
+
+    sidecar = MoonshineSidecar(
+        model_id=args.model,
+        device=args.device,
+        dtype=_torch_dtype(args.dtype),
+        max_length=args.max_length,
+    )
+    uvicorn.run(create_app(sidecar), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/asr-sidecars/parakeet/.gitignore
+++ b/contrib/asr-sidecars/parakeet/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+*.py[cod]

--- a/contrib/asr-sidecars/parakeet/README.md
+++ b/contrib/asr-sidecars/parakeet/README.md
@@ -1,0 +1,131 @@
+# Parakeet ASR sidecar
+
+This helper exposes NVIDIA Parakeet as the local HTTP endpoint expected by
+whisrs:
+
+```text
+POST http://127.0.0.1:8765/transcribe
+```
+
+The default model is `nvidia/parakeet-tdt-0.6b-v3`, a NeMo ASR model with
+automatic punctuation, capitalization, and multilingual support for European
+languages.
+
+## Requirements
+
+- Python 3.11+
+- `ffmpeg` available on `PATH`
+- PyTorch for your CPU/GPU runtime
+- NVIDIA NeMo ASR
+- A GPU is recommended for the default 0.6B model
+
+## Install
+
+Create an isolated Python environment:
+
+```bash
+cd contrib/asr-sidecars/parakeet
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+If the generic `torch` wheel is not appropriate for your GPU, install the
+correct PyTorch build first, then run:
+
+```bash
+pip install -r requirements.txt
+```
+
+For AMD ROCm, verify PyTorch sees the GPU:
+
+```bash
+python3 - <<'PY'
+import torch
+print("torch:", torch.__version__)
+print("cuda available:", torch.cuda.is_available())
+print("device count:", torch.cuda.device_count())
+if torch.cuda.is_available():
+    print("device:", torch.cuda.get_device_name(0))
+PY
+```
+
+## Run
+
+```bash
+python server.py --host 127.0.0.1 --port 8765
+```
+
+Useful options:
+
+```bash
+python server.py \
+  --model nvidia/parakeet-tdt-0.6b-v3 \
+  --device cuda:0 \
+  --batch-size 1
+```
+
+CPU mode is available but may be slow for the default model:
+
+```bash
+python server.py --device cpu
+```
+
+### AMD ROCm notes
+
+PyTorch exposes ROCm devices through the `torch.cuda` API, so `--device cuda:0`
+is still the right spelling when `torch.cuda.is_available()` is true. NeMo's
+CUDA graph decoder expects NVIDIA's CUDA driver library (`libcuda.so.1`),
+though, so this sidecar disables CUDA graph decoding by default.
+
+For ROCm, start with:
+
+```bash
+HIP_VISIBLE_DEVICES=0 \
+ROCR_VISIBLE_DEVICES=0 \
+python server.py \
+  --host 127.0.0.1 \
+  --port 8765 \
+  --model nvidia/parakeet-tdt-0.6b-v3 \
+  --device cuda:0 \
+  --batch-size 1
+```
+
+On NVIDIA, you can opt back into NeMo's CUDA graph decoder:
+
+```bash
+python server.py --device cuda:0 --use-cuda-graph-decoder
+```
+
+## Configure whisrs
+
+Set:
+
+```toml
+[general]
+backend = "asr-sidecar"
+language = "auto"
+
+[asr-sidecar]
+url = "http://127.0.0.1:8765/transcribe"
+model = "nvidia/parakeet-tdt-0.6b-v3"
+```
+
+The same example is available in `config.toml.example`.
+
+Then restart `whisrsd`.
+
+## Test the sidecar
+
+```bash
+curl -F file=@/path/to/audio.wav \
+  -F model=nvidia/parakeet-tdt-0.6b-v3 \
+  -F language=auto \
+  http://127.0.0.1:8765/transcribe
+```
+
+Expected response:
+
+```json
+{ "text": "transcribed text" }
+```

--- a/contrib/asr-sidecars/parakeet/config.toml.example
+++ b/contrib/asr-sidecars/parakeet/config.toml.example
@@ -1,0 +1,7 @@
+[general]
+backend = "asr-sidecar"
+language = "auto"
+
+[asr-sidecar]
+url = "http://127.0.0.1:8765/transcribe"
+model = "nvidia/parakeet-tdt-0.6b-v3"

--- a/contrib/asr-sidecars/parakeet/requirements.txt
+++ b/contrib/asr-sidecars/parakeet/requirements.txt
@@ -1,0 +1,9 @@
+fastapi>=0.115
+nemo_toolkit[asr]>=2.4
+omegaconf>=2.3
+python-multipart>=0.0.20
+torch
+uvicorn[standard]>=0.30
+
+# For AMD ROCm users only
+# pip install --index-url https://download.pytorch.org/whl/rocm6.4 torch torchvision torchaudio

--- a/contrib/asr-sidecars/parakeet/server.py
+++ b/contrib/asr-sidecars/parakeet/server.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""HTTP sidecar for NVIDIA Parakeet ASR.
+
+The whisrs `asr-sidecar` backend posts WAV audio to `/transcribe` as multipart
+form data. This sidecar loads a NeMo-compatible Parakeet model once at startup
+and returns a plain transcript as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import torch
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from nemo.collections import asr as nemo_asr
+from omegaconf import OmegaConf
+
+
+DEFAULT_MODEL = "nvidia/parakeet-tdt-0.6b-v3"
+
+
+def _first_text(value: Any) -> str:
+    """Normalize NeMo transcription outputs across versions."""
+    if isinstance(value, str):
+        return value.strip()
+    if hasattr(value, "text"):
+        return str(value.text).strip()
+    if isinstance(value, (list, tuple)) and value:
+        return _first_text(value[0])
+    return str(value).strip()
+
+
+class ParakeetSidecar:
+    def __init__(
+        self,
+        model_id: str,
+        device: str,
+        batch_size: int,
+        use_cuda_graph_decoder: bool,
+    ) -> None:
+        self.model_id = model_id
+        self.device = torch.device(device)
+        self.batch_size = batch_size
+
+        cfg = nemo_asr.models.ASRModel.from_pretrained(model_id, return_config=True)
+        OmegaConf.update(
+            cfg,
+            "decoding.greedy.use_cuda_graph_decoder",
+            use_cuda_graph_decoder,
+            merge=True,
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tmp:
+            cfg_path = Path(tmp.name)
+            OmegaConf.save(cfg, tmp)
+
+        try:
+            self.model = nemo_asr.models.ASRModel.from_pretrained(
+                model_name=model_id,
+                override_config_path=str(cfg_path),
+                map_location=self.device,
+            )
+        finally:
+            cfg_path.unlink(missing_ok=True)
+        self.model.to(self.device)
+        self.model.eval()
+
+    @torch.inference_mode()
+    def transcribe(self, audio_path: Path) -> str:
+        output = self.model.transcribe(
+            [str(audio_path)],
+            batch_size=self.batch_size,
+        )
+        return _first_text(output)
+
+
+def create_app(sidecar: ParakeetSidecar) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.sidecar = sidecar
+        yield
+
+    app = FastAPI(title="whisrs Parakeet ASR sidecar", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok", "model": app.state.sidecar.model_id}
+
+    @app.post("/transcribe")
+    async def transcribe(
+        file: UploadFile = File(...),
+        model: str = Form(DEFAULT_MODEL),
+        language: str | None = Form(None),
+        hotwords: str | None = Form(None),
+        prompt: str | None = Form(None),
+    ) -> dict[str, str]:
+        if model != app.state.sidecar.model_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"sidecar loaded {app.state.sidecar.model_id}, "
+                    f"but request asked for {model}"
+                ),
+            )
+        # Parakeet v3 auto-detects supported languages. The generic whisrs
+        # sidecar contract includes these fields, but basic NeMo Parakeet
+        # inference does not consume them directly.
+        _ = language
+        _ = hotwords or prompt
+
+        suffix = Path(file.filename or "audio.wav").suffix or ".wav"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(await file.read())
+
+        try:
+            text = app.state.sidecar.transcribe(tmp_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        return {"text": text}
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.getenv("PARAKEET_HOST", "127.0.0.1"))
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PARAKEET_PORT", "8765")),
+    )
+    parser.add_argument("--model", default=os.getenv("PARAKEET_MODEL", DEFAULT_MODEL))
+    parser.add_argument(
+        "--device",
+        default=os.getenv(
+            "PARAKEET_DEVICE",
+            "cuda:0" if torch.cuda.is_available() else "cpu",
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=int(os.getenv("PARAKEET_BATCH_SIZE", "1")),
+        help="Batch size passed to NeMo transcribe(). Keep at 1 for dictation.",
+    )
+    parser.add_argument(
+        "--use-cuda-graph-decoder",
+        action="store_true",
+        default=os.getenv("PARAKEET_USE_CUDA_GRAPH_DECODER", "0") == "1",
+        help=(
+            "Enable NeMo CUDA graph decoding. Faster on NVIDIA, but disable it "
+            "on ROCm/AMD because cuda-python expects libcuda.so.1."
+        ),
+    )
+    args = parser.parse_args()
+
+    import uvicorn
+
+    sidecar = ParakeetSidecar(
+        model_id=args.model,
+        device=args.device,
+        batch_size=args.batch_size,
+        use_cuda_graph_decoder=args.use_cuda_graph_decoder,
+    )
+    uvicorn.run(create_app(sidecar), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/asr-sidecars/vibevoice/.gitignore
+++ b/contrib/asr-sidecars/vibevoice/.gitignore
@@ -1,0 +1,4 @@
+.venv
+venv
+__pycache__
+*.pyc

--- a/contrib/asr-sidecars/vibevoice/README.md
+++ b/contrib/asr-sidecars/vibevoice/README.md
@@ -1,0 +1,194 @@
+# VibeVoice-ASR sidecar
+
+This helper exposes Microsoft VibeVoice-ASR as the local HTTP endpoint expected
+by whisrs:
+
+```text
+POST http://127.0.0.1:8765/transcribe
+```
+
+It uses the Transformers-compatible model `microsoft/VibeVoice-ASR-HF`.
+
+## Requirements
+
+- NVIDIA GPU strongly recommended
+- Python 3.11+
+- `ffmpeg` available on `PATH`
+- CUDA-compatible PyTorch installation for your system
+- 16+ GB of free disk space for the model cache, plus temporary download space
+
+Microsoft's upstream docs recommend an NVIDIA PyTorch container for the CUDA
+environment. The model is designed for long-form ASR, supports over 50
+languages, and can use customized context/hotwords.
+
+## Hugging Face access
+
+A Hugging Face account is not strictly required if the public model download
+works anonymously. For a model this large, a token is still recommended because
+unauthenticated requests can be slower or more rate-limited. A token is required
+only if Hugging Face returns a gated-model/authentication error or asks you to
+accept model terms.
+
+Temporary token for one shell:
+
+```bash
+export HF_TOKEN=hf_...
+python server.py --host 127.0.0.1 --port 8765
+```
+
+Persistent login:
+
+```bash
+huggingface-cli login
+```
+
+Model files are cached by Hugging Face, usually under
+`~/.cache/huggingface/hub`, so later sidecar starts should not redownload the
+full model.
+
+## Install
+
+Create an isolated Python environment:
+
+```bash
+cd contrib/asr-sidecars/vibevoice
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+If the generic `torch` wheel is not appropriate for your CUDA version, install
+PyTorch from the official PyTorch index first, then run:
+
+```bash
+pip install -r requirements.txt
+```
+
+The sidecar uses `device_map=auto` by default, so `accelerate` is required by
+Transformers for model placement.
+
+Transformers loads uploaded audio through `librosa`, which is included in
+`requirements.txt`. If you install dependencies manually, make sure both
+`accelerate` and `librosa` are present.
+
+## Run
+
+```bash
+python server.py --host 127.0.0.1 --port 8765
+```
+
+The first launch downloads the model into the Hugging Face cache.
+
+Useful options:
+
+```bash
+python server.py \
+  --model microsoft/VibeVoice-ASR-HF \
+  --dtype float16 \
+  --device-map auto
+```
+
+`float16` is the default because it works better across consumer GPUs. If you
+are running on NVIDIA hardware with good bfloat16 support, `--dtype bfloat16`
+is also worth testing.
+
+### AMD ROCm notes
+
+PyTorch exposes ROCm devices through the `torch.cuda` API. Verify the sidecar
+environment sees the GPU before starting the server:
+
+```bash
+python3 - <<'PY'
+import torch
+print("torch:", torch.__version__)
+print("cuda available:", torch.cuda.is_available())
+print("device count:", torch.cuda.device_count())
+if torch.cuda.is_available():
+    print("device:", torch.cuda.get_device_name(0))
+PY
+```
+
+For RDNA2 cards such as the Radeon RX 6800 XT, use `float16`. If you see
+`HIP error: invalid device function`, make sure the server is not running with
+`--dtype bfloat16`:
+
+```bash
+python server.py --host 127.0.0.1 --port 8765 --dtype float16
+```
+
+If `torch.cuda.device_count()` reports more than one device, pin the sidecar to
+the discrete GPU so `device_map=auto` does not place layers on an iGPU or other
+ROCm-visible device:
+
+```bash
+HIP_VISIBLE_DEVICES=0 \
+ROCR_VISIBLE_DEVICES=0 \
+python server.py --host 127.0.0.1 --port 8765 --dtype float16
+```
+
+If ROCm still reports kernel/device issues on gfx1030 hardware, these
+environment variables are common troubleshooting knobs:
+
+```bash
+HIP_VISIBLE_DEVICES=0 \
+ROCR_VISIBLE_DEVICES=0 \
+HSA_OVERRIDE_GFX_VERSION=10.3.0 \
+HSA_ENABLE_SDMA=0 \
+python server.py --host 127.0.0.1 --port 8765 --dtype float16
+```
+
+For ROCm memory aperture violations or out-of-memory failures, keep recordings
+short and lower generation memory. The `--tokenizer-chunk-size` option is
+best-effort; some Transformers/VibeVoice versions do not accept it, and the
+sidecar will retry without it if rejected.
+
+```bash
+HIP_VISIBLE_DEVICES=0 \
+ROCR_VISIBLE_DEVICES=0 \
+python server.py \
+  --host 127.0.0.1 \
+  --port 8765 \
+  --dtype float16 \
+  --max-new-tokens 2048 \
+  --tokenizer-chunk-size 64000
+```
+
+For lower-memory devices, try reducing the tokenizer chunk size:
+
+```bash
+python server.py --tokenizer-chunk-size 64000
+```
+
+## Configure whisrs
+
+Set:
+
+```toml
+[general]
+backend = "asr-sidecar"
+language = "auto"
+
+[asr-sidecar]
+url = "http://127.0.0.1:8765/transcribe"
+model = "microsoft/VibeVoice-ASR-HF"
+```
+
+The same example is available in `config.toml.example`.
+
+Then restart `whisrsd`.
+
+## Test the sidecar
+
+```bash
+curl -F file=@/path/to/audio.wav \
+  -F model=microsoft/VibeVoice-ASR-HF \
+  -F language=auto \
+  -F hotwords="whisrs,Hyprland,VibeVoice" \
+  http://127.0.0.1:8765/transcribe
+```
+
+Expected response:
+
+```json
+{ "text": "transcribed text" }
+```

--- a/contrib/asr-sidecars/vibevoice/config.toml.example
+++ b/contrib/asr-sidecars/vibevoice/config.toml.example
@@ -1,0 +1,7 @@
+[general]
+backend = "asr-sidecar"
+language = "auto"
+
+[asr-sidecar]
+url = "http://127.0.0.1:8765/transcribe"
+model = "microsoft/VibeVoice-ASR-HF"

--- a/contrib/asr-sidecars/vibevoice/requirements.txt
+++ b/contrib/asr-sidecars/vibevoice/requirements.txt
@@ -1,0 +1,10 @@
+accelerate>=1.0
+fastapi>=0.115
+librosa>=0.10
+python-multipart>=0.0.20
+transformers>=5.3.0
+uvicorn[standard]>=0.30
+# torch
+
+# For AMD ROCm users only
+# pip install --index-url https://download.pytorch.org/whl/rocm6.4 torch torchvision torchaudio

--- a/contrib/asr-sidecars/vibevoice/server.py
+++ b/contrib/asr-sidecars/vibevoice/server.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""HTTP sidecar for Microsoft VibeVoice-ASR.
+
+The whisrs `asr-sidecar` backend posts WAV audio to `/transcribe` as multipart
+form data. This sidecar loads the Transformers-compatible VibeVoice-ASR model
+once at startup and returns a flattened transcript as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import torch
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from transformers import AutoProcessor, VibeVoiceAsrForConditionalGeneration
+
+
+DEFAULT_MODEL = "microsoft/VibeVoice-ASR-HF"
+
+
+def _torch_dtype(name: str) -> torch.dtype | str:
+    if name == "auto":
+        return "auto"
+    try:
+        return getattr(torch, name)
+    except AttributeError as exc:
+        raise ValueError(f"unknown torch dtype: {name}") from exc
+
+
+def _model_device(model: Any) -> torch.device:
+    if hasattr(model, "device"):
+        return model.device
+    first_param = next(model.parameters())
+    return first_param.device
+
+
+class VibeVoiceSidecar:
+    def __init__(
+        self,
+        model_id: str,
+        device_map: str,
+        dtype: torch.dtype | str,
+        tokenizer_chunk_size: int | None,
+        max_new_tokens: int | None,
+    ) -> None:
+        self.model_id = model_id
+        self.tokenizer_chunk_size = tokenizer_chunk_size
+        self.max_new_tokens = max_new_tokens
+        self.processor = AutoProcessor.from_pretrained(model_id)
+        self.model = VibeVoiceAsrForConditionalGeneration.from_pretrained(
+            model_id,
+            device_map=device_map,
+            torch_dtype=dtype,
+        )
+
+    @torch.inference_mode()
+    def transcribe(self, audio_path: Path, prompt: str | None) -> str:
+        inputs = self.processor.apply_transcription_request(
+            audio=str(audio_path),
+            prompt=prompt or None,
+        )
+
+        device = _model_device(self.model)
+        model_dtype = getattr(self.model, "dtype", torch.float32)
+        inputs = inputs.to(device, model_dtype)
+
+        generate_kwargs: dict[str, Any] = {}
+        if self.tokenizer_chunk_size is not None:
+            generate_kwargs["tokenizer_chunk_size"] = self.tokenizer_chunk_size
+        if self.max_new_tokens is not None:
+            generate_kwargs["max_new_tokens"] = self.max_new_tokens
+
+        try:
+            output_ids = self.model.generate(**inputs, **generate_kwargs)
+        except ValueError as exc:
+            if (
+                "tokenizer_chunk_size" not in generate_kwargs
+                or "tokenizer_chunk_size" not in str(exc)
+            ):
+                raise
+            generate_kwargs.pop("tokenizer_chunk_size")
+            output_ids = self.model.generate(**inputs, **generate_kwargs)
+        generated_ids = output_ids[:, inputs["input_ids"].shape[1] :]
+        transcript = self.processor.decode(
+            generated_ids,
+            return_format="transcription_only",
+        )[0]
+        return str(transcript).strip()
+
+
+def create_app(sidecar: VibeVoiceSidecar) -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.sidecar = sidecar
+        yield
+
+    app = FastAPI(title="whisrs VibeVoice-ASR sidecar", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok", "model": app.state.sidecar.model_id}
+
+    @app.post("/transcribe")
+    async def transcribe(
+        file: UploadFile = File(...),
+        model: str = Form(DEFAULT_MODEL),
+        language: str | None = Form(None),
+        hotwords: str | None = Form(None),
+        prompt: str | None = Form(None),
+    ) -> dict[str, str]:
+        if model != app.state.sidecar.model_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"sidecar loaded {app.state.sidecar.model_id}, "
+                    f"but request asked for {model}"
+                ),
+            )
+        if language and language != "auto":
+            # VibeVoice-ASR is multilingual and does not require an explicit
+            # language parameter. Keep accepting the form field so whisrs can
+            # use the same transcription config shape as other backends.
+            pass
+
+        suffix = Path(file.filename or "audio.wav").suffix or ".wav"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(await file.read())
+
+        try:
+            text = app.state.sidecar.transcribe(tmp_path, prompt or hotwords)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        return {"text": text}
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=os.getenv("VIBEVOICE_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("VIBEVOICE_PORT", "8765")))
+    parser.add_argument("--model", default=os.getenv("VIBEVOICE_MODEL", DEFAULT_MODEL))
+    parser.add_argument("--device-map", default=os.getenv("VIBEVOICE_DEVICE_MAP", "auto"))
+    parser.add_argument("--dtype", default=os.getenv("VIBEVOICE_DTYPE", "float16"))
+    parser.add_argument(
+        "--tokenizer-chunk-size",
+        type=int,
+        default=(
+            int(os.environ["VIBEVOICE_TOKENIZER_CHUNK_SIZE"])
+            if "VIBEVOICE_TOKENIZER_CHUNK_SIZE" in os.environ
+            else None
+        ),
+        help="Optional generate() tokenizer chunk size for lowering memory use.",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=(
+            int(os.environ["VIBEVOICE_MAX_NEW_TOKENS"])
+            if "VIBEVOICE_MAX_NEW_TOKENS" in os.environ
+            else 4096
+        ),
+        help="Maximum generated transcript tokens per request. Set 0 to use the model default.",
+    )
+    args = parser.parse_args()
+
+    import uvicorn
+
+    sidecar = VibeVoiceSidecar(
+        model_id=args.model,
+        device_map=args.device_map,
+        dtype=_torch_dtype(args.dtype),
+        tokenizer_chunk_size=args.tokenizer_chunk_size,
+        max_new_tokens=args.max_new_tokens if args.max_new_tokens > 0 else None,
+    )
+    uvicorn.run(create_app(sidecar), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/whisrsd.1
+++ b/contrib/whisrsd.1
@@ -55,6 +55,12 @@ with the lowest latency. Recommended for the best experience.
 .B openai
 OpenAI REST API. Simple HTTP POST, non-streaming fallback.
 .TP
+.B asr-sidecar
+Generic local HTTP ASR sidecar. Sends WAV audio as multipart form
+data and expects a JSON response with a
+.B text
+field.
+.TP
 .B local
 Local transcription via whisper.cpp (requires the
 .B local

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -13,7 +13,7 @@ use dialoguer::{Confirm, Input, Password, Select};
 
 use crate::llm::LlmConfig;
 use crate::{
-    AudioConfig, Config, DeepgramConfig, GeneralConfig, GroqConfig, InputConfig,
+    AsrSidecarConfig, AudioConfig, Config, DeepgramConfig, GeneralConfig, GroqConfig, InputConfig,
     LocalWhisperConfig, OpenAiConfig,
 };
 
@@ -33,6 +33,7 @@ const BACKEND_CHOICES: &[&str] = &[
     "OpenAI Realtime    (best streaming, cloud)",
     "OpenAI REST        (simple, cloud)",
     "Local              (offline, no API key needed)",
+    "ASR sidecar        (local HTTP sidecar, model-agnostic)",
 ];
 
 /// Map selection index to backend string used in config.
@@ -43,6 +44,7 @@ const BACKEND_VALUES: &[&str] = &[
     "openai-realtime",
     "openai",
     "local",
+    "asr-sidecar",
 ];
 
 /// Whisper model choices (name, file size, description).
@@ -102,7 +104,7 @@ pub fn run_setup() -> Result<()> {
     let backend = select_backend(None)?;
 
     // 2. Configure backend (API key or model download).
-    let (deepgram_config, groq_config, openai_config, local_whisper_config) =
+    let (deepgram_config, groq_config, openai_config, local_whisper_config, asr_sidecar_config) =
         configure_backend(&backend, None)?;
 
     // 3. Language.
@@ -146,6 +148,7 @@ pub fn run_setup() -> Result<()> {
         local_whisper: local_whisper_config,
         local_vosk: None,
         local_parakeet: None,
+        asr_sidecar: asr_sidecar_config,
         llm: llm_config,
         hotkeys: None,
         overlay: if overlay { overlay_config } else { None },
@@ -185,6 +188,7 @@ fn select_backend(existing: Option<&Config>) -> Result<String> {
                 "openai-realtime" => 3,
                 "openai" => 4,
                 _ if b.starts_with("local") => 5,
+                "asr-sidecar" | "asr" | "vibevoice" => 6,
                 _ => 0,
             }
         })
@@ -249,6 +253,7 @@ fn configure_backend(
     Option<GroqConfig>,
     Option<OpenAiConfig>,
     Option<LocalWhisperConfig>,
+    Option<AsrSidecarConfig>,
 )> {
     match backend {
         "deepgram" | "deepgram-streaming" => {
@@ -264,7 +269,13 @@ fn configure_backend(
                 .and_then(|c| c.deepgram.as_ref())
                 .map(|d| d.model.clone())
                 .unwrap_or_else(|| "nova-3".to_string());
-            Ok((Some(DeepgramConfig { api_key, model }), None, None, None))
+            Ok((
+                Some(DeepgramConfig { api_key, model }),
+                None,
+                None,
+                None,
+                None,
+            ))
         }
         "groq" => {
             let existing_key = existing.and_then(|c| c.groq.as_ref()).map(|g| &g.api_key);
@@ -277,7 +288,7 @@ fn configure_backend(
                 .and_then(|c| c.groq.as_ref())
                 .map(|g| g.model.clone())
                 .unwrap_or_else(|| "whisper-large-v3-turbo".to_string());
-            Ok((None, Some(GroqConfig { api_key, model }), None, None))
+            Ok((None, Some(GroqConfig { api_key, model }), None, None, None))
         }
         "openai-realtime" | "openai" => {
             let existing_key = existing.and_then(|c| c.openai.as_ref()).map(|o| &o.api_key);
@@ -306,7 +317,13 @@ fn configure_backend(
                 }
                 .to_string()
             };
-            Ok((None, None, Some(OpenAiConfig { api_key, model }), None))
+            Ok((
+                None,
+                None,
+                Some(OpenAiConfig { api_key, model }),
+                None,
+                None,
+            ))
         }
         "local-whisper" => {
             // Select model size.
@@ -346,9 +363,45 @@ fn configure_backend(
             }
 
             let model_path = dest.to_string_lossy().to_string();
-            Ok((None, None, None, Some(LocalWhisperConfig { model_path })))
+            Ok((
+                None,
+                None,
+                None,
+                Some(LocalWhisperConfig { model_path }),
+                None,
+            ))
         }
-        _ => Ok((None, None, None, None)),
+        "asr-sidecar" | "asr" | "vibevoice" => {
+            let existing_sidecar = existing.and_then(|c| c.asr_sidecar.as_ref());
+            let url: String = Input::new()
+                .with_prompt("ASR sidecar URL")
+                .default(
+                    existing_sidecar
+                        .map(|v| v.url.clone())
+                        .unwrap_or_else(|| "http://127.0.0.1:8765/transcribe".to_string()),
+                )
+                .interact_text()
+                .context("failed to read ASR sidecar URL")?;
+
+            let model: String = Input::new()
+                .with_prompt("ASR sidecar model")
+                .default(
+                    existing_sidecar
+                        .map(|v| v.model.clone())
+                        .unwrap_or_else(|| "microsoft/VibeVoice-ASR-HF".to_string()),
+                )
+                .interact_text()
+                .context("failed to read ASR sidecar model")?;
+
+            Ok((
+                None,
+                None,
+                None,
+                None,
+                Some(AsrSidecarConfig { url, model }),
+            ))
+        }
+        _ => Ok((None, None, None, None, None)),
     }
 }
 

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -16,6 +16,7 @@ use whisrs::input::ClipboardHandler;
 use whisrs::llm;
 use whisrs::post_processing::filler::remove_filler_words;
 use whisrs::state::{Action, StateMachine};
+use whisrs::transcription::asr_sidecar::AsrSidecarBackend;
 use whisrs::transcription::deepgram::{DeepgramRestBackend, DeepgramStreamingBackend};
 use whisrs::transcription::groq::GroqBackend;
 use whisrs::transcription::local_parakeet::ParakeetBackend;
@@ -142,6 +143,7 @@ fn load_config() -> (Config, Option<String>) {
                             local_whisper: None,
                             local_vosk: None,
                             local_parakeet: None,
+                            asr_sidecar: None,
                             llm: None,
                             hotkeys: None,
                             overlay: None,
@@ -167,6 +169,7 @@ fn load_config() -> (Config, Option<String>) {
                         local_whisper: None,
                         local_vosk: None,
                         local_parakeet: None,
+                        asr_sidecar: None,
                         llm: None,
                         hotkeys: None,
                         overlay: None,
@@ -192,6 +195,7 @@ fn load_config() -> (Config, Option<String>) {
             local_whisper: None,
             local_vosk: None,
             local_parakeet: None,
+            asr_sidecar: None,
             llm: None,
             hotkeys: None,
             overlay: None,
@@ -464,6 +468,15 @@ fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
             info!("using Parakeet transcription backend (model: {model_path})");
             Arc::new(ParakeetBackend::new(model_path))
         }
+        "asr-sidecar" | "asr" | "vibevoice" => {
+            let url = config
+                .asr_sidecar
+                .as_ref()
+                .map(|v| v.url.clone())
+                .unwrap_or_else(|| "http://127.0.0.1:8765/transcribe".to_string());
+            info!("using ASR sidecar transcription backend ({url})");
+            Arc::new(AsrSidecarBackend::new(url))
+        }
         other => {
             warn!("unknown backend '{other}', falling back to groq");
             let api_key = resolve_groq_api_key(config).unwrap_or_default();
@@ -492,6 +505,11 @@ fn get_model_for_backend(config: &Config) -> String {
         "local-whisper" | "local" => "base.en".to_string(),
         "local-vosk" => "small-en-us".to_string(),
         "local-parakeet" => "eou-120m".to_string(),
+        "asr-sidecar" | "asr" | "vibevoice" => config
+            .asr_sidecar
+            .as_ref()
+            .map(|v| v.model.clone())
+            .unwrap_or_else(|| "microsoft/VibeVoice-ASR-HF".to_string()),
         _ => "whisper-large-v3-turbo".to_string(),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ pub struct Config {
     pub local_vosk: Option<LocalVoskConfig>,
     #[serde(default, rename = "local-parakeet")]
     pub local_parakeet: Option<LocalParakeetConfig>,
+    #[serde(default, rename = "asr-sidecar", alias = "asr", alias = "vibevoice")]
+    pub asr_sidecar: Option<AsrSidecarConfig>,
     /// LLM configuration for command mode (text rewriting).
     #[serde(default)]
     pub llm: Option<llm::LlmConfig>,
@@ -340,6 +342,14 @@ pub struct LocalParakeetConfig {
     pub model_path: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AsrSidecarConfig {
+    #[serde(default = "default_asr_sidecar_url")]
+    pub url: String,
+    #[serde(default = "default_asr_sidecar_model")]
+    pub model: String,
+}
+
 fn default_backend() -> String {
     "groq".to_string()
 }
@@ -369,6 +379,12 @@ fn default_groq_model() -> String {
 }
 fn default_openai_model() -> String {
     "gpt-4o-mini-transcribe".to_string()
+}
+fn default_asr_sidecar_url() -> String {
+    "http://127.0.0.1:8765/transcribe".to_string()
+}
+fn default_asr_sidecar_model() -> String {
+    "microsoft/VibeVoice-ASR-HF".to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -525,10 +541,24 @@ impl Config {
                     });
                 }
             }
+            "asr-sidecar" | "asr" | "vibevoice" => {
+                let url = self
+                    .asr_sidecar
+                    .as_ref()
+                    .map(|v| v.url.trim())
+                    .unwrap_or("");
+                if url.is_empty() {
+                    return Err(WhisrsError::Config(
+                        "ASR sidecar backend selected but no sidecar URL configured.\n\
+                         Add [asr-sidecar] url to config.toml."
+                            .to_string(),
+                    ));
+                }
+            }
             other => {
                 return Err(WhisrsError::Config(format!(
                     "Unknown backend '{other}'. Valid options: deepgram, deepgram-streaming, \
-                     groq, openai, openai-realtime, local-whisper, local-vosk, local-parakeet"
+                     groq, openai, openai-realtime, local-whisper, local-vosk, local-parakeet, asr-sidecar"
                 )));
             }
         }
@@ -575,7 +605,13 @@ impl Config {
             || self.local_vosk.is_some()
             || self.local_parakeet.is_some();
 
-        has_deepgram || has_groq || has_openai || has_local
+        let has_asr_sidecar = self
+            .asr_sidecar
+            .as_ref()
+            .map(|v| !v.url.trim().is_empty())
+            .unwrap_or(false);
+
+        has_deepgram || has_groq || has_openai || has_local || has_asr_sidecar
     }
 }
 
@@ -773,6 +809,7 @@ mod tests {
             local_whisper: None,
             local_vosk: None,
             local_parakeet: None,
+            asr_sidecar: None,
             llm: None,
             hotkeys: None,
             overlay: None,
@@ -814,6 +851,7 @@ mod tests {
             local_whisper: None,
             local_vosk: None,
             local_parakeet: None,
+            asr_sidecar: None,
             llm: None,
             hotkeys: None,
             overlay: None,
@@ -840,12 +878,75 @@ mod tests {
             local_whisper: None,
             local_vosk: None,
             local_parakeet: None,
+            asr_sidecar: None,
             llm: None,
             hotkeys: None,
             overlay: None,
         };
         let result = config.validate();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn config_parse_asr_sidecar_defaults() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "asr-sidecar"
+
+            [asr-sidecar]
+            "#,
+        )
+        .unwrap();
+
+        let asr_sidecar = config.asr_sidecar.unwrap();
+        assert_eq!(asr_sidecar.url, "http://127.0.0.1:8765/transcribe");
+        assert_eq!(asr_sidecar.model, "microsoft/VibeVoice-ASR-HF");
+    }
+
+    #[test]
+    fn config_validate_asr_sidecar_with_url() {
+        let config = Config {
+            general: GeneralConfig {
+                backend: "asr-sidecar".to_string(),
+                ..Default::default()
+            },
+            audio: Default::default(),
+            input: Default::default(),
+            deepgram: None,
+            groq: None,
+            openai: None,
+            local_whisper: None,
+            local_vosk: None,
+            local_parakeet: None,
+            asr_sidecar: Some(AsrSidecarConfig {
+                url: "http://127.0.0.1:8765/transcribe".to_string(),
+                model: "microsoft/VibeVoice-ASR-HF".to_string(),
+            }),
+            llm: None,
+            hotkeys: None,
+            overlay: None,
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn config_parse_vibevoice_alias() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "vibevoice"
+
+            [vibevoice]
+            url = "http://127.0.0.1:8765/transcribe"
+            model = "microsoft/VibeVoice-ASR-HF"
+            "#,
+        )
+        .unwrap();
+
+        assert!(config.validate().is_ok());
+        assert!(config.asr_sidecar.is_some());
     }
 
     #[test]
@@ -867,6 +968,7 @@ mod tests {
             local_whisper: None,
             local_vosk: None,
             local_parakeet: None,
+            asr_sidecar: None,
             llm: None,
             hotkeys: None,
             overlay: None,

--- a/src/transcription/asr_sidecar.rs
+++ b/src/transcription/asr_sidecar.rs
@@ -1,0 +1,182 @@
+//! Generic HTTP ASR sidecar transcription backend.
+//!
+//! This backend keeps the Rust daemon independent from Python/PyTorch by
+//! sending WAV audio to a local HTTP sidecar.
+
+use async_trait::async_trait;
+use reqwest::multipart;
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+use super::{TranscriptionBackend, TranscriptionConfig};
+
+/// Keep a guardrail so a runaway recording does not create an unbounded
+/// multipart request.
+const MAX_FILE_SIZE: usize = 1024 * 1024 * 1024;
+
+/// Generic HTTP ASR sidecar transcription backend.
+pub struct AsrSidecarBackend {
+    client: reqwest::Client,
+    url: String,
+}
+
+impl AsrSidecarBackend {
+    /// Create a new sidecar backend with the transcription URL.
+    pub fn new(url: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            url,
+        }
+    }
+}
+
+/// Response from the ASR sidecar.
+#[derive(Debug, Deserialize)]
+pub struct AsrSidecarResponse {
+    /// Plain text transcript. Sidecars may also return richer diarized output,
+    /// but whisrs currently consumes the flattened text for typing.
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AsrSidecarErrorResponse {
+    error: Option<String>,
+    detail: Option<serde_json::Value>,
+}
+
+impl AsrSidecarErrorResponse {
+    fn message(&self) -> String {
+        if let Some(error) = &self.error {
+            return error.clone();
+        }
+        match &self.detail {
+            Some(serde_json::Value::String(detail)) => detail.clone(),
+            Some(detail) => detail.to_string(),
+            None => "unknown sidecar error".to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl TranscriptionBackend for AsrSidecarBackend {
+    async fn transcribe(
+        &self,
+        audio: &[u8],
+        config: &TranscriptionConfig,
+    ) -> anyhow::Result<String> {
+        if audio.len() > MAX_FILE_SIZE {
+            anyhow::bail!(
+                "audio file too large ({} bytes, max {} bytes / 1GB)",
+                audio.len(),
+                MAX_FILE_SIZE
+            );
+        }
+
+        if audio.is_empty() {
+            anyhow::bail!("cannot transcribe empty audio");
+        }
+
+        if self.url.trim().is_empty() {
+            anyhow::bail!("no ASR sidecar URL configured");
+        }
+
+        debug!(
+            "sending {} bytes to ASR sidecar (model={}, language={})",
+            audio.len(),
+            config.model,
+            config.language
+        );
+
+        let file_part = multipart::Part::bytes(audio.to_vec())
+            .file_name("audio.wav")
+            .mime_str("audio/wav")?;
+
+        let mut form = multipart::Form::new()
+            .part("file", file_part)
+            .text("model", config.model.clone());
+
+        if config.language != "auto" {
+            form = form.text("language", config.language.clone());
+        }
+        if let Some(prompt) = &config.prompt {
+            form = form.text("hotwords", prompt.clone());
+        }
+
+        let response = self.client.post(&self.url).multipart(form).send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+
+        if !status.is_success() {
+            if let Ok(err_resp) = serde_json::from_str::<AsrSidecarErrorResponse>(&body) {
+                anyhow::bail!(
+                    "ASR sidecar error ({}): {}",
+                    status.as_u16(),
+                    err_resp.message()
+                );
+            }
+            anyhow::bail!("ASR sidecar error ({}): {}", status.as_u16(), body);
+        }
+
+        let parsed: AsrSidecarResponse = serde_json::from_str(&body)?;
+        let text = parsed.text.trim().to_string();
+
+        if text.is_empty() {
+            warn!("ASR sidecar returned empty transcription");
+        }
+
+        Ok(text)
+    }
+
+    // Uses the default transcribe_stream (collect + transcribe). Model-specific
+    // streaming behavior belongs in the sidecar process.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn transcribe_rejects_empty_audio() {
+        let backend = AsrSidecarBackend::new("http://127.0.0.1:8765/transcribe".to_string());
+        let config = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "test-asr-model".to_string(),
+            prompt: None,
+        };
+        let err = backend.transcribe(&[], &config).await.unwrap_err();
+        assert!(err.to_string().contains("empty audio"));
+    }
+
+    #[tokio::test]
+    async fn transcribe_rejects_missing_url() {
+        let backend = AsrSidecarBackend::new(String::new());
+        let config = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "test-asr-model".to_string(),
+            prompt: None,
+        };
+        let err = backend.transcribe(&[1, 2, 3], &config).await.unwrap_err();
+        assert!(err.to_string().contains("sidecar URL"));
+    }
+
+    #[test]
+    fn parse_asr_sidecar_response() {
+        let body = r#"{"text": "Hello world"}"#;
+        let parsed: AsrSidecarResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.text, "Hello world");
+    }
+
+    #[test]
+    fn parse_asr_sidecar_error() {
+        let body = r#"{"error": "model failed to load"}"#;
+        let parsed: AsrSidecarErrorResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.message(), "model failed to load");
+    }
+
+    #[test]
+    fn parse_fastapi_error_detail() {
+        let body = r#"{"detail": "request asked for wrong model"}"#;
+        let parsed: AsrSidecarErrorResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.message(), "request asked for wrong model");
+    }
+}

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -1,5 +1,6 @@
 //! Transcription backends: trait definition and implementations.
 
+pub mod asr_sidecar;
 pub mod dedup;
 pub mod deepgram;
 pub mod groq;


### PR DESCRIPTION
## Summary

Adds a generic ASR sidecar backend to whisrs. The daemon can now send captured WAV audio to a local HTTP `/transcribe` service, pass model/language/vocabulary metadata, and consume a plain JSON transcript response without embedding Python or ML runtimes in `whisrsd`.

Also ships local FastAPI sidecars for Moonshine, Microsoft VibeVoice-ASR, and NVIDIA Parakeet. These cover lightweight English dictation, long-form local transcription experiments, and high-quality multilingual local GPU dictation.

## Changes

- Add `src/transcription/asr_sidecar.rs` generic HTTP backend using multipart WAV upload
- Wire `asr-sidecar`, `asr`, and `vibevoice` backend aliases into config validation, setup, model selection, and daemon backend creation
- Forward sidecar request metadata: `model`, `language`, and vocabulary prompt as `hotwords`
- Add `contrib/asr-sidecars/` with shared protocol documentation
- Add Moonshine sidecar with `UsefulSensors/moonshine-base` default model
- Add VibeVoice sidecar with `microsoft/VibeVoice-ASR-HF` default model
- Add Parakeet sidecar with `nvidia/parakeet-tdt-0.6b-v3` default model
- Add `config.toml.example` snippets for all bundled sidecars
- Document AMD/ROCm handling for Parakeet; CUDA graph decoding is disabled by default so NeMo does not require NVIDIA `libcuda.so.1`
- Update README and manpage/setup docs with ASR sidecar usage

## Testing

Tested on AMD ROCm with the Parakeet sidecar. Steps:

1. Start the sidecar with `HIP_VISIBLE_DEVICES=0 ROCR_VISIBLE_DEVICES=0 python server.py --device cuda:0 --batch-size 1`
2. Configure whisrs with `backend = "asr-sidecar"`, `language = "auto"`, and model `nvidia/parakeet-tdt-0.6b-v3`
3. Start `whisrsd`
4. Trigger recording and dictate a sentence mixing English and Portuguese — Parakeet correctly detects both languages in the same sentence

Also checked the sidecar Python entrypoint syntax with:

```bash
python3 -m py_compile contrib/asr-sidecars/parakeet/server.py
```

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (211 tests)
- [x] Parakeet sidecar manually tested on AMD ROCm
- [x] Moonshine sidecar manually tested on AMD ROCm
- [x] VibeVoice sidecar manually tested on AMD ROCm
