### PR TITLE
Fix Debian/Ubuntu ALSA runtime package install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,11 @@ if command -v pacman &>/dev/null; then
 elif command -v apt-get &>/dev/null; then
     info "Detected:" "Debian/Ubuntu"
     needed=()
-    for pkg in libasound2 libxkbcommon0 ca-certificates curl tar; do
+    alsa_pkg="libasound2"
+    if ! apt-cache policy "$alsa_pkg" 2>/dev/null | grep -q 'Candidate: [^(]'; then
+        alsa_pkg="libasound2t64"
+    fi
+    for pkg in "$alsa_pkg" libxkbcommon0 ca-certificates curl tar; do
         if ! dpkg -s "$pkg" &>/dev/null 2>&1; then
             needed+=("$pkg")
         fi


### PR DESCRIPTION
## Summary

Fix the installer on Debian/Ubuntu releases where `libasound2` has no installable candidate and the runtime package is `libasound2t64`.

## Changes

- Check whether `libasound2` has an apt candidate.
- Fall back to `libasound2t64` when needed.

## Testing

- `bash -n install.sh`
- Reproduces from Ubuntu/Debian apt error: `Package 'libasound2' has no installation candidate`

## Checklist

- [ ] `cargo fmt` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] Tested on at least one compositor
