### PR TITLE
Revert PR #18: drop SEO/AEO framing from README + Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 name = "whisrs"
 version = "0.1.11"
 edition = "2021"
-description = "Open source Wispr Flow alternative for Linux — voice dictation for Wayland, X11, Hyprland, Sway, GNOME, KDE with offline whisper.cpp and cloud backends"
+description = "Linux-first voice-to-text dictation tool with Groq, OpenAI, and local Whisper backends"
 license = "MIT"
 repository = "https://github.com/y0sif/whisrs"
 homepage = "https://y0sif.github.io/whisrs/"
-keywords = ["dictation", "speech-to-text", "whisper", "linux", "wayland"]
+keywords = ["voice", "dictation", "speech-to-text", "whisper", "linux"]
 categories = ["multimedia::audio", "accessibility", "command-line-utilities"]
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 [![Crates.io](https://img.shields.io/crates/v/whisrs)](https://crates.io/crates/whisrs)
 [![docs.rs](https://img.shields.io/docsrs/whisrs)](https://docs.rs/whisrs)
 
-**whisrs is a Linux voice-to-text dictation tool written in Rust that transcribes speech via 7 backends — Groq, Deepgram REST, Deepgram Streaming, OpenAI REST, OpenAI Realtime, local whisper.cpp, and a generic ASR sidecar — and types it into the focused window. It is the open-source Wispr Flow alternative for Linux.**
+**Linux-first voice-to-text dictation tool, written in Rust.**
 
-Press a hotkey, speak, and your words appear at the cursor in any focused app on Wayland, X11, Hyprland, Sway, Niri, GNOME, or KDE. Audio is captured via cpal across PipeWire, PulseAudio, and ALSA. Fully offline local transcription runs in under 500 MB of RAM with `base.en`. Fast, private, open source.
+Speech-to-text for Wayland, X11, Hyprland, Sway, Niri, GNOME, and KDE. Press a hotkey, speak, and your words appear at the cursor. Works with any app, any window manager, any desktop environment. Supports cloud transcription (Groq, Deepgram, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source.
 
 ---
 
-## How does whisrs differ from Wispr Flow and Superwhisper?
+## Why whisrs?
 
-Wispr Flow and Superwhisper are closed-source dictation apps that don't run on Linux. whisrs is open source (MIT), Linux-native, and ships as a single async Rust process with native keyboard layout support (uinput + XKB), window tracking across Hyprland, Sway, Niri, X11, GNOME, and KDE, and 7 swappable transcription backends — both cloud (Groq, Deepgram, OpenAI) and fully offline (whisper.cpp, plus a generic ASR sidecar for arbitrary local models). [xhisper](https://github.com/imaginalnika/xhisper) proved the concept on Linux; whisrs rebuilds it from scratch in Rust with broader compositor support and a daemon/CLI architecture you can bind to any hotkey.
+Dictation tools like Wispr Flow and Superwhisper are not available on Linux. [xhisper](https://github.com/imaginalnika/xhisper) proved the concept works, but I kept running into limitations. whisrs takes that idea and rebuilds it in Rust as a single async process with native keyboard layout support, window tracking, and multiple transcription backends.
 
 ---
 
@@ -147,7 +147,7 @@ bindsym $mod+w exec whisrs toggle
 
 ---
 
-## What transcription backends does whisrs support?
+## Transcription Backends
 
 | Backend | Type | Streaming | Cost | Best for |
 |---|---|---|---|---|
@@ -201,11 +201,7 @@ whisrs log --clear  # Clear all history
 
 ---
 
-<a id="supported-environments"></a>
-
-## Does whisrs work on Wayland, GNOME, KDE, Hyprland, Sway, and Niri?
-
-Yes. whisrs runs natively on both Wayland and X11 across Hyprland, Sway, Niri, i3, GNOME Wayland, KDE Wayland, and any X11 window manager — with daily-driver coverage on Hyprland and community-confirmed reports on GNOME Wayland and Xorg. Audio capture works on PipeWire, PulseAudio, and ALSA via cpal.
+## Supported Environments
 
 | Component | Support |
 |---|---|
@@ -248,24 +244,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and project structu
 
 ---
 
-## How whisrs Compares to Wispr Flow and Other Dictation Tools
-
-whisrs is the open source alternative to closed-source dictation apps like **Wispr Flow** and **Superwhisper**, neither of which ships a Linux client. The closest open-source equivalents include [nerd-dictation](https://github.com/ideasman42/nerd-dictation), [Speech Note](https://github.com/mkiol/dsnote), and the cross-platform [Handy](https://github.com/cjpais/Handy). Head-to-head against the Linux-native options:
-
-| Feature | whisrs | [nerd-dictation](https://github.com/ideasman42/nerd-dictation) | [Speech Note](https://github.com/mkiol/dsnote) | [Wispr Flow](https://wisprflow.ai/) |
-|---|---|---|---|---|
-| **Platform** | Linux | Linux | Linux | macOS, Windows (no Linux) |
-| **Wayland support** | Yes (native) | Partial (xdotool) | Yes (GUI app) | N/A |
-| **Offline transcription** | Yes (whisper.cpp) | Yes (Vosk) | Yes (multiple) | No |
-| **Cloud transcription** | Groq, Deepgram (REST + streaming), OpenAI, OpenAI Realtime | No | No | Proprietary |
-| **True streaming** | Yes (OpenAI Realtime) | No | No | Yes |
-| **Keyboard injection** | uinput + XKB (layout-aware) | xdotool | Clipboard paste | Native |
-| **Window tracking** | Hyprland, Sway, Niri, X11, GNOME, KDE | No | No | Native |
-| **Architecture** | Daemon + CLI (bind to any hotkey) | Script | GUI app | GUI app |
-| **Language** | Rust | Python | C++/Qt | Closed source |
-| **Setup** | Interactive (`whisrs setup`) | Manual config | GUI | Installer |
-
-For the full comparison, see [docs/comparison.md](docs/comparison.md).
+## [How whisrs Compares](docs/comparison.md)
 
 ## [FAQ](docs/faq.md)
 


### PR DESCRIPTION
## Summary

Reverts the docs-only changes from PR #18 (`docs: optimize README and Cargo metadata for SEO + LLM discoverability`). The framing felt keyword-stuffed in retrospect and the traffic data over the two weeks since the merge does not show a clear lift that would justify keeping it as-is.

What goes back to pre-#18:

- **Cargo.toml** — `description` returns to *"Linux-first voice-to-text dictation tool with Groq, OpenAI, and local Whisper backends"* (was *"Open source Wispr Flow alternative for Linux — voice dictation for Wayland, X11, Hyprland, Sway, GNOME, KDE with offline whisper.cpp and cloud backends"*). `keywords` swap `wayland` back for `voice`.
- **README lead** — drops the entity-dense definition opener and the "open-source Wispr Flow alternative for Linux" tagline; restores the original short hero.
- **README H2s** — three question-shaped headings (`How does whisrs differ from Wispr Flow and Superwhisper?`, `What transcription backends does whisrs support?`, `Does whisrs work on Wayland, GNOME, KDE, Hyprland, Sway, and Niri?`) revert to plain titles (`Why whisrs?`, `Transcription Backends`, `Supported Environments`). The `<a id="supported-environments">` anchor is removed — GitHub auto-generates the same `#supported-environments` slug from the H2, so `docs/troubleshooting.md` still resolves.
- **Inlined comparison table** — collapses back to a single `## [How whisrs Compares](docs/comparison.md)` link. The full table still lives in `docs/comparison.md`.

What is **kept** (intentionally not reverted):

- **Niri** mentions across the lead, supported-environments table, and comparison row — these landed in `b6662dc` after PR #18 merged and are unrelated to SEO.
- **`docs/faq.md` factual fix** from `d4dd08e` — *"Wispr Flow ships clients for macOS and Windows; Superwhisper is macOS-only."* The pre-#18 text incorrectly said Wispr Flow is macOS-only. That fix is correctness, not SEO, so it stays.
- **`docs/comparison.md`, `docs/faq.md`, and `index.html`** (landing page) — created in earlier commits (March), not part of PR #18. Out of scope.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (16/16)
- [x] `cargo build` succeeds
- [ ] Verify `docs/troubleshooting.md` link to `../README.md#supported-environments` still resolves on the rendered README
- [ ] Confirm Cargo.toml description renders cleanly on the next crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)