### PR TITLE
feat: prebuilt installer, dev-install script, whisrs restart, aarch64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,25 @@ env:
 jobs:
   build:
     name: Build — ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
           - name: Linux x86_64
-            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
             artifact: whisrs-linux-x86_64
             features: ""
           - name: Linux x86_64 (no local-whisper)
-            target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
             artifact: whisrs-linux-x86_64-minimal
+            features: "--no-default-features"
+          - name: Linux aarch64
+            runner: ubuntu-24.04-arm
+            artifact: whisrs-linux-aarch64
+            features: ""
+          - name: Linux aarch64 (no local-whisper)
+            runner: ubuntu-24.04-arm
+            artifact: whisrs-linux-aarch64-minimal
             features: "--no-default-features"
 
     steps:
@@ -34,19 +42,17 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libxkbcommon-dev pkg-config
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.features }}
+        run: cargo build --release ${{ matrix.features }}
 
       - name: Package
         run: |
           mkdir -p staging
-          cp target/${{ matrix.target }}/release/whisrs staging/
-          cp target/${{ matrix.target }}/release/whisrsd staging/
+          cp target/release/whisrs staging/
+          cp target/release/whisrsd staging/
           cp README.md LICENSE staging/
           cp -r contrib staging/
           cd staging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ systemctl --user enable --now whisrs.service
 whisrs toggle    # start/stop recording
 whisrs cancel    # cancel and discard audio
 whisrs status    # query daemon state
+whisrs restart   # restart the daemon (wraps systemctl --user when present)
 
 # Debug logging
 set -x RUST_LOG debug; whisrsd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,10 @@ whisrs cancel    # cancel and discard audio
 whisrs status    # query daemon state
 whisrs restart   # restart the daemon (wraps systemctl --user when present)
 
+# Dev loop: rebuild this checkout and restart the daemon
+./scripts/dev-install.sh             # build + install to ~/.cargo/bin + restart
+./scripts/dev-install.sh --system    # build + sudo install to /usr/local/bin + restart
+
 # Debug logging
 set -x RUST_LOG debug; whisrsd
 ```

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ whisrs setup     # Interactive onboarding
 whisrs toggle    # Start/stop recording
 whisrs cancel    # Cancel recording, discard audio
 whisrs status    # Query daemon state
+whisrs restart   # Restart the daemon (uses the systemd user service when present)
 whisrs command   # Command mode: select text + speak instruction → LLM rewrite
 whisrs log       # Show recent transcription history
 whisrs log -n 5  # Show last 5 entries

--- a/README.md
+++ b/README.md
@@ -27,35 +27,36 @@ Wispr Flow and Superwhisper are closed-source dictation apps that don't run on L
 
 ## Installation
 
-### Quick install (any distro)
+### Quick install (Linux x86_64 / aarch64)
 
 ```bash
 curl -sSL https://y0sif.github.io/whisrs/install.sh | bash
 ```
 
-Or clone and run locally:
+The install script downloads the latest prebuilt tarball, installs `whisrs`/`whisrsd` to `/usr/local/bin`, and runs interactive setup.
 
-```bash
-git clone https://github.com/y0sif/whisrs && cd whisrs && ./install.sh
-```
+Pin a specific version with `WHISRS_VERSION=v0.1.10` or use the cloud-only minimal build with `WHISRS_MINIMAL=1`. Re-run the same command later to upgrade.
 
-The install script handles everything: detects your distro, installs system dependencies, builds the project, and runs interactive setup.
+To **build from source** instead — including custom feature flag combos or unsupported architectures — use `cargo install whisrs --locked` or the `whisrs-git` AUR package.
 
 After install, **press your hotkey** to start recording, **press again** to stop. Text appears at your cursor.
 
 <details>
 <summary><b>Other install methods (pre-built binary, AUR, Cargo, Nix, manual)</b></summary>
 
-### Pre-built binary (Linux x86_64)
+### Pre-built binary (manual)
 
-Each tagged release publishes a tarball on [GitHub Releases](https://github.com/y0sif/whisrs/releases/latest) with both `whisrs` and `whisrsd` plus the contrib files (udev rule, systemd unit, man pages).
+The Quick install above already does this — this section is for users who want to install the tarball by hand.
+
+Each tagged release publishes tarballs on [GitHub Releases](https://github.com/y0sif/whisrs/releases/latest) with both `whisrs` and `whisrsd` plus the contrib files (udev rule, systemd unit, man pages).
 
 ```bash
-# Full build (cloud + local whisper.cpp)
-curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-x86_64.tar.gz
+# Pick the artifact for your arch + variant:
+ARCH=x86_64   # or aarch64
+curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-${ARCH}.tar.gz
 
-# Or the minimal build (cloud backends only — smaller, no whisper.cpp)
-curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-x86_64-minimal.tar.gz
+# Or the minimal build (cloud backends only — no whisper.cpp):
+# curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-${ARCH}-minimal.tar.gz
 
 tar xzf whisrs.tar.gz
 sudo install -m755 whisrs whisrsd /usr/local/bin/
@@ -65,10 +66,10 @@ sudo usermod -aG input $USER   # log out / back in for the group change
 whisrs setup
 ```
 
-| Variant | Includes local whisper.cpp | Tarball |
+| Variant | Architectures | Includes local whisper.cpp |
 |---|---|---|
-| `whisrs-linux-x86_64.tar.gz` | yes | full build |
-| `whisrs-linux-x86_64-minimal.tar.gz` | no (cloud backends only) | minimal build |
+| `whisrs-linux-{x86_64,aarch64}.tar.gz` | x86_64, aarch64 | yes (full build) |
+| `whisrs-linux-{x86_64,aarch64}-minimal.tar.gz` | x86_64, aarch64 | no (cloud backends only) |
 
 ### Arch Linux (AUR)
 

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -37,6 +37,14 @@ Query the daemon state. Prints one of:
 .BR recording ,
 or
 .BR transcribing .
+.TP
+.B restart
+Restart the whisrs daemon. Uses
+.B systemctl --user restart whisrs.service
+when the systemd user unit is loaded; otherwise prints guidance for
+manual restart. Does not require the daemon to be running \(em
+.B restart
+will start a stopped service.
 .SH ENVIRONMENT
 .TP
 .B WHISRS_GROQ_API_KEY

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
-# whisrs installer — builds from source, installs, and runs setup.
+# whisrs installer — downloads the latest prebuilt release tarball and runs setup.
+#
+# For end-user installs and updates. To build from a local checkout, see
+# scripts/dev-install.sh; to build from source elsewhere, use
+# `cargo install whisrs --locked` or the `whisrs-git` AUR package.
 #
 # Usage:
+#   curl -sSf https://y0sif.github.io/whisrs/install.sh | bash
 #   curl -sSf https://raw.githubusercontent.com/y0sif/whisrs/main/install.sh | bash
-#   # or from a local clone:
 #   ./install.sh
+#
+# Environment:
+#   WHISRS_VERSION=v0.1.11   Pin to a specific tag (default: latest)
+#   WHISRS_MINIMAL=1         Use the minimal build (cloud-only, no whisper.cpp)
 
 set -euo pipefail
 
@@ -13,7 +21,6 @@ GREEN='\033[32m'
 YELLOW='\033[33m'
 RED='\033[31m'
 BOLD='\033[1m'
-DIM='\033[2m'
 RESET='\033[0m'
 
 info()  { echo -e "  ${GREEN}${BOLD}$1${RESET} $2"; }
@@ -25,153 +32,167 @@ TOTAL=5
 
 echo -e "\n${BOLD}whisrs installer${RESET} — voice-to-text dictation for Linux\n"
 
-# ── Step 1: Check / install system dependencies ─────────────────────────
+# ── Detect architecture ─────────────────────────────────────────────────
+
+case "$(uname -m)" in
+    x86_64)         ARCH="x86_64" ;;
+    aarch64|arm64)  ARCH="aarch64" ;;
+    *)
+        error "Unsupported architecture: $(uname -m)"
+        echo "  Prebuilt tarballs are published for x86_64 and aarch64 only."
+        echo "  To build from source on this arch:"
+        echo ""
+        echo "    cargo install whisrs --locked"
+        echo ""
+        echo "  See https://github.com/y0sif/whisrs#installation for system deps."
+        exit 1
+        ;;
+esac
+
+# ── Step 1: Install runtime dependencies ────────────────────────────────
 
 step 1 "Checking system dependencies..."
 
-# Detect package manager and distro.
-install_deps() {
-    if command -v pacman &>/dev/null; then
-        info "Detected:" "Arch Linux"
-        local needed=()
-        for pkg in base-devel alsa-lib libxkbcommon clang cmake; do
-            if ! pacman -Qi "$pkg" &>/dev/null; then
-                needed+=("$pkg")
-            fi
-        done
-        if [ ${#needed[@]} -gt 0 ]; then
-            echo "  Installing: ${needed[*]}"
-            sudo pacman -S --needed --noconfirm "${needed[@]}"
-        else
-            echo "  All system packages already installed."
+if command -v pacman &>/dev/null; then
+    info "Detected:" "Arch Linux"
+    needed=()
+    for pkg in alsa-lib libxkbcommon ca-certificates curl tar; do
+        if ! pacman -Qi "$pkg" &>/dev/null; then
+            needed+=("$pkg")
         fi
-
-    elif command -v apt-get &>/dev/null; then
-        info "Detected:" "Debian/Ubuntu"
-        local needed=()
-        for pkg in build-essential libasound2-dev libxkbcommon-dev libclang-dev cmake; do
-            if ! dpkg -s "$pkg" &>/dev/null 2>&1; then
-                needed+=("$pkg")
-            fi
-        done
-        if [ ${#needed[@]} -gt 0 ]; then
-            echo "  Installing: ${needed[*]}"
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq "${needed[@]}"
-        else
-            echo "  All system packages already installed."
-        fi
-
-    elif command -v dnf &>/dev/null; then
-        info "Detected:" "Fedora/RHEL"
-        local needed=()
-        for pkg in gcc-c++ alsa-lib-devel libxkbcommon-devel clang-devel cmake; do
-            if ! rpm -q "$pkg" &>/dev/null 2>&1; then
-                needed+=("$pkg")
-            fi
-        done
-        if [ ${#needed[@]} -gt 0 ]; then
-            echo "  Installing: ${needed[*]}"
-            sudo dnf install -y "${needed[@]}"
-        else
-            echo "  All system packages already installed."
-        fi
-
-    elif command -v zypper &>/dev/null; then
-        info "Detected:" "openSUSE"
-        sudo zypper install -y gcc-c++ alsa-devel libxkbcommon-devel clang cmake
-
+    done
+    if [ ${#needed[@]} -gt 0 ]; then
+        echo "  Installing: ${needed[*]}"
+        sudo pacman -S --needed --noconfirm "${needed[@]}"
     else
-        warn "Could not detect package manager."
-        echo "  Please install manually: C/C++ compiler, ALSA dev libs, libxkbcommon, clang, cmake"
-        echo "  Then re-run this script."
+        echo "  All runtime libraries already installed."
+    fi
+
+elif command -v apt-get &>/dev/null; then
+    info "Detected:" "Debian/Ubuntu"
+    needed=()
+    for pkg in libasound2 libxkbcommon0 ca-certificates curl tar; do
+        if ! dpkg -s "$pkg" &>/dev/null 2>&1; then
+            needed+=("$pkg")
+        fi
+    done
+    if [ ${#needed[@]} -gt 0 ]; then
+        echo "  Installing: ${needed[*]}"
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq "${needed[@]}"
+    else
+        echo "  All runtime libraries already installed."
+    fi
+
+elif command -v dnf &>/dev/null; then
+    info "Detected:" "Fedora/RHEL"
+    needed=()
+    for pkg in alsa-lib libxkbcommon ca-certificates curl tar; do
+        if ! rpm -q "$pkg" &>/dev/null 2>&1; then
+            needed+=("$pkg")
+        fi
+    done
+    if [ ${#needed[@]} -gt 0 ]; then
+        echo "  Installing: ${needed[*]}"
+        sudo dnf install -y "${needed[@]}"
+    else
+        echo "  All runtime libraries already installed."
+    fi
+
+elif command -v zypper &>/dev/null; then
+    info "Detected:" "openSUSE"
+    sudo zypper install -y alsa libxkbcommon0 ca-certificates curl tar
+
+else
+    warn "Could not detect package manager."
+    echo "  Please install manually: alsa-lib (or libasound2), libxkbcommon, curl, tar."
+    echo "  Then re-run this script."
+    exit 1
+fi
+
+# ── Step 2: Resolve the release tag ─────────────────────────────────────
+
+step 2 "Resolving release tag..."
+
+if [ -n "${WHISRS_VERSION:-}" ]; then
+    TAG="$WHISRS_VERSION"
+    info "Pinned:" "$TAG (WHISRS_VERSION)"
+else
+    # Follow the /releases/latest redirect to the canonical tag URL, then
+    # extract the trailing tag name. No GitHub API token or jq required.
+    TAG=$(curl -sSL -o /dev/null -w '%{url_effective}' \
+        "https://github.com/y0sif/whisrs/releases/latest" \
+        | sed 's|.*/tag/||' | tr -d '[:space:]')
+
+    if [ -z "$TAG" ] || [ "$TAG" = "latest" ]; then
+        error "Could not resolve the latest release tag."
+        echo "  Set WHISRS_VERSION=v0.1.11 (or similar) and re-run."
         exit 1
     fi
-}
-
-install_deps
-
-# Check for Rust toolchain.
-if ! command -v cargo &>/dev/null; then
-    warn "Rust toolchain not found. Installing via rustup..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    # shellcheck source=/dev/null
-    source "$HOME/.cargo/env"
-    info "Rust installed:" "$(rustc --version)"
-else
-    info "Rust:" "$(rustc --version)"
+    info "Latest:" "$TAG"
 fi
 
-# ── Step 2: Clone or locate the source ──────────────────────────────────
+# ── Step 3: Download and extract the tarball ────────────────────────────
 
-step 2 "Building whisrs..."
+step 3 "Downloading prebuilt tarball..."
 
-# If we're already in a whisrs checkout, use it. Otherwise clone.
-if [ -f "Cargo.toml" ] && grep -q 'name = "whisrs"' Cargo.toml 2>/dev/null; then
-    SRCDIR="$(pwd)"
-    info "Using local source:" "$SRCDIR"
+if [ "${WHISRS_MINIMAL:-}" = "1" ]; then
+    ARTIFACT="whisrs-linux-${ARCH}-minimal.tar.gz"
+    info "Variant:" "minimal (cloud backends only)"
 else
-    SRCDIR="$HOME/.cache/whisrs-src"
-    if [ -d "$SRCDIR/.git" ]; then
-        info "Updating:" "$SRCDIR"
-        git -C "$SRCDIR" pull --ff-only
-    else
-        info "Cloning:" "whisrs → $SRCDIR"
-        git clone https://github.com/y0sif/whisrs "$SRCDIR"
-    fi
+    ARTIFACT="whisrs-linux-${ARCH}.tar.gz"
+    info "Variant:" "full (with offline whisper.cpp)"
 fi
 
-# ── Step 3: Build and install ────────────────────────────────────────────
+URL="https://github.com/y0sif/whisrs/releases/download/${TAG}/${ARTIFACT}"
+info "URL:" "$URL"
 
-step 3 "Installing binaries..."
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
 
-cargo install --path "$SRCDIR" --locked 2>&1 | tail -5
-
-# Verify install.
-if command -v whisrs &>/dev/null; then
-    info "Installed:" "$(which whisrs)"
-    info "Installed:" "$(which whisrsd)"
-else
-    # Might not be in PATH yet.
-    if [ -f "$HOME/.cargo/bin/whisrs" ]; then
-        warn "Binaries installed to ~/.cargo/bin/ but not in PATH."
-        echo "  Add to your shell config:"
-        echo "    fish:  fish_add_path ~/.cargo/bin"
-        echo "    bash:  export PATH=\"\$HOME/.cargo/bin:\$PATH\""
-        export PATH="$HOME/.cargo/bin:$PATH"
-    else
-        error "Build failed — check output above."
-        exit 1
-    fi
+if ! curl -fsSL -o "$TMPDIR/whisrs.tar.gz" "$URL"; then
+    error "Download failed."
+    echo "  Check that release ${TAG} has artifact ${ARTIFACT}:"
+    echo "    https://github.com/y0sif/whisrs/releases/tag/${TAG}"
+    exit 1
 fi
 
-# ── Step 4: Restart daemon if running ───────────────────────────────────
+tar xzf "$TMPDIR/whisrs.tar.gz" -C "$TMPDIR"
 
-step 4 "Checking for running daemon..."
+if [ ! -x "$TMPDIR/whisrs" ] || [ ! -x "$TMPDIR/whisrsd" ]; then
+    error "Extracted tarball is missing the expected binaries."
+    exit 1
+fi
+
+# ── Step 4: Install binaries and restart any running daemon ─────────────
+
+step 4 "Installing binaries..."
+
+sudo install -Dm755 "$TMPDIR/whisrs"  /usr/local/bin/whisrs
+sudo install -Dm755 "$TMPDIR/whisrsd" /usr/local/bin/whisrsd
+info "Installed:" "/usr/local/bin/whisrs"
+info "Installed:" "/usr/local/bin/whisrsd"
 
 if systemctl --user is-active whisrs.service &>/dev/null; then
-    info "Restarting:" "whisrs daemon (systemd service)"
-    systemctl --user restart whisrs.service
-    echo "  Daemon restarted with the new binary."
+    info "Restarting:" "running daemon (whisrs restart)"
+    /usr/local/bin/whisrs restart || true
 elif pgrep -x whisrsd &>/dev/null; then
     warn "whisrsd is running but not via systemd."
-    echo "  Please restart it manually: kill \$(pgrep whisrsd) && whisrsd &"
+    echo "  Restart it manually: pkill whisrsd; sleep 0.2; whisrsd &"
 else
-    echo "  No running daemon found — it will start after setup."
+    echo "  No running daemon — it will start after setup."
 fi
 
-# ── Step 5: Run interactive setup ────────────────────────────────────────
+# ── Step 5: Run interactive setup ───────────────────────────────────────
 
 step 5 "Running whisrs setup..."
 
 echo ""
-whisrs setup
+/usr/local/bin/whisrs setup
 
-# Restart daemon again if setup changed the config.
 if systemctl --user is-active whisrs.service &>/dev/null; then
-    systemctl --user restart whisrs.service
+    /usr/local/bin/whisrs restart || true
     info "Daemon restarted" "with new config."
 fi
 
-echo -e "\n${GREEN}${BOLD}Installation complete!${RESET}"
-echo ""
+echo -e "\n${GREEN}${BOLD}Installation complete!${RESET}\n"

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# whisrs dev-install — rebuild the local checkout and restart the daemon.
+#
+# Maintainer convenience for the dev loop. End users should use install.sh
+# (which downloads the prebuilt tarball from the latest GitHub Release).
+#
+# Usage:
+#   ./scripts/dev-install.sh             # cargo install --path . (binaries → ~/.cargo/bin)
+#   ./scripts/dev-install.sh --system    # build + sudo install to /usr/local/bin
+#   ./scripts/dev-install.sh --no-restart  # skip the `whisrs restart` step
+
+set -euo pipefail
+
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()  { echo -e "  ${GREEN}${BOLD}$1${RESET} $2"; }
+warn()  { echo -e "  ${YELLOW}$1${RESET}"; }
+error() { echo -e "  ${RED}$1${RESET}"; }
+step()  { echo -e "\n${BOLD}[$1/$TOTAL] $2${RESET}"; }
+
+TOTAL=2
+SYSTEM_INSTALL=0
+SKIP_RESTART=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --system)     SYSTEM_INSTALL=1 ;;
+        --no-restart) SKIP_RESTART=1 ;;
+        -h|--help)
+            sed -n '2,8p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            error "Unknown flag: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+# Resolve the repo root from the script's location so relative paths work
+# regardless of where the script is invoked from.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ ! -f "$REPO_ROOT/Cargo.toml" ] || ! grep -q 'name = "whisrs"' "$REPO_ROOT/Cargo.toml"; then
+    error "Could not find a whisrs Cargo.toml at $REPO_ROOT."
+    echo "  Run this script from inside a whisrs checkout."
+    exit 1
+fi
+
+echo -e "\n${BOLD}whisrs dev-install${RESET} — local rebuild\n"
+
+cd "$REPO_ROOT"
+
+# ── Step 1: Build and install ───────────────────────────────────────────
+
+if [ "$SYSTEM_INSTALL" -eq 1 ]; then
+    step 1 "Building release binaries..."
+    cargo build --release
+    info "Built:" "target/release/whisrs, target/release/whisrsd"
+
+    info "Installing:" "system-wide → /usr/local/bin (sudo)"
+    sudo install -m755 target/release/whisrs  /usr/local/bin/whisrs
+    sudo install -m755 target/release/whisrsd /usr/local/bin/whisrsd
+    info "Installed:" "/usr/local/bin/whisrs"
+    info "Installed:" "/usr/local/bin/whisrsd"
+else
+    step 1 "Installing via cargo install --path ..."
+    cargo install --path . --locked --force 2>&1 | tail -5
+
+    if [ -f "$HOME/.cargo/bin/whisrs" ]; then
+        info "Installed:" "$HOME/.cargo/bin/whisrs"
+        info "Installed:" "$HOME/.cargo/bin/whisrsd"
+    else
+        error "cargo install did not produce ~/.cargo/bin/whisrs — check output above."
+        exit 1
+    fi
+fi
+
+# ── Step 2: Restart daemon ──────────────────────────────────────────────
+
+if [ "$SKIP_RESTART" -eq 1 ]; then
+    info "Skipping" "daemon restart (--no-restart)"
+    echo -e "\n${GREEN}${BOLD}Done.${RESET}\n"
+    exit 0
+fi
+
+step 2 "Restarting daemon..."
+
+# Prefer the just-installed binary so we always restart with the version we
+# just built, not whichever `whisrs` happens to be first in PATH.
+if [ "$SYSTEM_INSTALL" -eq 1 ]; then
+    WHISRS_BIN="/usr/local/bin/whisrs"
+else
+    WHISRS_BIN="$HOME/.cargo/bin/whisrs"
+fi
+
+if [ -x "$WHISRS_BIN" ]; then
+    "$WHISRS_BIN" restart
+else
+    warn "Could not locate the freshly installed whisrs binary at $WHISRS_BIN."
+    echo "  Run 'whisrs restart' manually."
+fi
+
+echo -e "\n${GREEN}${BOLD}Done.${RESET}\n"

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,4 +1,5 @@
 use std::process;
+use std::process::Command as StdCommand;
 
 use clap::{Parser, Subcommand};
 use tokio::io::AsyncWriteExt;
@@ -59,6 +60,8 @@ enum SubCmd {
     },
     /// Command mode: select text, speak an instruction, LLM rewrites it in place
     Command,
+    /// Restart the whisrs daemon (uses the systemd user service when present)
+    Restart,
 }
 
 /// Check if stdout is a TTY for color support.
@@ -114,9 +117,99 @@ async fn main() -> anyhow::Result<()> {
         SubCmd::Command => {
             send_command(Command::CommandMode).await?;
         }
+        SubCmd::Restart => {
+            cmd_restart()?;
+        }
     }
 
     Ok(())
+}
+
+/// Restart the whisrs daemon.
+///
+/// Uses the systemd user service when `whisrs.service` is loaded; otherwise
+/// prints guidance for non-systemd setups. We don't try to `pkill whisrsd`
+/// ourselves because that races with respawn and silently breaks for users
+/// who launched the daemon under tmux/foot/etc.
+fn cmd_restart() -> anyhow::Result<()> {
+    let use_color = is_tty();
+
+    if has_systemd_unit() {
+        if use_color {
+            println!("{BOLD}Restarting whisrs daemon (systemd)…{RESET}");
+        } else {
+            println!("Restarting whisrs daemon (systemd)…");
+        }
+
+        let status = StdCommand::new("systemctl")
+            .args(["--user", "restart", "whisrs.service"])
+            .status()?;
+
+        if !status.success() {
+            if use_color {
+                eprintln!("{RED}systemctl --user restart whisrs.service failed.{RESET}");
+            } else {
+                eprintln!("systemctl --user restart whisrs.service failed.");
+            }
+            process::exit(1);
+        }
+
+        if use_color {
+            println!("{GREEN}Daemon restarted.{RESET}");
+        } else {
+            println!("Daemon restarted.");
+        }
+        return Ok(());
+    }
+
+    if use_color {
+        eprintln!(
+            "{YELLOW}No whisrs systemd user unit detected.{RESET}\n\
+             \n\
+             Install the systemd unit (run `whisrs setup` and accept the systemd step),\n\
+             or restart the daemon manually:\n\
+             \n\
+             \x20 pkill whisrsd; sleep 0.2; whisrsd &"
+        );
+    } else {
+        eprintln!(
+            "No whisrs systemd user unit detected.\n\
+             \n\
+             Install the systemd unit (run `whisrs setup` and accept the systemd step),\n\
+             or restart the daemon manually:\n\
+             \n\
+             \x20 pkill whisrsd; sleep 0.2; whisrsd &"
+        );
+    }
+    process::exit(1);
+}
+
+/// Returns `true` when `whisrs.service` is loaded as a user unit.
+fn has_systemd_unit() -> bool {
+    // `is-enabled` exits 0 for enabled/static/linked units and non-zero when
+    // the unit isn't loaded. It works whether the service is currently active
+    // or not, which matches `whisrs restart`'s "start or restart" semantics.
+    let Ok(output) = StdCommand::new("systemctl")
+        .args(["--user", "is-enabled", "whisrs.service"])
+        .output()
+    else {
+        return false;
+    };
+
+    if output.status.success() {
+        return true;
+    }
+
+    // Fall back to `list-unit-files` for the static/linked case where
+    // `is-enabled` may exit non-zero on some distros.
+    let Ok(output) = StdCommand::new("systemctl")
+        .args(["--user", "list-unit-files", "whisrs.service"])
+        .output()
+    else {
+        return false;
+    };
+
+    output.status.success() && String::from_utf8_lossy(&output.stdout).contains("whisrs.service")
 }
 
 /// Connect to the daemon and send a command, printing the response.


### PR DESCRIPTION
## Summary

Reworks how users install, update, and restart whisrs. Five commits, one PR.

- **`whisrs restart` CLI subcommand** — wraps `systemctl --user restart whisrs.service` when the user unit is loaded; prints guidance for non-systemd setups otherwise. No `pkill` fallback in this PR — that races with respawn and silently breaks for daemons launched outside systemd, so we'd rather defer to the user (or a future explicit non-systemd path).
- **`scripts/dev-install.sh`** — maintainer convenience for the local rebuild loop. Default: `cargo install --path . --locked --force` (binaries land in `~/.cargo/bin`, no sudo). `--system` flag does a release build and sudo-installs to `/usr/local/bin` so dev builds match the production layout. Always ends with `whisrs restart` unless `--no-restart` is passed.
- **`install.sh` rewrite** — switches from "always build from source" to "download the latest prebuilt tarball." Detects arch (x86_64 / aarch64; bails on others with a pointer to `cargo install whisrs --locked`), installs runtime deps only, follows the `releases/latest` redirect to find the tag, downloads the matching tarball into `/usr/local/bin`, then runs `whisrs setup`. Pin a tag via `WHISRS_VERSION=v0.1.11`; pick the cloud-only build via `WHISRS_MINIMAL=1`.
- **aarch64 release matrix** — `release.yml` now ships four tarballs per tag (x86_64 / aarch64, each with a full and `--no-default-features` minimal variant). aarch64 builds run natively on `ubuntu-24.04-arm` (GitHub-hosted ARM runner, GA + free for public repos), avoiding `cross` and the cross-compile toolchain dance.
- **Docs** — README Quick install section rewritten for the new flow; Pre-built binary section reframed and extended to cover aarch64; CLAUDE.md and the man page mention `whisrs restart` and `./scripts/dev-install.sh`.

## Why this matters

The old `install.sh` always cloned and built from `main` HEAD. That meant:

1. Users got "v0.1.X + N unreleased commits" builds whose `whisrs --version` lied about which release they were on.
2. Every install required the full Rust + C++ toolchain (clang, cmake, libclang, base-devel, etc.) — slow and a lot of surface area for things to go wrong.
3. Restarting the daemon after an upgrade was undocumented; users had to remember `systemctl --user restart whisrs.service`.

After this PR, the end-user path is: download a tagged tarball, install runtime libs only, `whisrs restart` wraps the systemd dance. The maintainer dev loop moves to `scripts/dev-install.sh`, which is what `install.sh`'s "use local checkout" branch was secretly being used for.

## Sequencing

Because the install script now expects `whisrs restart` to exist in the binary it just installed, the new `install.sh` should not be synced to gh-pages until **v0.1.11** is tagged and its tarballs are uploaded. Plan after merge:

1. Cut **v0.1.11** with notes calling out `whisrs restart`, the prebuilt installer, and aarch64 binaries.
2. Wait for `release.yml` to publish the four tarballs.
3. Sync the new `install.sh` over to the `gh-pages` branch so `https://y0sif.github.io/whisrs/install.sh` serves the rewritten version.

## Risk

Low. CLI change is additive (no existing command behavior touched). Script changes don't affect the published binary. Only thing that affects users in flight is the gh-pages sync, gated on v0.1.11 being live.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass locally.
- `bash -n install.sh` and `bash -n scripts/dev-install.sh` syntax-check clean.
- The aarch64 matrix entry will be exercised by the next tagged release; if the build breaks there it's a clean revert (drop two matrix entries).