### PR TITLE
feat: add Niri window tracking via IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 
 **whisrs is a Linux voice-to-text dictation tool written in Rust that transcribes speech via 6 backends — Groq, Deepgram REST, Deepgram Streaming, OpenAI REST, OpenAI Realtime, and local whisper.cpp — and types it into the focused window. It is the open-source Wispr Flow alternative for Linux.**
 
-Press a hotkey, speak, and your words appear at the cursor in any focused app on Wayland, X11, Hyprland, Sway, GNOME, or KDE. Audio is captured via cpal across PipeWire, PulseAudio, and ALSA. Fully offline local transcription runs in under 500 MB of RAM with `base.en`. Fast, private, open source.
+Press a hotkey, speak, and your words appear at the cursor in any focused app on Wayland, X11, Hyprland, Sway, Niri, GNOME, or KDE. Audio is captured via cpal across PipeWire, PulseAudio, and ALSA. Fully offline local transcription runs in under 500 MB of RAM with `base.en`. Fast, private, open source.
 
 ---
 
 ## How does whisrs differ from Wispr Flow and Superwhisper?
 
-Wispr Flow and Superwhisper are closed-source dictation apps that don't run on Linux. whisrs is open source (MIT), Linux-native, and ships as a single async Rust process with native keyboard layout support (uinput + XKB), window tracking across Hyprland, Sway, X11, GNOME, and KDE, and 6 swappable transcription backends — both cloud (Groq, Deepgram, OpenAI) and fully offline (whisper.cpp). [xhisper](https://github.com/imaginalnika/xhisper) proved the concept on Linux; whisrs rebuilds it from scratch in Rust with broader compositor support and a daemon/CLI architecture you can bind to any hotkey.
+Wispr Flow and Superwhisper are closed-source dictation apps that don't run on Linux. whisrs is open source (MIT), Linux-native, and ships as a single async Rust process with native keyboard layout support (uinput + XKB), window tracking across Hyprland, Sway, Niri, X11, GNOME, and KDE, and 6 swappable transcription backends — both cloud (Groq, Deepgram, OpenAI) and fully offline (whisper.cpp). [xhisper](https://github.com/imaginalnika/xhisper) proved the concept on Linux; whisrs rebuilds it from scratch in Rust with broader compositor support and a daemon/CLI architecture you can bind to any hotkey.
 
 ---
 
@@ -198,21 +198,22 @@ whisrs log --clear  # Clear all history
 
 <a id="supported-environments"></a>
 
-## Does whisrs work on Wayland, GNOME, KDE, Hyprland, and Sway?
+## Does whisrs work on Wayland, GNOME, KDE, Hyprland, Sway, and Niri?
 
-Yes. whisrs runs natively on both Wayland and X11 across Hyprland, Sway, i3, GNOME Wayland, KDE Wayland, and any X11 window manager — with daily-driver coverage on Hyprland and community-confirmed reports on GNOME Wayland and Xorg. Audio capture works on PipeWire, PulseAudio, and ALSA via cpal.
+Yes. whisrs runs natively on both Wayland and X11 across Hyprland, Sway, Niri, i3, GNOME Wayland, KDE Wayland, and any X11 window manager — with daily-driver coverage on Hyprland and community-confirmed reports on GNOME Wayland and Xorg. Audio capture works on PipeWire, PulseAudio, and ALSA via cpal.
 
 | Component | Support |
 |---|---|
 | **Hyprland** | Tested by maintainer and community (Arch Linux) |
 | **Sway / i3** | Implemented; additional reports welcome |
+| **Niri** | Implemented; tested by contributor on Niri 26.04 (CachyOS) |
 | **X11 (any WM)** | Tested by community on Ubuntu 24.04 (Xorg) |
 | **GNOME Wayland** | Tested by community on Ubuntu 24.04 and Arch (mutter); overlay via the bundled [GNOME Shell extension](contrib/gnome-shell-extension/README.md) |
 | **KDE Wayland** | Implemented via D-Bus; reports welcome |
 | **Audio** | PipeWire, PulseAudio, ALSA (auto-detected via cpal) |
 | **Distros** | Confirmed on Arch Linux and Ubuntu 24.04; any Linux with the system dependencies above |
 
-> **Note:** whisrs is daily-driven on Hyprland (Arch Linux), with community confirmation on GNOME Wayland (Ubuntu 24.04 + Arch) and Xorg (Ubuntu 24.04). Sway, i3, and KDE reports are still wanted — if you use whisrs there, please open an issue with what works and what doesn't.
+> **Note:** whisrs is daily-driven on Hyprland (Arch Linux), with community confirmation on GNOME Wayland (Ubuntu 24.04 + Arch), Xorg (Ubuntu 24.04), and Niri (CachyOS). Sway, i3, and KDE reports are still wanted — if you use whisrs there, please open an issue with what works and what doesn't.
 
 ---
 
@@ -254,7 +255,7 @@ whisrs is the open source alternative to closed-source dictation apps like **Wis
 | **Cloud transcription** | Groq, Deepgram (REST + streaming), OpenAI, OpenAI Realtime | No | No | Proprietary |
 | **True streaming** | Yes (OpenAI Realtime) | No | No | Yes |
 | **Keyboard injection** | uinput + XKB (layout-aware) | xdotool | Clipboard paste | Native |
-| **Window tracking** | Hyprland, Sway, X11, GNOME, KDE | No | No | Native |
+| **Window tracking** | Hyprland, Sway, Niri, X11, GNOME, KDE | No | No | Native |
 | **Architecture** | Daemon + CLI (bind to any hotkey) | Script | GUI app | GUI app |
 | **Language** | Rust | Python | C++/Qt | Closed source |
 | **Setup** | Interactive (`whisrs setup`) | Manual config | GUI | Installer |

--- a/contrib/whisrs.service
+++ b/contrib/whisrs.service
@@ -11,7 +11,7 @@ RestartSec=3
 
 # Import compositor environment variables so window tracking works.
 # These are set by the compositor/session and must be passed through.
-PassEnvironment=HYPRLAND_INSTANCE_SIGNATURE SWAYSOCK WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP XDG_RUNTIME_DIR
+PassEnvironment=HYPRLAND_INSTANCE_SIGNATURE NIRI_SOCKET SWAYSOCK WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP XDG_RUNTIME_DIR
 
 # Logging
 StandardOutput=journal

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -788,7 +788,7 @@ fn setup_systemd_service() {
                      ExecStart={whisrsd_path}\n\
                      Restart=on-failure\n\
                      RestartSec=3\n\
-                     PassEnvironment=HYPRLAND_INSTANCE_SIGNATURE SWAYSOCK WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP XDG_RUNTIME_DIR\n\
+                     PassEnvironment=HYPRLAND_INSTANCE_SIGNATURE NIRI_SOCKET SWAYSOCK WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP XDG_RUNTIME_DIR\n\
                      StandardOutput=journal\n\
                      StandardError=journal\n\
                      \n\

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod dbus;
 pub mod hyprland;
+pub mod niri;
 pub mod sway;
 pub mod x11;
 
@@ -43,13 +44,19 @@ impl WindowTracker for NoopTracker {
 ///
 /// Detection order:
 /// 1. `$HYPRLAND_INSTANCE_SIGNATURE` → Hyprland
-/// 2. `$SWAYSOCK` → Sway
-/// 3. `$XDG_SESSION_TYPE == x11` → X11
-/// 4. Fallback → NoopTracker
+/// 2. `$NIRI_SOCKET` → Niri
+/// 3. `$SWAYSOCK` → Sway
+/// 4. `$XDG_SESSION_TYPE == x11` → X11
+/// 5. Fallback → NoopTracker
 pub fn detect_tracker() -> Box<dyn WindowTracker> {
     if std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok() {
         info!("detected Hyprland compositor for window tracking");
         return Box::new(hyprland::HyprlandTracker::new());
+    }
+
+    if std::env::var("NIRI_SOCKET").is_ok() {
+        info!("detected Niri compositor for window tracking");
+        return Box::new(niri::NiriTracker::new());
     }
 
     if std::env::var("SWAYSOCK").is_ok() {

--- a/src/window/niri.rs
+++ b/src/window/niri.rs
@@ -1,0 +1,151 @@
+//! Niri window tracking via `niri msg` commands.
+
+use std::process::Command;
+
+use anyhow::Context;
+use serde::Deserialize;
+use tracing::debug;
+
+use super::WindowTracker;
+
+/// Window tracker for the Niri compositor.
+///
+/// Uses `niri msg --json focused-window` to query the current focus and
+/// `niri msg action focus-window --id <ID>` to restore it. Niri's CLI is the
+/// stable boundary here; talking to the IPC socket directly would save one
+/// process spawn, but it would also duplicate request framing that the CLI
+/// already owns.
+pub struct NiriTracker;
+
+impl Default for NiriTracker {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl NiriTracker {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Parsed JSON output from `niri msg --json focused-window`.
+#[derive(Debug, Deserialize)]
+struct NiriFocusedWindow {
+    /// Niri's stable window ID, used by targeted window actions.
+    id: u64,
+    /// Wayland application ID, equivalent to the class-like identifier used by
+    /// terminal-aware command mode.
+    #[serde(default)]
+    app_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum NiriFocusedWindowResponse {
+    /// Current `niri msg --json focused-window` output.
+    FocusedWindow(NiriFocusedWindow),
+    /// Raw IPC response shape documented for direct socket access.
+    IpcEnvelope {
+        #[serde(rename = "Ok")]
+        ok: NiriIpcOk,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+enum NiriIpcOk {
+    FocusedWindow(NiriFocusedWindow),
+}
+
+impl NiriFocusedWindowResponse {
+    fn into_window(self) -> NiriFocusedWindow {
+        match self {
+            Self::FocusedWindow(window) => window,
+            Self::IpcEnvelope {
+                ok: NiriIpcOk::FocusedWindow(window),
+            } => window,
+        }
+    }
+}
+
+impl WindowTracker for NiriTracker {
+    fn get_focused_window(&self) -> anyhow::Result<String> {
+        let focused_window = query_focused_window()?;
+
+        debug!("niri focused window id: {}", focused_window.id);
+        Ok(focused_window.id.to_string())
+    }
+
+    fn get_focused_window_class(&self) -> Option<String> {
+        let focused_window = query_focused_window().ok()?;
+        focused_window.app_id.filter(|app_id| !app_id.is_empty())
+    }
+
+    fn focus_window(&self, id: &str) -> anyhow::Result<()> {
+        let id: u64 = id
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid niri window id: {id}"))?;
+
+        debug!("focusing niri window id: {id}");
+
+        let output = Command::new("niri")
+            .args(["msg", "action", "focus-window", "--id", &id.to_string()])
+            .output()
+            .context("failed to run niri msg action focus-window")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("niri msg action focus-window failed: {stderr}");
+        }
+
+        Ok(())
+    }
+}
+
+fn query_focused_window() -> anyhow::Result<NiriFocusedWindow> {
+    let output = Command::new("niri")
+        .args(["msg", "--json", "focused-window"])
+        .output()
+        .context("failed to run niri msg --json focused-window — is Niri running?")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("niri msg --json focused-window failed: {stderr}");
+    }
+
+    parse_focused_window(&output.stdout)
+}
+
+fn parse_focused_window(stdout: &[u8]) -> anyhow::Result<NiriFocusedWindow> {
+    let parsed: NiriFocusedWindowResponse =
+        serde_json::from_slice(stdout).context("failed to parse niri focused-window JSON")?;
+
+    Ok(parsed.into_window())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_focused_window_cli_json() {
+        let window = parse_focused_window(
+            br#"{"id":12,"title":"shell","app_id":"Alacritty","workspace_id":6,"is_focused":true}"#,
+        )
+        .unwrap();
+
+        assert_eq!(window.id, 12);
+        assert_eq!(window.app_id.as_deref(), Some("Alacritty"));
+    }
+
+    #[test]
+    fn parses_focused_window_ipc_envelope() {
+        let window = parse_focused_window(
+            br#"{"Ok":{"FocusedWindow":{"id":12,"title":"shell","app_id":"Alacritty","workspace_id":6,"is_focused":true}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(window.id, 12);
+        assert_eq!(window.app_id.as_deref(), Some("Alacritty"));
+    }
+}


### PR DESCRIPTION
## Summary

Add window tracking for the [Niri](https://github.com/YaLTeR/niri) compositor so dictation can restore focus to the original window when a transient surface (notification, overlay) steals it mid-recording. Niri sessions previously fell through to the noop tracker and lost focus context after every transcription.

## Changes

- New `src/window/niri.rs` implementing `WindowTracker` via `niri msg`, mirroring the Hyprland tracker in shape (CLI shell-out rather than direct socket access, to match the existing style and avoid an extra dependency for one feature).
- `src/window/mod.rs`: detect Niri via `$NIRI_SOCKET` between Hyprland and Sway in `detect_tracker()`, and update the doc-comment ordering accordingly.
- `contrib/whisrs.service` and the embedded systemd template in `src/config/setup.rs`: add `NIRI_SOCKET` to `PassEnvironment` so the daemon inherits it under systemd-managed installs.
- Unit tests for both the current `niri msg --json focused-window` output shape and the wrapped IPC envelope shape, so future schema drift is caught at parse time rather than silently breaking focus capture.

## Testing

- **Compositor:** Niri 26.04 (`8ed0da4`)
- **Distro:** CachyOS (Arch-based, kernel 7.0.2-2-cachyos)
- **Audio backend:** PipeWire

Verified by toggling dictation, switching focus mid-recording with a Niri keybind, and stopping — text lands in the original window. Daemon logs went from:

```
INFO whisrsd: captured source window: noop
```

to:

```
INFO whisrs::window: detected Niri compositor for window tracking
INFO whisrsd: captured source window: 7
```

where `7` is the real Niri window id of the originally focused window.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass locally; the two new tests run as part of the standard suite.

## Checklist

- [x] \`cargo fmt\` passes
- [x] \`cargo clippy --all-targets -- -D warnings\` passes
- [x] \`cargo test\` passes
- [x] Tested on at least one compositor