### PR TITLE
Drop empty/silent recordings and prompt-echo hallucinations

### DIFF
--- a/src/audio/capture.rs
+++ b/src/audio/capture.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, info, warn};
 use super::AudioChunk;
 
 /// Desired sample rate for speech recognition.
-const SAMPLE_RATE: u32 = 16_000;
+pub const SAMPLE_RATE: u32 = 16_000;
 
 /// Number of channels (mono).
 const CHANNELS: u16 = 1;

--- a/src/audio/silence.rs
+++ b/src/audio/silence.rs
@@ -3,6 +3,13 @@
 //! Used to detect when the user has stopped speaking, for auto-stop
 //! and VAD-based chunk splitting.
 
+/// Normalized RMS threshold below which audio is considered silence.
+///
+/// Shared between [`AutoStopDetector`] and [`audio_gate_reason`] so the gate
+/// agrees with auto-stop on what counts as silence — empirically, recordings
+/// whose entire duration sits under this floor carry no usable speech.
+pub const SILENCE_RMS_THRESHOLD: f64 = 0.003;
+
 /// Calculate the RMS (root mean square) energy of a slice of i16 samples.
 ///
 /// Returns a value between 0.0 and 1.0 (normalized to the i16 range).
@@ -24,6 +31,62 @@ pub fn rms_energy(samples: &[i16]) -> f64 {
 /// produces RMS around 0.02–0.15; silence is usually below 0.005.
 pub fn is_silent(samples: &[i16], threshold: f64) -> bool {
     rms_energy(samples) < threshold
+}
+
+/// Reason a recorded buffer should be skipped instead of sent to a transcription
+/// backend.
+///
+/// Returned by [`audio_gate_reason`]; carries a short human-readable label
+/// that the daemon logs and surfaces in notifications.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateReason {
+    Empty,
+    /// Recording shorter than the minimum allowed duration.
+    TooShort,
+    Silent,
+}
+
+impl GateReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GateReason::Empty => "empty",
+            GateReason::TooShort => "too short",
+            GateReason::Silent => "silent",
+        }
+    }
+}
+
+/// Decide whether an audio buffer is too empty/silent to bother sending to a
+/// cloud transcription backend.
+///
+/// Returns `Some(reason)` when the buffer should be discarded outright, `None`
+/// otherwise. Thresholds are intentionally permissive — the goal is to filter
+/// out the obviously unusable cases (accidental hotkey taps, recordings that
+/// captured only background hum) that would otherwise reach the API. Cloud
+/// Whisper variants (whisper-1, gpt-4o-*-transcribe) hallucinate verbatim
+/// chunks of the supplied `prompt` when the audio carries no speech, so this
+/// gate is the first line of defence against prompt-echo output.
+pub fn audio_gate_reason(
+    samples: &[i16],
+    sample_rate: u32,
+    min_duration_ms: u64,
+    threshold: f64,
+) -> Option<GateReason> {
+    debug_assert!(
+        sample_rate > 0,
+        "audio_gate_reason requires sample_rate > 0"
+    );
+    if samples.is_empty() {
+        return Some(GateReason::Empty);
+    }
+    let duration_ms = (samples.len() as u64).saturating_mul(1000) / sample_rate as u64;
+    if duration_ms < min_duration_ms {
+        return Some(GateReason::TooShort);
+    }
+    if is_silent(samples, threshold) {
+        return Some(GateReason::Silent);
+    }
+    None
 }
 
 /// Tracks consecutive silent frames and signals when silence has exceeded
@@ -193,6 +256,45 @@ mod tests {
 
         detector.reset();
         assert!(!detector.has_speech());
+    }
+
+    // --- audio_gate_reason tests ---
+
+    #[test]
+    fn gate_rejects_empty() {
+        assert_eq!(
+            audio_gate_reason(&[], 16_000, 300, 0.005),
+            Some(GateReason::Empty)
+        );
+    }
+
+    #[test]
+    fn gate_rejects_too_short() {
+        // 100ms at 16kHz = 1600 samples; threshold 300ms.
+        let samples: Vec<i16> = vec![10_000; 1_600];
+        assert_eq!(
+            audio_gate_reason(&samples, 16_000, 300, 0.005),
+            Some(GateReason::TooShort)
+        );
+    }
+
+    #[test]
+    fn gate_rejects_silent_long_recording() {
+        // 1s of pure silence — long enough but below threshold.
+        let samples = vec![0i16; 16_000];
+        assert_eq!(
+            audio_gate_reason(&samples, 16_000, 300, 0.005),
+            Some(GateReason::Silent)
+        );
+    }
+
+    #[test]
+    fn gate_accepts_speech() {
+        // ~50% amplitude tone, 1s — clearly above threshold.
+        let samples: Vec<i16> = (0..16_000)
+            .map(|i| ((i as f64 * 0.1).sin() * 16_000.0) as i16)
+            .collect();
+        assert_eq!(audio_gate_reason(&samples, 16_000, 300, 0.005), None);
     }
 
     #[test]

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -7,14 +7,15 @@ use tokio::net::UnixListener;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
-use whisrs::audio::capture::AudioCaptureHandle;
+use whisrs::audio::capture::{AudioCaptureHandle, SAMPLE_RATE};
 use whisrs::audio::feedback;
-use whisrs::audio::silence::AutoStopDetector;
+use whisrs::audio::silence::{audio_gate_reason, AutoStopDetector, SILENCE_RMS_THRESHOLD};
 use whisrs::history::{self, HistoryEntry};
 use whisrs::input::clipboard::ClipboardOps;
 use whisrs::input::ClipboardHandler;
 use whisrs::llm;
 use whisrs::post_processing::filler::remove_filler_words;
+use whisrs::post_processing::prompt_echo::is_prompt_echo;
 use whisrs::state::{Action, StateMachine};
 use whisrs::transcription::deepgram::{DeepgramRestBackend, DeepgramStreamingBackend};
 use whisrs::transcription::groq::GroqBackend;
@@ -205,6 +206,10 @@ const COMPOSITOR_ENV_MAX_RETRIES: u32 = 10;
 
 /// Initial retry delay for compositor env detection (doubles each attempt, capped at 10 s).
 const COMPOSITOR_ENV_INITIAL_DELAY: Duration = Duration::from_secs(1);
+
+/// Minimum recording duration accepted by the gate. Anything shorter is almost
+/// certainly an accidental hotkey tap.
+const AUDIO_GATE_MIN_MS: u64 = 300;
 
 /// Compositor environment variables to import from systemd.
 const COMPOSITOR_ENV_VARS: &[&str] = &[
@@ -1060,7 +1065,8 @@ async fn run_streaming_pipeline(
     });
 
     // Forward audio from capture to backend, with auto-stop detection.
-    let mut auto_stop = AutoStopDetector::new(0.003, silence_timeout_ms, 16_000);
+    let mut auto_stop =
+        AutoStopDetector::new(SILENCE_RMS_THRESHOLD, silence_timeout_ms, SAMPLE_RATE);
 
     while let Some(chunk) = audio_rx.recv().await {
         // Check for auto-stop.
@@ -1181,6 +1187,30 @@ async fn process_recording_batch(
 
     info!("collected {} audio samples", samples.len());
 
+    // Skip the API call entirely when the recording is empty, too short, or
+    // pure silence. Cloud Whisper variants (whisper-1, gpt-4o-*-transcribe)
+    // hallucinate verbatim chunks of the supplied prompt when handed audio
+    // with no speech, which whisrs would then type at the cursor — for a
+    // multi-hundred-character prompt that means tens of seconds of garbage
+    // typing on every accidental hotkey tap. Filtering here also saves the
+    // round-trip cost.
+    if let Some(reason) = audio_gate_reason(
+        &samples,
+        SAMPLE_RATE,
+        AUDIO_GATE_MIN_MS,
+        SILENCE_RMS_THRESHOLD,
+    ) {
+        let label = reason.as_str();
+        info!(
+            "skipping transcription: recording was {label} ({} samples)",
+            samples.len()
+        );
+        if context.notify_state() {
+            send_notification("whisrs", &format!("Skipped: recording was {label}"));
+        }
+        return Ok(String::new());
+    }
+
     let wav_data = encode_wav(&samples)?;
     info!("encoded WAV: {} bytes", wav_data.len());
 
@@ -1220,6 +1250,28 @@ async fn process_recording_batch(
             return Err(e);
         }
     };
+
+    // Defence in depth against prompt-echo hallucinations: even with the
+    // upstream gate, low-SNR recordings (tap microphones, very brief speech
+    // followed by silence) sometimes squeak through and trigger the model to
+    // regurgitate the prompt. Drop those before they reach the keyboard.
+    if config
+        .prompt
+        .as_deref()
+        .is_some_and(|prompt| is_prompt_echo(&text, prompt))
+    {
+        warn!(
+            "discarding likely prompt-echo response ({} chars) — see post_processing::prompt_echo",
+            text.len()
+        );
+        if context.notify_state() {
+            send_notification(
+                "whisrs",
+                "Skipped: response looked like a prompt echo (no speech detected)",
+            );
+        }
+        return Ok(String::new());
+    }
 
     // Apply filler word removal if enabled.
     let text = if context.config.general.remove_filler_words {
@@ -1560,7 +1612,7 @@ async fn command_mode_background(
     context: Arc<DaemonContext>,
 ) {
     let silence_timeout = context.config.general.silence_timeout_ms;
-    let mut auto_stop = AutoStopDetector::new(0.003, silence_timeout, 16_000);
+    let mut auto_stop = AutoStopDetector::new(SILENCE_RMS_THRESHOLD, silence_timeout, SAMPLE_RATE);
     let mut all_samples: Vec<i16> = Vec::new();
 
     // Collect audio until silence auto-stop or channel close (manual stop).
@@ -1605,9 +1657,19 @@ async fn command_mode_background(
         feedback::play_stop(context.config.general.audio_feedback_volume);
     }
 
-    if all_samples.is_empty() {
+    if let Some(reason) = audio_gate_reason(
+        &all_samples,
+        SAMPLE_RATE,
+        AUDIO_GATE_MIN_MS,
+        SILENCE_RMS_THRESHOLD,
+    ) {
+        let label = reason.as_str();
+        info!(
+            "command mode: skipping (recording was {label}, {} samples)",
+            all_samples.len()
+        );
         if context.notify_error() {
-            send_notification("whisrs", "Command mode: no audio captured");
+            send_notification("whisrs", &format!("Command mode: recording was {label}"));
         }
         let mut ds = daemon_state.lock().await;
         let _ = ds.state_machine.transition(Action::TranscriptionDone);

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -1,3 +1,4 @@
 //! Post-processing pipeline for transcribed text.
 
 pub mod filler;
+pub mod prompt_echo;

--- a/src/post_processing/prompt_echo.rs
+++ b/src/post_processing/prompt_echo.rs
@@ -1,0 +1,187 @@
+//! Detect prompt-echo hallucinations from cloud STT backends.
+//!
+//! Whisper-family models (OpenAI `whisper-1`, `gpt-4o-*-transcribe`, and most
+//! Whisper-derived APIs) condition decoding on the optional `prompt` parameter.
+//! When the audio carries no speech the model has nothing to anchor decoding
+//! to and falls back to its strongest prior — the prompt itself — emitting it
+//! verbatim (or in long contiguous chunks) as the "transcription".
+//!
+//! Without filtering, those echoes are typed at the cursor by whisrs, which
+//! for a multi-hundred-character prompt can take tens of seconds at the
+//! configured key delay. This module provides a conservative substring/word-run
+//! heuristic that flags the obvious cases without false-positiving on real
+//! speech that happens to use vocabulary present in the prompt.
+
+/// Lowercase, drop non-alphanumeric characters (replaced with whitespace), and
+/// collapse runs of whitespace. The output is suitable for substring/word-run
+/// comparisons that ignore punctuation, casing, and incidental spacing.
+fn normalize(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = true;
+    for c in s.chars() {
+        if c.is_alphanumeric() {
+            for lc in c.to_lowercase() {
+                out.push(lc);
+            }
+            prev_space = false;
+        } else if !prev_space {
+            out.push(' ');
+            prev_space = true;
+        }
+    }
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// Heuristically classify `response` as an echo of `prompt`.
+///
+/// Two checks, both intentionally conservative:
+///
+/// 1. After normalisation, the entire response is a substring of the prompt.
+///    This covers the common case where the model regurgitates a contiguous
+///    chunk of the prompt verbatim.
+/// 2. The longest contiguous word-run that appears in both response and prompt
+///    spans at least 6 words **and** covers at least 70% of the response. This
+///    catches partial echoes where the model added a couple of stray words
+///    around an otherwise verbatim regurgitation.
+///
+/// Short responses (fewer than 8 normalised characters or 6 words for the
+/// run-based check) are never flagged: they could plausibly be a real one-word
+/// utterance that overlaps the prompt's vocabulary, and the pain-from-typing
+/// cost of letting such a short response through is negligible.
+pub fn is_prompt_echo(response: &str, prompt: &str) -> bool {
+    let resp = normalize(response);
+    let prompt_n = normalize(prompt);
+
+    if resp.chars().count() < 8 || prompt_n.is_empty() {
+        return false;
+    }
+
+    if prompt_n.contains(&resp) {
+        return true;
+    }
+
+    let resp_words: Vec<&str> = resp.split_whitespace().collect();
+    let prompt_words: Vec<&str> = prompt_n.split_whitespace().collect();
+    if resp_words.len() < 6 {
+        return false;
+    }
+    let max_run = longest_common_word_run(&resp_words, &prompt_words);
+    max_run >= 6 && max_run.saturating_mul(10) >= resp_words.len().saturating_mul(7)
+}
+
+/// Length of the longest contiguous run of equal words shared between `a` and
+/// `b`, computed with the standard rolling longest-common-substring DP.
+///
+/// O(|a| * |b|) time, O(|b|) space. Prompts in practice are well under a
+/// thousand words, so this is comfortably fast.
+fn longest_common_word_run(a: &[&str], b: &[&str]) -> usize {
+    if a.is_empty() || b.is_empty() {
+        return 0;
+    }
+    let mut best = 0usize;
+    let mut prev = vec![0usize; b.len()];
+    let mut curr = vec![0usize; b.len()];
+    for ai in a {
+        for (j, bj) in b.iter().enumerate() {
+            curr[j] = if ai == bj {
+                if j == 0 {
+                    1
+                } else {
+                    prev[j - 1] + 1
+                }
+            } else {
+                0
+            };
+            if curr[j] > best {
+                best = curr[j];
+            }
+        }
+        std::mem::swap(&mut prev, &mut curr);
+        curr.fill(0);
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_PROMPT: &str = "John Doe speaking. Professional, culinary register: \
+        French pastry, sourdough baking, fermentation science, restaurant kitchen workflows. \
+        Speech is in English or French; transcribe in the spoken language.";
+
+    #[test]
+    fn empty_prompt_never_echoes() {
+        assert!(!is_prompt_echo("hello world this is a test", ""));
+    }
+
+    #[test]
+    fn empty_response_not_echo() {
+        assert!(!is_prompt_echo("", SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn short_response_not_echo() {
+        // Could be a legitimate single word; refuse to flag.
+        assert!(!is_prompt_echo("John.", SAMPLE_PROMPT));
+        assert!(!is_prompt_echo("pastry", SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn full_prompt_echo_detected() {
+        assert!(is_prompt_echo(SAMPLE_PROMPT, SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn prefix_chunk_echo_detected() {
+        let chunk = "John Doe speaking. Professional, culinary register: \
+            French pastry, sourdough baking";
+        assert!(is_prompt_echo(chunk, SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn punctuation_and_case_insensitive() {
+        let chunk = "JOHN DOE SPEAKING — professional / culinary register";
+        assert!(is_prompt_echo(chunk, SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn partial_echo_with_extra_words_detected() {
+        // Model regurgitated a long prompt run with a couple of stray words.
+        let resp = "okay um John Doe speaking professional culinary register French \
+            pastry sourdough baking right";
+        assert!(is_prompt_echo(resp, SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn real_speech_not_flagged() {
+        // Real utterance that happens to share vocabulary with the prompt but
+        // doesn't echo a long contiguous run.
+        let resp = "let's rebase this branch onto master and push it up to my fork";
+        assert!(!is_prompt_echo(resp, SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn real_speech_with_isolated_prompt_terms_not_flagged() {
+        // Several prompt terms appear but scattered, no long contiguous run.
+        let resp = "I am working on the sourdough recipe for a French pastry tonight";
+        assert!(!is_prompt_echo(resp, SAMPLE_PROMPT));
+    }
+
+    #[test]
+    fn longest_run_basic() {
+        let a = ["the", "quick", "brown", "fox"];
+        let b = ["jumps", "over", "the", "quick", "brown", "dog"];
+        assert_eq!(longest_common_word_run(&a, &b), 3);
+    }
+
+    #[test]
+    fn longest_run_no_overlap() {
+        let a = ["alpha", "beta"];
+        let b = ["gamma", "delta"];
+        assert_eq!(longest_common_word_run(&a, &b), 0);
+    }
+}


### PR DESCRIPTION
## Summary

When the OpenAI transcription endpoint (`whisper-1` and the `gpt-4o-*-transcribe` family) is handed audio with no speech together with a `prompt`, the model has nothing to anchor decoding to and falls back to its strongest prior — the prompt itself — emitting it verbatim or in long contiguous chunks as the "transcription". whisrs then dutifully types that text at the cursor.

For prompts in the multi-hundred-character range (a paragraph of speaker context plus a vocabulary list) this means **tens of seconds of garbage typing** every time the user fat-fingers the toggle hotkey or the microphone happened to capture only background noise. The behaviour is documented by OpenAI as expected output for low-SNR audio, so the mitigation must live on the client side.

This PR adds two layers, applied in `process_recording_batch`:

1. **Upstream gate** (`audio::silence::audio_gate_reason`). Reject empty buffers, recordings shorter than 300 ms, and recordings whose RMS energy never crosses the silence threshold. These cases cannot carry usable speech, so skipping them avoids the round-trip entirely (saves cost and latency in addition to preventing the echo). The threshold is exposed as `audio::silence::SILENCE_RMS_THRESHOLD` and shared with `AutoStopDetector`, so the gate and the streaming auto-stop agree by construction on what counts as silence.

2. **Post-hoc echo detector** (`post_processing::prompt_echo::is_prompt_echo`). Catches the residue: low-SNR recordings that pass the gate but still trigger the model to regurgitate the prompt. The check normalises case/punctuation/whitespace and then flags responses that are either:
   - a verbatim substring of the prompt, or
   - share a contiguous word-run of ≥6 words covering ≥70% of the response.

   Short responses and isolated vocabulary overlap are deliberately ignored to avoid false-positiving on real speech that happens to use prompt vocabulary (tests cover the non-match case explicitly).

Both layers fail soft: they return an empty string so the existing "transcription returned no text" path takes over and the state machine returns cleanly to `Idle`. When `notify` is enabled the user sees a one-line toast explaining what was dropped, so silent skips don't look like crashes.

The streaming pipeline is intentionally not touched. It already has its own auto-stop on silence and emits short deltas, where echo-detection heuristics would risk false positives on legitimate single-word utterances.

### Notes from review

- `audio::capture::SAMPLE_RATE` was promoted to `pub` and reused by the gate instead of redeclaring 16 kHz in the daemon.
- `audio_gate_reason` documents its sample-rate invariant with `debug_assert!(sample_rate > 0)`; the only caller passes the const, so the redundant runtime guard was removed.
- The echo-check site uses `Option::is_some_and` to avoid a nested `if let` / `if`.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — all tests pass (gate gains 4, echo gains 11, none regress)
- [x] Manual: empty hotkey tap with a multi-hundred-character prompt no longer types anything; recording with real speech is unaffected.