### PR TITLE
Sync Pages installer with release installer

### DIFF
--- a/.github/workflows/sync-installer.yml
+++ b/.github/workflows/sync-installer.yml
@@ -1,0 +1,48 @@
+name: Sync install.sh to gh-pages
+
+# Mirrors install.sh from main to gh-pages whenever it changes, so the
+# `curl | bash` recipe served from the landing page never drifts from the
+# canonical installer.
+#
+# NOTE: GitHub Actions only triggers workflows that live on the default
+# branch (main). For this workflow to fire, the same file must also be
+# committed to main. The copy on gh-pages is kept here as the source of
+# truth for the gh-pages installer sync, but it has no effect until a
+# matching file is present on main.
+
+on:
+  push:
+    branches: [main]
+    paths: [install.sh]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Copy install.sh from main
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          git checkout origin/main -- install.sh
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet --cached HEAD -- install.sh; then
+            echo "install.sh already in sync with main"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Sync install.sh from main"
+          git push origin gh-pages

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
-# whisrs installer — builds from source, installs, and runs setup.
+# whisrs installer — downloads the latest prebuilt release tarball and runs setup.
+#
+# For end-user installs and updates. To build from a local checkout, see
+# scripts/dev-install.sh; to build from source elsewhere, use
+# `cargo install whisrs --locked` or the `whisrs-git` AUR package.
 #
 # Usage:
+#   curl -sSf https://y0sif.github.io/whisrs/install.sh | bash
 #   curl -sSf https://raw.githubusercontent.com/y0sif/whisrs/main/install.sh | bash
-#   # or from a local clone:
 #   ./install.sh
+#
+# Environment:
+#   WHISRS_VERSION=v0.1.11   Pin to a specific tag (default: latest)
+#   WHISRS_MINIMAL=1         Use the minimal build (cloud-only, no whisper.cpp)
 
 set -euo pipefail
 
@@ -13,7 +21,6 @@ GREEN='\033[32m'
 YELLOW='\033[33m'
 RED='\033[31m'
 BOLD='\033[1m'
-DIM='\033[2m'
 RESET='\033[0m'
 
 info()  { echo -e "  ${GREEN}${BOLD}$1${RESET} $2"; }
@@ -25,153 +32,171 @@ TOTAL=5
 
 echo -e "\n${BOLD}whisrs installer${RESET} — voice-to-text dictation for Linux\n"
 
-# ── Step 1: Check / install system dependencies ─────────────────────────
+# ── Detect architecture ─────────────────────────────────────────────────
+
+case "$(uname -m)" in
+    x86_64)         ARCH="x86_64" ;;
+    aarch64|arm64)  ARCH="aarch64" ;;
+    *)
+        error "Unsupported architecture: $(uname -m)"
+        echo "  Prebuilt tarballs are published for x86_64 and aarch64 only."
+        echo "  To build from source on this arch:"
+        echo ""
+        echo "    cargo install whisrs --locked"
+        echo ""
+        echo "  See https://github.com/y0sif/whisrs#installation for system deps."
+        exit 1
+        ;;
+esac
+
+# ── Step 1: Install runtime dependencies ────────────────────────────────
 
 step 1 "Checking system dependencies..."
 
-# Detect package manager and distro.
-install_deps() {
-    if command -v pacman &>/dev/null; then
-        info "Detected:" "Arch Linux"
-        local needed=()
-        for pkg in base-devel alsa-lib libxkbcommon clang cmake; do
-            if ! pacman -Qi "$pkg" &>/dev/null; then
-                needed+=("$pkg")
-            fi
-        done
-        if [ ${#needed[@]} -gt 0 ]; then
-            echo "  Installing: ${needed[*]}"
-            sudo pacman -S --needed --noconfirm "${needed[@]}"
-        else
-            echo "  All system packages already installed."
+if command -v pacman &>/dev/null; then
+    info "Detected:" "Arch Linux"
+    needed=()
+    for pkg in alsa-lib libxkbcommon ca-certificates curl tar; do
+        if ! pacman -Qi "$pkg" &>/dev/null; then
+            needed+=("$pkg")
         fi
-
-    elif command -v apt-get &>/dev/null; then
-        info "Detected:" "Debian/Ubuntu"
-        local needed=()
-        for pkg in build-essential libasound2-dev libxkbcommon-dev libclang-dev cmake; do
-            if ! dpkg -s "$pkg" &>/dev/null 2>&1; then
-                needed+=("$pkg")
-            fi
-        done
-        if [ ${#needed[@]} -gt 0 ]; then
-            echo "  Installing: ${needed[*]}"
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq "${needed[@]}"
-        else
-            echo "  All system packages already installed."
-        fi
-
-    elif command -v dnf &>/dev/null; then
-        info "Detected:" "Fedora/RHEL"
-        local needed=()
-        for pkg in gcc-c++ alsa-lib-devel libxkbcommon-devel clang-devel cmake; do
-            if ! rpm -q "$pkg" &>/dev/null 2>&1; then
-                needed+=("$pkg")
-            fi
-        done
-        if [ ${#needed[@]} -gt 0 ]; then
-            echo "  Installing: ${needed[*]}"
-            sudo dnf install -y "${needed[@]}"
-        else
-            echo "  All system packages already installed."
-        fi
-
-    elif command -v zypper &>/dev/null; then
-        info "Detected:" "openSUSE"
-        sudo zypper install -y gcc-c++ alsa-devel libxkbcommon-devel clang cmake
-
+    done
+    if [ ${#needed[@]} -gt 0 ]; then
+        echo "  Installing: ${needed[*]}"
+        sudo pacman -S --needed --noconfirm "${needed[@]}"
     else
-        warn "Could not detect package manager."
-        echo "  Please install manually: C/C++ compiler, ALSA dev libs, libxkbcommon, clang, cmake"
-        echo "  Then re-run this script."
+        echo "  All runtime libraries already installed."
+    fi
+
+elif command -v apt-get &>/dev/null; then
+    info "Detected:" "Debian/Ubuntu"
+    needed=()
+    alsa_pkg="libasound2"
+    if ! apt-cache policy "$alsa_pkg" 2>/dev/null | grep -q 'Candidate: [^(]'; then
+        alsa_pkg="libasound2t64"
+    fi
+    for pkg in "$alsa_pkg" libxkbcommon0 ca-certificates curl tar; do
+        if ! dpkg -s "$pkg" &>/dev/null 2>&1; then
+            needed+=("$pkg")
+        fi
+    done
+    if [ ${#needed[@]} -gt 0 ]; then
+        echo "  Installing: ${needed[*]}"
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq "${needed[@]}"
+    else
+        echo "  All runtime libraries already installed."
+    fi
+
+elif command -v dnf &>/dev/null; then
+    info "Detected:" "Fedora/RHEL"
+    needed=()
+    for pkg in alsa-lib libxkbcommon ca-certificates curl tar; do
+        if ! rpm -q "$pkg" &>/dev/null 2>&1; then
+            needed+=("$pkg")
+        fi
+    done
+    if [ ${#needed[@]} -gt 0 ]; then
+        echo "  Installing: ${needed[*]}"
+        sudo dnf install -y "${needed[@]}"
+    else
+        echo "  All runtime libraries already installed."
+    fi
+
+elif command -v zypper &>/dev/null; then
+    info "Detected:" "openSUSE"
+    sudo zypper install -y alsa libxkbcommon0 ca-certificates curl tar
+
+else
+    warn "Could not detect package manager."
+    echo "  Please install manually: alsa-lib (or libasound2), libxkbcommon, curl, tar."
+    echo "  Then re-run this script."
+    exit 1
+fi
+
+# ── Step 2: Resolve the release tag ─────────────────────────────────────
+
+step 2 "Resolving release tag..."
+
+if [ -n "${WHISRS_VERSION:-}" ]; then
+    TAG="$WHISRS_VERSION"
+    info "Pinned:" "$TAG (WHISRS_VERSION)"
+else
+    # Follow the /releases/latest redirect to the canonical tag URL, then
+    # extract the trailing tag name. No GitHub API token or jq required.
+    TAG=$(curl -sSL -o /dev/null -w '%{url_effective}' \
+        "https://github.com/y0sif/whisrs/releases/latest" \
+        | sed 's|.*/tag/||' | tr -d '[:space:]')
+
+    if [ -z "$TAG" ] || [ "$TAG" = "latest" ]; then
+        error "Could not resolve the latest release tag."
+        echo "  Set WHISRS_VERSION=v0.1.11 (or similar) and re-run."
         exit 1
     fi
-}
-
-install_deps
-
-# Check for Rust toolchain.
-if ! command -v cargo &>/dev/null; then
-    warn "Rust toolchain not found. Installing via rustup..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    # shellcheck source=/dev/null
-    source "$HOME/.cargo/env"
-    info "Rust installed:" "$(rustc --version)"
-else
-    info "Rust:" "$(rustc --version)"
+    info "Latest:" "$TAG"
 fi
 
-# ── Step 2: Clone or locate the source ──────────────────────────────────
+# ── Step 3: Download and extract the tarball ────────────────────────────
 
-step 2 "Building whisrs..."
+step 3 "Downloading prebuilt tarball..."
 
-# If we're already in a whisrs checkout, use it. Otherwise clone.
-if [ -f "Cargo.toml" ] && grep -q 'name = "whisrs"' Cargo.toml 2>/dev/null; then
-    SRCDIR="$(pwd)"
-    info "Using local source:" "$SRCDIR"
+if [ "${WHISRS_MINIMAL:-}" = "1" ]; then
+    ARTIFACT="whisrs-linux-${ARCH}-minimal.tar.gz"
+    info "Variant:" "minimal (cloud backends only)"
 else
-    SRCDIR="$HOME/.cache/whisrs-src"
-    if [ -d "$SRCDIR/.git" ]; then
-        info "Updating:" "$SRCDIR"
-        git -C "$SRCDIR" pull --ff-only
-    else
-        info "Cloning:" "whisrs → $SRCDIR"
-        git clone https://github.com/y0sif/whisrs "$SRCDIR"
-    fi
+    ARTIFACT="whisrs-linux-${ARCH}.tar.gz"
+    info "Variant:" "full (with offline whisper.cpp)"
 fi
 
-# ── Step 3: Build and install ────────────────────────────────────────────
+URL="https://github.com/y0sif/whisrs/releases/download/${TAG}/${ARTIFACT}"
+info "URL:" "$URL"
 
-step 3 "Installing binaries..."
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
 
-cargo install --path "$SRCDIR" --locked 2>&1 | tail -5
-
-# Verify install.
-if command -v whisrs &>/dev/null; then
-    info "Installed:" "$(which whisrs)"
-    info "Installed:" "$(which whisrsd)"
-else
-    # Might not be in PATH yet.
-    if [ -f "$HOME/.cargo/bin/whisrs" ]; then
-        warn "Binaries installed to ~/.cargo/bin/ but not in PATH."
-        echo "  Add to your shell config:"
-        echo "    fish:  fish_add_path ~/.cargo/bin"
-        echo "    bash:  export PATH=\"\$HOME/.cargo/bin:\$PATH\""
-        export PATH="$HOME/.cargo/bin:$PATH"
-    else
-        error "Build failed — check output above."
-        exit 1
-    fi
+if ! curl -fsSL -o "$TMPDIR/whisrs.tar.gz" "$URL"; then
+    error "Download failed."
+    echo "  Check that release ${TAG} has artifact ${ARTIFACT}:"
+    echo "    https://github.com/y0sif/whisrs/releases/tag/${TAG}"
+    exit 1
 fi
 
-# ── Step 4: Restart daemon if running ───────────────────────────────────
+tar xzf "$TMPDIR/whisrs.tar.gz" -C "$TMPDIR"
 
-step 4 "Checking for running daemon..."
+if [ ! -x "$TMPDIR/whisrs" ] || [ ! -x "$TMPDIR/whisrsd" ]; then
+    error "Extracted tarball is missing the expected binaries."
+    exit 1
+fi
+
+# ── Step 4: Install binaries and restart any running daemon ─────────────
+
+step 4 "Installing binaries..."
+
+sudo install -Dm755 "$TMPDIR/whisrs"  /usr/local/bin/whisrs
+sudo install -Dm755 "$TMPDIR/whisrsd" /usr/local/bin/whisrsd
+info "Installed:" "/usr/local/bin/whisrs"
+info "Installed:" "/usr/local/bin/whisrsd"
 
 if systemctl --user is-active whisrs.service &>/dev/null; then
-    info "Restarting:" "whisrs daemon (systemd service)"
-    systemctl --user restart whisrs.service
-    echo "  Daemon restarted with the new binary."
+    info "Restarting:" "running daemon (whisrs restart)"
+    /usr/local/bin/whisrs restart || true
 elif pgrep -x whisrsd &>/dev/null; then
     warn "whisrsd is running but not via systemd."
-    echo "  Please restart it manually: kill \$(pgrep whisrsd) && whisrsd &"
+    echo "  Restart it manually: pkill whisrsd; sleep 0.2; whisrsd &"
 else
-    echo "  No running daemon found — it will start after setup."
+    echo "  No running daemon — it will start after setup."
 fi
 
-# ── Step 5: Run interactive setup ────────────────────────────────────────
+# ── Step 5: Run interactive setup ───────────────────────────────────────
 
 step 5 "Running whisrs setup..."
 
 echo ""
-whisrs setup
+/usr/local/bin/whisrs setup
 
-# Restart daemon again if setup changed the config.
 if systemctl --user is-active whisrs.service &>/dev/null; then
-    systemctl --user restart whisrs.service
+    /usr/local/bin/whisrs restart || true
     info "Daemon restarted" "with new config."
 fi
 
-echo -e "\n${GREEN}${BOLD}Installation complete!${RESET}"
-echo ""
+echo -e "\n${GREEN}${BOLD}Installation complete!${RESET}\n"


### PR DESCRIPTION
## Summary

Update the GitHub Pages installer so the advertised install command uses the current prebuilt-release installer instead of the stale source-build script.

## Changes

- Replace `gh-pages` `install.sh` with the current release-tarball installer.
- Includes the Debian/Ubuntu ALSA package fallback from the main installer fix.

## Testing

- `bash -n install.sh`

## Checklist

- [ ] `cargo fmt` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] Tested on at least one compositor
