### PR TITLE
feat(config): add `whisrs config` interactive editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ For the full reference (overlay, `[input]`, `[asr-sidecar]`, `[llm]`, `[hotkeys]
 
 ```
 whisrs setup     # Interactive onboarding
+whisrs config    # Interactive editor for ~/.config/whisrs/config.toml
 whisrs toggle    # Start/stop recording
 whisrs cancel    # Cancel recording, discard audio
 whisrs status    # Query daemon state

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -22,6 +22,14 @@ test the microphone, and write
 .IR config.toml .
 Does not require the daemon to be running.
 .TP
+.B config
+Open an interactive menu to edit any section of
+.IR config.toml
+\(em backend, language, hotkeys, overlay, command-mode LLM, and more.
+On save, writes the file and restarts the daemon via systemd. Unlike
+.B setup
+this does not touch udev rules, the systemd unit, or compositor keybindings.
+.TP
 .B toggle
 Start or stop recording. If idle, begins audio capture. If recording,
 stops capture and sends audio for transcription. Text is typed at the

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -150,6 +150,8 @@ fn cmd_restart() -> anyhow::Result<()> {
 
     if use_color {
         println!("{BOLD}Restarting whisrs daemon (systemd)…{RESET}");
+    } else {
+        println!("Restarting whisrs daemon (systemd)…");
     }
 
     match restart_daemon_via_systemd() {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,12 +1,14 @@
 use std::process;
-use std::process::Command as StdCommand;
 
 use clap::{Parser, Subcommand};
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 
 use whisrs::history::HistoryEntry;
-use whisrs::{encode_message, read_message, socket_path, Command, Response, State};
+use whisrs::{
+    encode_message, read_message, restart_daemon_via_systemd, socket_path, Command, Response,
+    RestartOutcome, State,
+};
 
 const ASCII_BANNER: &str = concat!(
     "\n",
@@ -43,6 +45,8 @@ struct Cli {
 enum SubCmd {
     /// Interactive onboarding — pick a backend, set API key, test microphone
     Setup,
+    /// Edit any part of ~/.config/whisrs/config.toml; restarts the daemon on save
+    Config,
     /// Toggle recording on/off (start dictation or stop and transcribe)
     Toggle,
     /// Cancel the current recording and discard audio
@@ -98,6 +102,16 @@ async fn main() -> anyhow::Result<()> {
                 process::exit(1);
             }
         }
+        SubCmd::Config => {
+            if let Err(e) = whisrs::config::edit::run_config_menu() {
+                if is_tty() {
+                    eprintln!("{RED}config failed:{RESET} {e:#}");
+                } else {
+                    eprintln!("config failed: {e:#}");
+                }
+                process::exit(1);
+            }
+        }
         SubCmd::Toggle => {
             send_command(Command::Toggle).await?;
         }
@@ -134,18 +148,20 @@ async fn main() -> anyhow::Result<()> {
 fn cmd_restart() -> anyhow::Result<()> {
     let use_color = is_tty();
 
-    if has_systemd_unit() {
-        if use_color {
-            println!("{BOLD}Restarting whisrs daemon (systemd)…{RESET}");
-        } else {
-            println!("Restarting whisrs daemon (systemd)…");
+    if use_color {
+        println!("{BOLD}Restarting whisrs daemon (systemd)…{RESET}");
+    }
+
+    match restart_daemon_via_systemd() {
+        RestartOutcome::Restarted => {
+            if use_color {
+                println!("{GREEN}Daemon restarted.{RESET}");
+            } else {
+                println!("Daemon restarted.");
+            }
+            Ok(())
         }
-
-        let status = StdCommand::new("systemctl")
-            .args(["--user", "restart", "whisrs.service"])
-            .status()?;
-
-        if !status.success() {
+        RestartOutcome::Failed => {
             if use_color {
                 eprintln!("{RED}systemctl --user restart whisrs.service failed.{RESET}");
             } else {
@@ -153,63 +169,29 @@ fn cmd_restart() -> anyhow::Result<()> {
             }
             process::exit(1);
         }
-
-        if use_color {
-            println!("{GREEN}Daemon restarted.{RESET}");
-        } else {
-            println!("Daemon restarted.");
+        RestartOutcome::NoSystemdUnit => {
+            if use_color {
+                eprintln!(
+                    "{YELLOW}No whisrs systemd user unit detected.{RESET}\n\
+                     \n\
+                     Install the systemd unit (run `whisrs setup` and accept the systemd step),\n\
+                     or restart the daemon manually:\n\
+                     \n\
+                     \x20 pkill whisrsd; sleep 0.2; whisrsd &"
+                );
+            } else {
+                eprintln!(
+                    "No whisrs systemd user unit detected.\n\
+                     \n\
+                     Install the systemd unit (run `whisrs setup` and accept the systemd step),\n\
+                     or restart the daemon manually:\n\
+                     \n\
+                     \x20 pkill whisrsd; sleep 0.2; whisrsd &"
+                );
+            }
+            process::exit(1);
         }
-        return Ok(());
     }
-
-    if use_color {
-        eprintln!(
-            "{YELLOW}No whisrs systemd user unit detected.{RESET}\n\
-             \n\
-             Install the systemd unit (run `whisrs setup` and accept the systemd step),\n\
-             or restart the daemon manually:\n\
-             \n\
-             \x20 pkill whisrsd; sleep 0.2; whisrsd &"
-        );
-    } else {
-        eprintln!(
-            "No whisrs systemd user unit detected.\n\
-             \n\
-             Install the systemd unit (run `whisrs setup` and accept the systemd step),\n\
-             or restart the daemon manually:\n\
-             \n\
-             \x20 pkill whisrsd; sleep 0.2; whisrsd &"
-        );
-    }
-    process::exit(1);
-}
-
-/// Returns `true` when `whisrs.service` is loaded as a user unit.
-fn has_systemd_unit() -> bool {
-    // `is-enabled` exits 0 for enabled/static/linked units and non-zero when
-    // the unit isn't loaded. It works whether the service is currently active
-    // or not, which matches `whisrs restart`'s "start or restart" semantics.
-    let Ok(output) = StdCommand::new("systemctl")
-        .args(["--user", "is-enabled", "whisrs.service"])
-        .output()
-    else {
-        return false;
-    };
-
-    if output.status.success() {
-        return true;
-    }
-
-    // Fall back to `list-unit-files` for the static/linked case where
-    // `is-enabled` may exit non-zero on some distros.
-    let Ok(output) = StdCommand::new("systemctl")
-        .args(["--user", "list-unit-files", "whisrs.service"])
-        .output()
-    else {
-        return false;
-    };
-
-    output.status.success() && String::from_utf8_lossy(&output.stdout).contains("whisrs.service")
 }
 
 /// Connect to the daemon and send a command, printing the response.

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -82,13 +82,19 @@ pub fn run_config_menu() -> Result<()> {
                     // External edit already wrote the file; reload and skip the
                     // normal save path so we don't clobber formatting/comments
                     // the user might have added.
-                    println!("  {GREEN}Reloaded config from disk.{RESET}");
+                    println!("  {GREEN}Applied edits from $EDITOR.{RESET}");
                 }
             }
             12 => {
                 // separator — no-op
             }
-            13 => return save_and_restart(&config, fresh),
+            13 => {
+                if save_and_restart(&config, fresh)? {
+                    return Ok(());
+                }
+                // Validation failed — fall through to next loop iteration,
+                // preserving the in-memory `config` so the user can fix it.
+            }
             14 => {
                 println!("\n  {DIM}Discarded changes.{RESET}");
                 return Ok(());
@@ -175,14 +181,7 @@ fn daemon_status_string() -> String {
 
 fn edit_backend(config: &mut Config) -> Result<()> {
     println!("\n  {BOLD}Backend & API keys{RESET}");
-    let mut new_backend = setup::select_backend(Some(config))?;
-
-    // Map "local" pseudo-value (chosen from the engine sub-menu) to the
-    // canonical engine string — select_backend already does this, but if the
-    // user picked another local engine we keep it.
-    if new_backend == "local" {
-        new_backend = "local-whisper".to_string();
-    }
+    let new_backend = setup::select_backend(Some(config))?;
 
     let (deepgram, groq, openai, local_whisper, asr_sidecar) =
         setup::configure_backend(&new_backend, Some(config))?;
@@ -549,10 +548,14 @@ fn open_in_editor(config: &mut Config) -> Result<bool> {
 
 /// Validate, write, and restart. Called only from the "Save & exit" branch.
 ///
+/// Returns `Ok(true)` on a successful save (caller should exit the menu) and
+/// `Ok(false)` when validation failed (caller should return to the menu while
+/// preserving the in-memory edit buffer).
+///
 /// `fresh` is true when we created the config from defaults (no file on disk
 /// at startup) — in that case we point the user at `whisrs setup` for the
 /// permissions/systemd/keybinding bits we deliberately skipped.
-fn save_and_restart(config: &Config, fresh: bool) -> Result<()> {
+fn save_and_restart(config: &Config, fresh: bool) -> Result<bool> {
     match config.validate() {
         Ok(warnings) => {
             for w in warnings {
@@ -563,8 +566,9 @@ fn save_and_restart(config: &Config, fresh: bool) -> Result<()> {
             println!("\n  {RED}Cannot save — config is invalid:{RESET}");
             println!("    {e}");
             println!("  {DIM}Fix the issue and try again, or pick \"Discard & exit\".{RESET}");
-            // Re-enter the menu by recursing.
-            return run_config_menu();
+            // Signal the caller to re-enter the menu without losing the
+            // in-memory edits the user has already made this session.
+            return Ok(false);
         }
     }
 
@@ -608,7 +612,7 @@ fn save_and_restart(config: &Config, fresh: bool) -> Result<()> {
              udev rules, the systemd unit, and a compositor keybinding.{RESET}"
         );
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Parse a comma-separated list, trimming whitespace and dropping empty entries.

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -1,0 +1,622 @@
+//! Interactive editor for `~/.config/whisrs/config.toml`.
+//!
+//! `whisrs config` opens a menu that lets the user jump to any section of the
+//! config file, edit it, and on save writes a validated `config.toml` and
+//! restarts the daemon if the systemd user unit is loaded.
+//!
+//! This complements `whisrs setup` (the one-time onboarding wizard). `setup`
+//! handles install-time concerns — mic test, udev rules, systemd install,
+//! compositor keybinding — while `config` only edits the TOML.
+
+use std::fs;
+use std::process::Command as StdCommand;
+
+use anyhow::{Context, Result};
+use dialoguer::{Confirm, Editor, Input, Select};
+
+use crate::config::setup;
+use crate::{Config, RestartOutcome};
+
+use setup::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+
+/// Top-level entry point for `whisrs config`.
+///
+/// Loads the existing config (or a fresh default if none exists), runs the
+/// menu loop, and on save writes the file and triggers a daemon restart.
+pub fn run_config_menu() -> Result<()> {
+    println!("\n{BOLD}whisrs config{RESET} — edit ~/.config/whisrs/config.toml\n");
+
+    let (mut config, fresh) = match setup::load_existing_config() {
+        Some(cfg) => (cfg, false),
+        None => {
+            println!(
+                "  {YELLOW}No config file found — starting from defaults.{RESET} \
+                 Run {BOLD}whisrs setup{RESET} for the full onboarding flow."
+            );
+            (default_config(), true)
+        }
+    };
+
+    loop {
+        print_summary(&config);
+
+        let choices = &[
+            "Backend & API keys",
+            "Language",
+            "Behavior (silence timeout, notifications, audio feedback)",
+            "Filler words",
+            "Vocabulary & prompt",
+            "Audio device",
+            "Keyboard injection (key delay)",
+            "Hotkeys",
+            "Tray & overlay",
+            "Command mode (LLM)",
+            "Show full config (masked)",
+            "Open in $EDITOR",
+            "─────────",
+            "Save & exit",
+            "Discard & exit",
+        ];
+
+        let selection = Select::new()
+            .with_prompt("What do you want to change?")
+            .items(choices)
+            .default(0)
+            .interact()
+            .context("failed to read menu selection")?;
+
+        match selection {
+            0 => edit_backend(&mut config)?,
+            1 => edit_language(&mut config)?,
+            2 => edit_behavior(&mut config)?,
+            3 => edit_filler_words(&mut config)?,
+            4 => edit_vocabulary_and_prompt(&mut config)?,
+            5 => edit_audio_device(&mut config)?,
+            6 => edit_key_delay(&mut config)?,
+            7 => edit_hotkeys(&mut config)?,
+            8 => edit_tray_overlay(&mut config)?,
+            9 => edit_llm(&mut config)?,
+            10 => show_config(&config),
+            11 => {
+                if open_in_editor(&mut config)? {
+                    // External edit already wrote the file; reload and skip the
+                    // normal save path so we don't clobber formatting/comments
+                    // the user might have added.
+                    println!("  {GREEN}Reloaded config from disk.{RESET}");
+                }
+            }
+            12 => {
+                // separator — no-op
+            }
+            13 => return save_and_restart(&config, fresh),
+            14 => {
+                println!("\n  {DIM}Discarded changes.{RESET}");
+                return Ok(());
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Build a fresh Config from defaults — used when no `config.toml` exists yet.
+fn default_config() -> Config {
+    Config {
+        general: Default::default(),
+        audio: Default::default(),
+        input: Default::default(),
+        deepgram: None,
+        groq: None,
+        openai: None,
+        local_whisper: None,
+        local_vosk: None,
+        local_parakeet: None,
+        asr_sidecar: None,
+        llm: None,
+        hotkeys: None,
+        overlay: None,
+    }
+}
+
+/// Print the current state header above the menu so the user can see at a
+/// glance what backend/language/daemon-status they're working with.
+fn print_summary(config: &Config) {
+    println!("\n  {BOLD}Current settings:{RESET}");
+    println!(
+        "    Backend:  {BOLD}{}{RESET}    Language: {BOLD}{}{RESET}",
+        config.general.backend, config.general.language
+    );
+    let key_status = current_key_summary(config);
+    println!("    API key:  {key_status}");
+    println!("    Daemon:   {}", daemon_status_string());
+    println!();
+}
+
+/// Summarize whether the active backend has an API key configured. Shows the
+/// last 4 chars so the user can tell which key they're looking at without
+/// leaking the full secret.
+fn current_key_summary(config: &Config) -> String {
+    let key = match config.general.backend.as_str() {
+        "groq" => config.groq.as_ref().map(|g| g.api_key.as_str()),
+        "deepgram" | "deepgram-streaming" => config.deepgram.as_ref().map(|d| d.api_key.as_str()),
+        "openai" | "openai-realtime" => config.openai.as_ref().map(|o| o.api_key.as_str()),
+        "local-whisper" | "local" | "local-vosk" | "local-parakeet" => {
+            return format!("{DIM}(local backend — no API key needed){RESET}");
+        }
+        "asr-sidecar" | "asr" | "vibevoice" => {
+            return format!("{DIM}(sidecar backend — no API key needed){RESET}");
+        }
+        _ => None,
+    };
+    match key {
+        Some(k) if !k.is_empty() => format!("{BOLD}{}{RESET}", setup::mask_api_key(k)),
+        _ => format!("{YELLOW}not set{RESET}"),
+    }
+}
+
+fn daemon_status_string() -> String {
+    // `is-active` exits 0 when running. We don't surface "failed/inactive"
+    // separately — the user only cares about active vs not when deciding
+    // whether a restart is meaningful.
+    let active = StdCommand::new("systemctl")
+        .args(["--user", "is-active", "whisrs.service"])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "active")
+        .unwrap_or(false);
+    if active {
+        format!("{GREEN}running{RESET}")
+    } else {
+        format!("{DIM}not running (or no systemd unit){RESET}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section editors
+// ---------------------------------------------------------------------------
+
+fn edit_backend(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Backend & API keys{RESET}");
+    let mut new_backend = setup::select_backend(Some(config))?;
+
+    // Map "local" pseudo-value (chosen from the engine sub-menu) to the
+    // canonical engine string — select_backend already does this, but if the
+    // user picked another local engine we keep it.
+    if new_backend == "local" {
+        new_backend = "local-whisper".to_string();
+    }
+
+    let (deepgram, groq, openai, local_whisper, asr_sidecar) =
+        setup::configure_backend(&new_backend, Some(config))?;
+
+    // Only overwrite the section the user just edited. Other backend sections
+    // are preserved so the user can switch back without re-entering a key.
+    config.general.backend = new_backend;
+    if deepgram.is_some() {
+        config.deepgram = deepgram;
+    }
+    if groq.is_some() {
+        config.groq = groq;
+    }
+    if openai.is_some() {
+        config.openai = openai;
+    }
+    if local_whisper.is_some() {
+        config.local_whisper = local_whisper;
+    }
+    if asr_sidecar.is_some() {
+        config.asr_sidecar = asr_sidecar;
+    }
+    Ok(())
+}
+
+fn edit_language(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Language{RESET}");
+    config.general.language = setup::select_language(Some(config))?;
+    Ok(())
+}
+
+fn edit_behavior(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Behavior{RESET}");
+
+    let timeout: String = Input::new()
+        .with_prompt("Silence timeout (ms) — 0 disables auto-stop")
+        .default(config.general.silence_timeout_ms.to_string())
+        .interact_text()
+        .context("failed to read silence timeout")?;
+    if let Ok(t) = timeout.parse::<u64>() {
+        config.general.silence_timeout_ms = t;
+    } else {
+        println!("  {YELLOW}Not a number — left unchanged.{RESET}");
+    }
+
+    config.general.notify = Confirm::new()
+        .with_prompt("Enable desktop notifications?")
+        .default(config.general.notify)
+        .interact()
+        .unwrap_or(config.general.notify);
+
+    config.general.audio_feedback = Confirm::new()
+        .with_prompt("Enable audio feedback (tones on start/stop)?")
+        .default(config.general.audio_feedback)
+        .interact()
+        .unwrap_or(config.general.audio_feedback);
+
+    if config.general.audio_feedback {
+        let vol: String = Input::new()
+            .with_prompt("Audio feedback volume (0.0 to 1.0)")
+            .default(format!("{:.2}", config.general.audio_feedback_volume))
+            .interact_text()
+            .context("failed to read volume")?;
+        if let Ok(v) = vol.parse::<f32>() {
+            config.general.audio_feedback_volume = v.clamp(0.0, 1.0);
+        } else {
+            println!("  {YELLOW}Not a number — left unchanged.{RESET}");
+        }
+    }
+
+    Ok(())
+}
+
+fn edit_filler_words(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Filler words{RESET}");
+
+    config.general.remove_filler_words = Confirm::new()
+        .with_prompt("Remove filler words (\"um\", \"uh\", ...) from transcriptions?")
+        .default(config.general.remove_filler_words)
+        .interact()
+        .unwrap_or(config.general.remove_filler_words);
+
+    if !config.general.remove_filler_words {
+        return Ok(());
+    }
+
+    let current = if config.general.filler_words.is_empty() {
+        "(built-in list)".to_string()
+    } else {
+        config.general.filler_words.join(", ")
+    };
+    println!("  {DIM}Current custom list: {current}{RESET}");
+
+    let edit_list = Confirm::new()
+        .with_prompt("Edit custom filler list? (empty = use built-in defaults)")
+        .default(false)
+        .interact()
+        .unwrap_or(false);
+    if !edit_list {
+        return Ok(());
+    }
+
+    let input: String = Input::new()
+        .with_prompt("Comma-separated filler words (leave blank to clear)")
+        .default(config.general.filler_words.join(", "))
+        .allow_empty(true)
+        .interact_text()
+        .context("failed to read filler word list")?;
+
+    config.general.filler_words = parse_csv_list(&input);
+    Ok(())
+}
+
+fn edit_vocabulary_and_prompt(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Vocabulary & prompt{RESET}");
+    println!("  {DIM}Domain terms/names sent as a hint to the backend to improve accuracy.{RESET}");
+
+    let current = if config.general.vocabulary.is_empty() {
+        "(empty)".to_string()
+    } else {
+        config.general.vocabulary.join(", ")
+    };
+    println!("  Current vocabulary: {current}");
+
+    let input: String = Input::new()
+        .with_prompt("Comma-separated vocabulary (leave blank to clear)")
+        .default(config.general.vocabulary.join(", "))
+        .allow_empty(true)
+        .interact_text()
+        .context("failed to read vocabulary")?;
+    config.general.vocabulary = parse_csv_list(&input);
+
+    let current_prompt = config.general.prompt.as_deref().unwrap_or("(none)");
+    println!("  Current prompt: {current_prompt}");
+    let prompt: String = Input::new()
+        .with_prompt("Free-form prompt (style/register hints; leave blank to clear)")
+        .default(config.general.prompt.clone().unwrap_or_default())
+        .allow_empty(true)
+        .interact_text()
+        .context("failed to read prompt")?;
+    config.general.prompt = if prompt.trim().is_empty() {
+        None
+    } else {
+        Some(prompt)
+    };
+
+    Ok(())
+}
+
+fn edit_audio_device(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Audio device{RESET}");
+
+    let devices = list_input_devices();
+    if devices.is_empty() {
+        println!("  {YELLOW}No input devices detected.{RESET}");
+    } else {
+        println!("  {DIM}Detected input devices:{RESET}");
+        for d in &devices {
+            println!("    - {d}");
+        }
+    }
+
+    let new_device: String = Input::new()
+        .with_prompt("Audio device name (\"default\" to use system default)")
+        .default(config.audio.device.clone())
+        .interact_text()
+        .context("failed to read audio device")?;
+    config.audio.device = new_device;
+    Ok(())
+}
+
+fn list_input_devices() -> Vec<String> {
+    use cpal::traits::{DeviceTrait, HostTrait};
+    cpal::default_host()
+        .input_devices()
+        .map(|iter| iter.filter_map(|d| d.name().ok()).collect())
+        .unwrap_or_default()
+}
+
+fn edit_key_delay(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Keyboard injection{RESET}");
+    println!(
+        "  {DIM}Delay between simulated keystrokes. Raise this if characters are dropped \
+         by TUI apps that read stdin in raw mode (e.g. Claude Code).{RESET}"
+    );
+
+    let input: String = Input::new()
+        .with_prompt("key_delay_ms")
+        .default(config.input.key_delay_ms.to_string())
+        .interact_text()
+        .context("failed to read key delay")?;
+    if let Ok(v) = input.parse::<u64>() {
+        config.input.key_delay_ms = v;
+    } else {
+        println!("  {YELLOW}Not a number — left unchanged.{RESET}");
+    }
+    Ok(())
+}
+
+fn edit_hotkeys(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Hotkeys{RESET}");
+    println!(
+        "  {DIM}Key combo strings (e.g. \"Super+Shift+D\"). Whether these bind globally\n   \
+         depends on your compositor — most users let the compositor invoke\n   \
+         `whisrs toggle` instead.{RESET}"
+    );
+
+    let mut hotkeys = config.hotkeys.clone().unwrap_or_default();
+    hotkeys.toggle = prompt_optional_string("Toggle hotkey", &hotkeys.toggle)?;
+    hotkeys.cancel = prompt_optional_string("Cancel hotkey", &hotkeys.cancel)?;
+    hotkeys.command = prompt_optional_string("Command-mode hotkey", &hotkeys.command)?;
+
+    // Drop the whole section if every field is empty — keeps the TOML clean.
+    let any_set = hotkeys.toggle.is_some() || hotkeys.cancel.is_some() || hotkeys.command.is_some();
+    config.hotkeys = if any_set { Some(hotkeys) } else { None };
+    Ok(())
+}
+
+fn prompt_optional_string(label: &str, current: &Option<String>) -> Result<Option<String>> {
+    let default = current.clone().unwrap_or_default();
+    let input: String = Input::new()
+        .with_prompt(format!("{label} (leave blank to unset)"))
+        .default(default)
+        .allow_empty(true)
+        .interact_text()
+        .with_context(|| format!("failed to read {label}"))?;
+    Ok(if input.trim().is_empty() {
+        None
+    } else {
+        Some(input)
+    })
+}
+
+fn edit_tray_overlay(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Tray & overlay{RESET}");
+
+    config.general.tray = Confirm::new()
+        .with_prompt("Show system tray icon?")
+        .default(config.general.tray)
+        .interact()
+        .unwrap_or(config.general.tray);
+
+    config.general.overlay = Confirm::new()
+        .with_prompt("Show bottom recording overlay?")
+        .default(config.general.overlay)
+        .interact()
+        .unwrap_or(config.general.overlay);
+
+    if config.general.overlay {
+        let theme = setup::pick_overlay_theme();
+        let mut overlay_cfg = config.overlay.clone().unwrap_or_default();
+        overlay_cfg.theme = theme;
+        config.overlay = Some(overlay_cfg);
+        println!(
+            "  {DIM}Note: width/height and custom colors can be set by hand in config.toml.{RESET}"
+        );
+    }
+    Ok(())
+}
+
+fn edit_llm(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Command mode (LLM){RESET}");
+    println!("  {DIM}Select text + hotkey + speak instruction → LLM rewrites it in place.{RESET}");
+
+    let current_label = config
+        .llm
+        .as_ref()
+        .map(|l| format!("{} ({})", l.model, setup::mask_api_key(&l.api_key)))
+        .unwrap_or_else(|| "not configured".to_string());
+    println!("  Current: {current_label}");
+
+    let choice = Select::new()
+        .with_prompt("LLM configuration")
+        .items(&[
+            "Configure / replace",
+            "Disable (remove [llm] section)",
+            "Keep current",
+        ])
+        .default(0)
+        .interact()
+        .context("failed to read LLM choice")?;
+
+    match choice {
+        0 => {
+            // Reuse the same picker the setup flow uses — same model lists,
+            // same provider URLs, same masking.
+            let new_llm = setup::configure_llm()?;
+            if let Some(llm) = new_llm {
+                config.llm = Some(llm);
+            }
+        }
+        1 => {
+            config.llm = None;
+            println!("  {GREEN}LLM removed.{RESET}");
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Show / external editor / save
+// ---------------------------------------------------------------------------
+
+fn show_config(config: &Config) {
+    println!("\n  {BOLD}Current config (masked){RESET}\n");
+    match render_masked_toml(config) {
+        Ok(s) => {
+            for line in s.lines() {
+                println!("    {line}");
+            }
+        }
+        Err(e) => println!("  {RED}Failed to render config: {e}{RESET}"),
+    }
+}
+
+/// Serialize a copy of the config with API keys replaced by `****<last4>`.
+///
+/// We clone before masking so the in-memory edit buffer keeps real keys.
+fn render_masked_toml(config: &Config) -> Result<String> {
+    let mut clone = config.clone();
+    if let Some(d) = clone.deepgram.as_mut() {
+        d.api_key = setup::mask_api_key(&d.api_key);
+    }
+    if let Some(g) = clone.groq.as_mut() {
+        g.api_key = setup::mask_api_key(&g.api_key);
+    }
+    if let Some(o) = clone.openai.as_mut() {
+        o.api_key = setup::mask_api_key(&o.api_key);
+    }
+    if let Some(l) = clone.llm.as_mut() {
+        l.api_key = setup::mask_api_key(&l.api_key);
+    }
+    toml::to_string_pretty(&clone).context("failed to serialize config")
+}
+
+/// Open the current config in $EDITOR. Returns `true` when the user saved
+/// edits, in which case the in-memory config is replaced by what's on disk.
+///
+/// We write the current in-memory config to a temp string first so the editor
+/// session sees the user's pending changes (not stale on-disk content).
+fn open_in_editor(config: &mut Config) -> Result<bool> {
+    let toml_str = toml::to_string_pretty(config).context("failed to serialize config")?;
+    let edited = Editor::new()
+        .extension(".toml")
+        .edit(&toml_str)
+        .context("failed to open editor")?;
+    let Some(edited) = edited else {
+        println!("  {DIM}Editor exited without saving.{RESET}");
+        return Ok(false);
+    };
+    match toml::from_str::<Config>(&edited) {
+        Ok(new_config) => {
+            *config = new_config;
+            Ok(true)
+        }
+        Err(e) => {
+            println!("  {RED}Edited TOML is invalid: {e}{RESET}");
+            println!("  {YELLOW}Changes from $EDITOR discarded.{RESET}");
+            Ok(false)
+        }
+    }
+}
+
+/// Validate, write, and restart. Called only from the "Save & exit" branch.
+///
+/// `fresh` is true when we created the config from defaults (no file on disk
+/// at startup) — in that case we point the user at `whisrs setup` for the
+/// permissions/systemd/keybinding bits we deliberately skipped.
+fn save_and_restart(config: &Config, fresh: bool) -> Result<()> {
+    match config.validate() {
+        Ok(warnings) => {
+            for w in warnings {
+                println!("  {YELLOW}warning:{RESET} {w}");
+            }
+        }
+        Err(e) => {
+            println!("\n  {RED}Cannot save — config is invalid:{RESET}");
+            println!("    {e}");
+            println!("  {DIM}Fix the issue and try again, or pick \"Discard & exit\".{RESET}");
+            // Re-enter the menu by recursing.
+            return run_config_menu();
+        }
+    }
+
+    let path = setup::write_config(config).context("failed to write config")?;
+    println!("\n  {GREEN}Wrote {}{RESET}", path.display());
+
+    // Permissions are set to 0600 by write_config(); double-check for the
+    // case where a previous run created the file with a different umask.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(&path) {
+            let mode = meta.permissions().mode() & 0o777;
+            if mode != 0o600 {
+                let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+            }
+        }
+    }
+
+    println!("\n  Restarting daemon to pick up new config...");
+    match crate::restart_daemon_via_systemd() {
+        RestartOutcome::Restarted => {
+            println!("  {GREEN}Daemon restarted.{RESET}");
+        }
+        RestartOutcome::Failed => {
+            println!("  {RED}systemctl --user restart whisrs.service failed.{RESET}");
+            println!("  {DIM}Check `journalctl --user -u whisrs -e` for details.{RESET}");
+        }
+        RestartOutcome::NoSystemdUnit => {
+            println!(
+                "  {DIM}No whisrs.service user unit detected — restart the daemon manually \
+                 for the new config to take effect:{RESET}"
+            );
+            println!("    pkill whisrsd; sleep 0.2; whisrsd &");
+        }
+    }
+
+    if fresh {
+        println!(
+            "\n  {DIM}This was a fresh config. Run {BOLD}whisrs setup{RESET}{DIM} once to install\n   \
+             udev rules, the systemd unit, and a compositor keybinding.{RESET}"
+        );
+    }
+    Ok(())
+}
+
+/// Parse a comma-separated list, trimming whitespace and dropping empty entries.
+fn parse_csv_list(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
 //! Configuration management and interactive setup for whisrs.
 
+pub mod edit;
 pub mod setup;

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -18,15 +18,15 @@ use crate::{
 };
 
 // ANSI color codes.
-const GREEN: &str = "\x1b[32m";
-const YELLOW: &str = "\x1b[33m";
-const RED: &str = "\x1b[31m";
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const RESET: &str = "\x1b[0m";
+pub(crate) const GREEN: &str = "\x1b[32m";
+pub(crate) const YELLOW: &str = "\x1b[33m";
+pub(crate) const RED: &str = "\x1b[31m";
+pub(crate) const BOLD: &str = "\x1b[1m";
+pub(crate) const DIM: &str = "\x1b[2m";
+pub(crate) const RESET: &str = "\x1b[0m";
 
 /// Backend choices presented to the user.
-const BACKEND_CHOICES: &[&str] = &[
+pub(crate) const BACKEND_CHOICES: &[&str] = &[
     "Groq               (free, fast, cloud)",
     "Deepgram Streaming (free credits, true streaming, cloud)",
     "Deepgram REST      (free credits, simple, cloud)",
@@ -37,7 +37,7 @@ const BACKEND_CHOICES: &[&str] = &[
 ];
 
 /// Map selection index to backend string used in config.
-const BACKEND_VALUES: &[&str] = &[
+pub(crate) const BACKEND_VALUES: &[&str] = &[
     "groq",
     "deepgram-streaming",
     "deepgram",
@@ -48,15 +48,15 @@ const BACKEND_VALUES: &[&str] = &[
 ];
 
 /// Whisper model choices (name, file size, description).
-const WHISPER_MODEL_CHOICES: &[&str] = &[
+pub(crate) const WHISPER_MODEL_CHOICES: &[&str] = &[
     "tiny.en    (75 MB,  decent accuracy, very fast)",
     "base.en    (142 MB, good accuracy, real-time)  <- recommended",
     "small.en   (466 MB, very good accuracy, slower)",
 ];
-const WHISPER_MODEL_NAMES: &[&str] = &["tiny.en", "base.en", "small.en"];
+pub(crate) const WHISPER_MODEL_NAMES: &[&str] = &["tiny.en", "base.en", "small.en"];
 
 /// Try to load an existing config from disk.
-fn load_existing_config() -> Option<Config> {
+pub(crate) fn load_existing_config() -> Option<Config> {
     let path = crate::config_path();
     if !path.exists() {
         return None;
@@ -66,7 +66,7 @@ fn load_existing_config() -> Option<Config> {
 }
 
 /// Mask an API key for display, showing only the last 4 characters.
-fn mask_api_key(key: &str) -> String {
+pub(crate) fn mask_api_key(key: &str) -> String {
     if key.len() <= 4 {
         "****".to_string()
     } else {
@@ -176,7 +176,7 @@ pub fn run_setup() -> Result<()> {
 }
 
 /// Prompt the user to select a transcription backend.
-fn select_backend(existing: Option<&Config>) -> Result<String> {
+pub(crate) fn select_backend(existing: Option<&Config>) -> Result<String> {
     // Determine the default index based on existing config.
     let default_idx = existing
         .map(|cfg| {
@@ -245,7 +245,7 @@ fn select_local_engine() -> Result<String> {
 
 /// Configure the selected backend (API key or model path).
 #[allow(clippy::type_complexity)]
-fn configure_backend(
+pub(crate) fn configure_backend(
     backend: &str,
     existing: Option<&Config>,
 ) -> Result<(
@@ -484,7 +484,7 @@ fn download_whisper_model(model_name: &str, model_dir: &std::path::Path) -> Resu
 }
 
 /// Prompt for an API key, offering to keep the existing one if present.
-fn prompt_api_key_with_existing(
+pub(crate) fn prompt_api_key_with_existing(
     prompt: &str,
     hint: &str,
     existing_key: Option<&String>,
@@ -517,7 +517,7 @@ fn prompt_api_key_with_existing(
 }
 
 /// Common languages with their ISO 639-1 codes.
-const LANGUAGE_CHOICES: &[(&str, &str)] = &[
+pub(crate) const LANGUAGE_CHOICES: &[(&str, &str)] = &[
     ("en", "English"),
     ("auto", "Auto-detect"),
     ("es", "Spanish"),
@@ -539,7 +539,7 @@ const LANGUAGE_CHOICES: &[(&str, &str)] = &[
 ];
 
 /// Ask the user for their preferred language.
-fn select_language(existing: Option<&Config>) -> Result<String> {
+pub(crate) fn select_language(existing: Option<&Config>) -> Result<String> {
     let default_lang = existing
         .map(|c| c.general.language.clone())
         .unwrap_or_else(|| "en".to_string());
@@ -631,7 +631,7 @@ fn test_microphone() {
 }
 
 /// Write the config to `~/.config/whisrs/config.toml` with `chmod 0600`.
-fn write_config(config: &Config) -> Result<PathBuf> {
+pub(crate) fn write_config(config: &Config) -> Result<PathBuf> {
     let config_path = crate::config_path();
     let config_dir = config_path
         .parent()
@@ -1166,7 +1166,7 @@ fn configure_overlay() -> (bool, Option<crate::OverlayConfig>) {
 
 /// Theme picker for the overlay. Always returns a named theme — "custom" is
 /// left for power users to set in config.toml.
-fn pick_overlay_theme() -> String {
+pub(crate) fn pick_overlay_theme() -> String {
     println!();
     let selection = Select::new()
         .with_prompt("Pick an overlay theme")
@@ -1279,7 +1279,7 @@ fn offer_install_gnome_extension() {
 }
 
 /// LLM provider choices for command mode.
-const LLM_PROVIDER_CHOICES: &[&str] = &[
+pub(crate) const LLM_PROVIDER_CHOICES: &[&str] = &[
     "OpenAI         (recommended)",
     "Groq           (fast, free tier)",
     "OpenRouter     (many models, free options)",
@@ -1288,7 +1288,7 @@ const LLM_PROVIDER_CHOICES: &[&str] = &[
 ];
 
 /// LLM provider API URLs.
-const LLM_PROVIDER_URLS: &[&str] = &[
+pub(crate) const LLM_PROVIDER_URLS: &[&str] = &[
     "https://api.openai.com/v1/chat/completions",
     "https://api.groq.com/openai/v1/chat/completions",
     "https://openrouter.ai/api/v1/chat/completions",
@@ -1379,7 +1379,7 @@ const GEMINI_MODELS: &[(&str, &str)] = &[
 ];
 
 /// Configure the LLM for command mode (optional).
-fn configure_llm() -> Result<Option<LlmConfig>> {
+pub(crate) fn configure_llm() -> Result<Option<LlmConfig>> {
     println!("\n{BOLD}Command mode (optional)...{RESET}");
     println!("  {DIM}Select text + hotkey + speak instruction → LLM rewrites it in place{RESET}");
     println!();
@@ -1434,7 +1434,7 @@ fn configure_llm() -> Result<Option<LlmConfig>> {
 }
 
 /// Show model selection menu for a given provider, with an "Other" option.
-fn select_llm_model(provider_idx: usize) -> Result<String> {
+pub(crate) fn select_llm_model(provider_idx: usize) -> Result<String> {
     let models: &[(&str, &str)] = match provider_idx {
         0 => OPENAI_MODELS,
         1 => GROQ_MODELS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,66 @@ fn default_asr_sidecar_model() -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Daemon control
+// ---------------------------------------------------------------------------
+
+/// Outcome of an attempt to restart the daemon via systemd.
+///
+/// The CLI and `whisrs config` both need to nudge the daemon after writing a
+/// new `config.toml`. They want the same systemd detection logic but different
+/// output formatting (e.g. ANSI colors only when stdout is a TTY), so this
+/// helper returns a structured outcome instead of printing directly.
+#[derive(Debug)]
+pub enum RestartOutcome {
+    /// `systemctl --user restart whisrs.service` succeeded.
+    Restarted,
+    /// No `whisrs.service` user unit is loaded — caller should show fallback hints.
+    NoSystemdUnit,
+    /// systemd is installed but the restart command failed (non-zero exit).
+    Failed,
+}
+
+/// Restart the whisrs daemon via systemd if a user unit is loaded.
+///
+/// Returns [`RestartOutcome::NoSystemdUnit`] without running anything when the
+/// unit isn't present; callers can fall back to printing manual instructions.
+pub fn restart_daemon_via_systemd() -> RestartOutcome {
+    if !has_systemd_unit() {
+        return RestartOutcome::NoSystemdUnit;
+    }
+    let status = std::process::Command::new("systemctl")
+        .args(["--user", "restart", "whisrs.service"])
+        .status();
+    match status {
+        Ok(s) if s.success() => RestartOutcome::Restarted,
+        _ => RestartOutcome::Failed,
+    }
+}
+
+/// Returns `true` when `whisrs.service` is loaded as a user unit.
+fn has_systemd_unit() -> bool {
+    // `is-enabled` exits 0 for enabled/static/linked units and non-zero when
+    // the unit isn't loaded. Falls back to `list-unit-files` for distros where
+    // `is-enabled` may exit non-zero on static/linked units.
+    let Ok(output) = std::process::Command::new("systemctl")
+        .args(["--user", "is-enabled", "whisrs.service"])
+        .output()
+    else {
+        return false;
+    };
+    if output.status.success() {
+        return true;
+    }
+    let Ok(output) = std::process::Command::new("systemctl")
+        .args(["--user", "list-unit-files", "whisrs.service"])
+        .output()
+    else {
+        return false;
+    };
+    output.status.success() && String::from_utf8_lossy(&output.stdout).contains("whisrs.service")
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- New `whisrs config` subcommand: interactive menu for editing every section of `~/.config/whisrs/config.toml` without re-running the full setup wizard or hand-editing TOML.
- Covers backend & API keys, language, behavior (silence timeout, notifications, audio feedback), filler words, vocabulary & prompt, audio device, key delay, hotkeys, tray/overlay, and command-mode LLM. Also shows the masked config and can open in `$EDITOR`.
- Validates on save, writes `config.toml` with `0600` perms, and restarts the daemon via `systemctl --user` when the user unit is loaded.
- Setup-time concerns (mic test, udev rules, systemd install, compositor keybindings) stay in `whisrs setup` — `config` only touches the TOML.

Closes #28.

## Test plan

- [ ] `whisrs config` with no existing config writes a sensible default and points the user at `whisrs setup` for udev/systemd/keybindings.
- [ ] `whisrs config` with an existing config preserves unmodified sections.
- [ ] Editing the active backend's API key masks correctly and offers to keep the existing one.
- [ ] Switching backends keeps the previous backend's section in TOML (so swapping back doesn't require re-entering the key).
- [ ] "Open in `\$EDITOR`" round-trips through the user's editor and rejects invalid TOML cleanly.
- [ ] "Save & exit" with an invalid config (e.g. backend selected but no key) returns to the menu with in-memory edits preserved.
- [ ] On save, the daemon is restarted via systemd; on systems without the user unit, manual restart guidance is printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)