### PR TITLE
Add X11 recording overlay backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-x11rb = "0.13"
+x11rb = { version = "0.13", features = ["shape"] }
 zbus = "5"
 
 [dependencies.ksni]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-x11rb = { version = "0.13", features = ["shape"] }
+x11rb = { version = "0.13", features = ["randr", "shape"] }
 zbus = "5"
 
 [dependencies.ksni]

--- a/src/overlay/mod.rs
+++ b/src/overlay/mod.rs
@@ -1,7 +1,6 @@
 //! Bottom-screen recording overlay.
 //!
-//! The overlay is optional and currently implemented for wlroots layer-shell
-//! compositors such as Hyprland and Sway.
+//! The overlay is optional and has native Wayland layer-shell and X11 backends.
 
 #[cfg(feature = "overlay")]
 mod service;

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -15,9 +15,9 @@ enum OverlayError {
     Shm(#[from] smithay_client_toolkit::shm::CreatePoolError),
     #[error("Wayland dispatch error: {0}")]
     Dispatch(#[from] wayland_client::DispatchError),
-    #[error("X11 connection error: {0}")]
+    #[error("X11 display connect error: {0}")]
     X11Connect(#[from] x11rb::errors::ConnectError),
-    #[error("X11 connection error: {0}")]
+    #[error("X11 protocol/IO error: {0}")]
     X11Connection(#[from] x11rb::errors::ConnectionError),
     #[error("X11 reply error: {0}")]
     X11Reply(#[from] x11rb::errors::ReplyError),
@@ -78,7 +78,7 @@ const BOTTOM_MARGIN: i32 = 16;
 // Per-frame sleep matching the draw loop. ~16 ms ≈ 60 fps for visibly
 // smoother motion. Spawn animation progress is wall-clock-driven (see
 // `Overlay::spawn_t`), so this only caps the redraw rate.
-const FRAME_MS: f32 = 16.0;
+const FRAME_MS: u64 = 16;
 
 // Spawn animation: the pill "draws out" from a 4-px sliver anchored at the
 // bottom of the surface up to its full configured height. Slight overshoot
@@ -230,6 +230,7 @@ pub async fn spawn_overlay(
     let (level_tx, level_rx_thread) = mpsc::channel::<f32>();
 
     let backend = OverlayBackend::detect();
+    info!("overlay backend selected: {backend:?}");
     let overlay_config = config;
     std::thread::Builder::new()
         .name("whisrs-overlay".to_string())
@@ -276,7 +277,9 @@ enum OverlayBackend {
 
 impl OverlayBackend {
     fn detect() -> Self {
-        if env_var_is_set("WAYLAND_DISPLAY") && !matches_env("XDG_SESSION_TYPE", "x11") {
+        let session_is_wayland = matches_env("XDG_SESSION_TYPE", "wayland");
+        let session_is_x11 = matches_env("XDG_SESSION_TYPE", "x11");
+        if (env_var_is_set("WAYLAND_DISPLAY") || session_is_wayland) && !session_is_x11 {
             Self::Wayland
         } else if env_var_is_set("DISPLAY") {
             Self::X11
@@ -444,6 +447,9 @@ fn run_overlay(
     info!("recording overlay started");
     while !overlay.exit {
         overlay.renderer.apply_state_updates();
+        if overlay.renderer.disconnected {
+            break;
+        }
         event_queue.blocking_dispatch(&mut overlay)?;
     }
 
@@ -500,31 +506,48 @@ fn run_x11_overlay(
         OverlayRenderer::new(state_rx, level_rx, width as u32, height as u32, theme)?;
     let mut frame = vec![0_u8; width as usize * height as usize * 4];
     let mut mapped = false;
+    // Cache of the last bounding-shape rectangles applied to the window.
+    // Recomputing alpha_shape_rectangles every frame is cheap, but issuing
+    // the SHAPE round-trip when geometry hasn't changed is not — skip it.
+    let mut last_shape: Vec<Rectangle> = Vec::new();
 
     info!("recording X11 overlay started");
     loop {
+        // Drain the event queue. Redraws are time-driven (the loop below
+        // pushes a frame every `FRAME_MS`), so we don't react to `Expose`
+        // explicitly — we just consume events so the protocol stream
+        // stays well-formed.
         while conn.poll_for_event()?.is_some() {}
 
         renderer.draw_frame();
+        if renderer.disconnected {
+            break;
+        }
         let visible_shape = alpha_shape_rectangles(&renderer.pixmap);
         if visible_shape.is_empty() {
             if mapped {
                 conn.unmap_window(window)?;
                 conn.flush()?;
                 mapped = false;
+                last_shape.clear();
             }
-            std::thread::sleep(Duration::from_millis(FRAME_MS as u64));
+            std::thread::sleep(Duration::from_millis(FRAME_MS));
             continue;
         }
 
-        if shape_supported {
+        if shape_supported && !shape_rectangles_eq(&visible_shape, &last_shape) {
             set_x11_bounding_shape(&conn, window, &visible_shape)?;
+            last_shape.clear();
+            last_shape.extend_from_slice(&visible_shape);
         }
         copy_pixmap_to_x11_zpixmap(&renderer.pixmap, visual, &mut frame);
-        if !mapped {
+        let just_mapped = if !mapped {
             conn.map_window(window)?;
             mapped = true;
-        }
+            true
+        } else {
+            false
+        };
         conn.put_image(
             ImageFormat::Z_PIXMAP,
             window,
@@ -537,13 +560,23 @@ fn run_x11_overlay(
             visual.depth,
             &frame,
         )?;
-        conn.configure_window(
-            window,
-            &ConfigureWindowAux::default().stack_mode(StackMode::ABOVE),
-        )?;
+        // Only re-assert stacking on map — the WM honors the initial
+        // request and re-issuing it every frame is pointless churn.
+        if just_mapped {
+            conn.configure_window(
+                window,
+                &ConfigureWindowAux::default().stack_mode(StackMode::ABOVE),
+            )?;
+        }
         conn.flush()?;
-        std::thread::sleep(Duration::from_millis(FRAME_MS as u64));
+        std::thread::sleep(Duration::from_millis(FRAME_MS));
     }
+
+    if mapped {
+        let _ = conn.unmap_window(window);
+        let _ = conn.flush();
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -713,6 +746,15 @@ fn set_x11_bounding_shape(
     Ok(())
 }
 
+fn shape_rectangles_eq(a: &[Rectangle], b: &[Rectangle]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b.iter()).all(|(lhs, rhs)| {
+        lhs.x == rhs.x && lhs.y == rhs.y && lhs.width == rhs.width && lhs.height == rhs.height
+    })
+}
+
 fn alpha_shape_rectangles(pixmap: &Pixmap) -> Vec<Rectangle> {
     let width = pixmap.width() as usize;
     let mut rectangles = Vec::new();
@@ -775,6 +817,10 @@ struct OverlayRenderer {
     /// `true` while transitioning into a visible state, `false` while
     /// transitioning out. Determines easing direction and duration.
     spawn_in: bool,
+    /// Set once either input channel returns `Disconnected` — the daemon's
+    /// forwarding task has exited, so the overlay should wind down cleanly
+    /// instead of leaking the thread.
+    disconnected: bool,
     frame: u32,
     /// Smoothed audio level driving bar heights. Advanced toward
     /// `level_target` by a critically-damped spring stepped with the
@@ -827,6 +873,7 @@ impl OverlayRenderer {
             visible_state: State::Idle,
             spawn_started: Instant::now(),
             spawn_in: false,
+            disconnected: false,
             frame: 0,
             level: 0.0,
             level_target: 0.0,
@@ -837,30 +884,47 @@ impl OverlayRenderer {
     }
 
     fn apply_state_updates(&mut self) {
-        while let Ok(state) = self.state_rx.try_recv() {
-            let was_idle = self.target_state == State::Idle;
-            let now_idle = state == State::Idle;
-            self.target_state = state;
+        loop {
+            match self.state_rx.try_recv() {
+                Ok(state) => {
+                    let was_idle = self.target_state == State::Idle;
+                    let now_idle = state == State::Idle;
+                    self.target_state = state;
 
-            if !now_idle {
-                self.visible_state = state;
-            }
+                    if !now_idle {
+                        self.visible_state = state;
+                    }
 
-            // Trigger spawn / despawn only on the boundary between idle and
-            // visible. Recording ↔ Transcribing keeps the pill steady.
-            if was_idle && !now_idle {
-                self.spawn_in = true;
-                self.spawn_started = Instant::now();
-            } else if !was_idle && now_idle {
-                self.spawn_in = false;
-                self.spawn_started = Instant::now();
+                    // Trigger spawn / despawn only on the boundary between
+                    // idle and visible. Recording ↔ Transcribing keeps the
+                    // pill steady.
+                    if was_idle && !now_idle {
+                        self.spawn_in = true;
+                        self.spawn_started = Instant::now();
+                    } else if !was_idle && now_idle {
+                        self.spawn_in = false;
+                        self.spawn_started = Instant::now();
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.disconnected = true;
+                    break;
+                }
             }
         }
         // Drain incoming audio levels — keep only the latest as the
         // spring target. The spring is stepped below using real elapsed
         // `dt`, so it doesn't matter how many samples we drained.
-        while let Ok(new) = self.level_rx.try_recv() {
-            self.level_target = new.clamp(0.0, 1.0);
+        loop {
+            match self.level_rx.try_recv() {
+                Ok(new) => self.level_target = new.clamp(0.0, 1.0),
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.disconnected = true;
+                    break;
+                }
+            }
         }
 
         // Critically-damped-ish spring on the displayed level. Stepped
@@ -1003,7 +1067,7 @@ impl Overlay {
         }
         self.layer.commit();
 
-        std::thread::sleep(Duration::from_millis(FRAME_MS as u64));
+        std::thread::sleep(Duration::from_millis(FRAME_MS));
     }
 }
 
@@ -1049,6 +1113,12 @@ fn copy_pixmap_to_x11_zpixmap(pixmap: &Pixmap, visual: X11ArgbVisual, canvas: &m
     }
 }
 
+/// Pack an 8-bit channel `value` into the bits described by `mask`, scaling
+/// it from `[0, 255]` into `[0, mask_max]`. The `(value * max + 127) / 255`
+/// form is the textbook integer rescale: adding `127` before dividing by
+/// `255` performs round-half-up so the brightest input (`0xFF`) always
+/// produces the brightest output, and intermediate values are nearest-
+/// rounded instead of truncated toward zero.
 fn pack_masked_channel(value: u8, mask: u32) -> u32 {
     if mask == 0 {
         return 0;

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -1,4 +1,4 @@
-//! Wayland layer-shell overlay shown while recording or transcribing.
+//! Desktop overlay shown while recording or transcribing.
 
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
@@ -15,6 +15,16 @@ enum OverlayError {
     Shm(#[from] smithay_client_toolkit::shm::CreatePoolError),
     #[error("Wayland dispatch error: {0}")]
     Dispatch(#[from] wayland_client::DispatchError),
+    #[error("X11 connection error: {0}")]
+    X11Connect(#[from] x11rb::errors::ConnectError),
+    #[error("X11 connection error: {0}")]
+    X11Connection(#[from] x11rb::errors::ConnectionError),
+    #[error("X11 reply error: {0}")]
+    X11Reply(#[from] x11rb::errors::ReplyError),
+    #[error("X11 reply/id error: {0}")]
+    X11ReplyOrId(#[from] x11rb::errors::ReplyOrIdError),
+    #[error("X11 ARGB visual not available")]
+    X11Visual,
     #[error("D-Bus error: {0}")]
     DBus(#[from] zbus::Error),
     #[error("D-Bus signal error: {0}")]
@@ -46,8 +56,20 @@ use tracing::{info, warn};
 use wayland_client::{
     globals::registry_queue_init,
     protocol::{wl_output, wl_region, wl_shm, wl_surface},
-    Connection, Dispatch, QueueHandle,
+    Connection as WaylandConnection, Dispatch, QueueHandle,
 };
+use x11rb::connection::{Connection as X11Connection, RequestConnection};
+use x11rb::protocol::{
+    shape::{ConnectionExt as X11ShapeConnectionExt, SK, SO, X11_EXTENSION_NAME as SHAPE_EXT},
+    xproto::{
+        AtomEnum, ClipOrdering, ColormapAlloc, ConfigureWindowAux,
+        ConnectionExt as X11ProtoConnectionExt, CreateGCAux, CreateWindowAux, EventMask,
+        ImageFormat, PropMode, Rectangle, Screen, StackMode, VisualClass, Visualid, Window,
+        WindowClass,
+    },
+};
+use x11rb::rust_connection::RustConnection;
+use x11rb::wrapper::ConnectionExt as X11WrapperConnectionExt;
 
 use crate::{OverlayConfig, State};
 
@@ -184,31 +206,43 @@ impl Theme {
 
 /// Spawn the bottom recording overlay.
 ///
-/// The Wayland event loop runs on a dedicated OS thread because it is a
-/// blocking client loop. A small Tokio task forwards daemon state changes into
+/// Native compositor event loops run on a dedicated OS thread because they are
+/// blocking client loops. A small Tokio task forwards daemon state changes into
 /// that thread.
 pub async fn spawn_overlay(
     mut state_rx: watch::Receiver<State>,
     mut level_rx: watch::Receiver<f32>,
     config: OverlayConfig,
 ) {
-    let gnome_state_rx = state_rx.clone();
-    let gnome_level_rx = level_rx.clone();
-    let gnome_theme = config.theme.clone();
-    tokio::spawn(async move {
-        if let Err(e) = run_gnome_broadcaster(gnome_state_rx, gnome_level_rx, gnome_theme).await {
-            warn!("GNOME overlay D-Bus broadcaster unavailable: {e:#}");
-        }
-    });
+    if is_gnome_desktop() {
+        let gnome_state_rx = state_rx.clone();
+        let gnome_level_rx = level_rx.clone();
+        let gnome_theme = config.theme.clone();
+        tokio::spawn(async move {
+            if let Err(e) = run_gnome_broadcaster(gnome_state_rx, gnome_level_rx, gnome_theme).await
+            {
+                warn!("GNOME overlay D-Bus broadcaster unavailable: {e:#}");
+            }
+        });
+    }
 
     let (tx, rx) = mpsc::channel::<State>();
     let (level_tx, level_rx_thread) = mpsc::channel::<f32>();
 
+    let backend = OverlayBackend::detect();
     let overlay_config = config;
     std::thread::Builder::new()
         .name("whisrs-overlay".to_string())
         .spawn(move || {
-            if let Err(e) = run_overlay(rx, level_rx_thread, overlay_config) {
+            let result = match backend {
+                OverlayBackend::Wayland => run_overlay(rx, level_rx_thread, overlay_config),
+                OverlayBackend::X11 => run_x11_overlay(rx, level_rx_thread, overlay_config),
+                OverlayBackend::Unavailable => {
+                    warn!("overlay unavailable: no Wayland or X11 display in environment");
+                    return;
+                }
+            };
+            if let Err(e) = result {
                 warn!("overlay unavailable: {e:#}");
             }
         })
@@ -231,6 +265,43 @@ pub async fn spawn_overlay(
             }
         }
     });
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OverlayBackend {
+    Wayland,
+    X11,
+    Unavailable,
+}
+
+impl OverlayBackend {
+    fn detect() -> Self {
+        if env_var_is_set("WAYLAND_DISPLAY") && !matches_env("XDG_SESSION_TYPE", "x11") {
+            Self::Wayland
+        } else if env_var_is_set("DISPLAY") {
+            Self::X11
+        } else {
+            Self::Unavailable
+        }
+    }
+}
+
+fn env_var_is_set(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|value| !value.is_empty())
+}
+
+fn matches_env(name: &str, expected: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn is_gnome_desktop() -> bool {
+    std::env::var("XDG_CURRENT_DESKTOP")
+        .map(|value| {
+            value
+                .split(':')
+                .any(|part| part.eq_ignore_ascii_case("GNOME"))
+        })
+        .unwrap_or(false)
 }
 
 async fn run_gnome_broadcaster(
@@ -334,7 +405,7 @@ fn run_overlay(
     let height = config.clamped_height();
     let theme = Theme::from_config(&config);
 
-    let conn = Connection::connect_to_env()?;
+    let conn = WaylandConnection::connect_to_env()?;
     let (globals, mut event_queue) = registry_queue_init(&conn)?;
     let qh = event_queue.handle();
 
@@ -359,39 +430,320 @@ fn run_overlay(
     layer.commit();
 
     let pool = SlotPool::new((width * height * 4) as usize, &shm)?;
-    let pixmap = Pixmap::new(width, height).ok_or(OverlayError::Pixmap(width, height))?;
     let mut overlay = Overlay {
         registry_state: RegistryState::new(&globals),
         output_state: OutputState::new(&globals, &qh),
         shm,
         pool,
-        pixmap,
         layer,
-        state_rx,
-        level_rx,
+        renderer: OverlayRenderer::new(state_rx, level_rx, width, height, theme)?,
         exit: false,
         first_configure: true,
-        width,
-        height,
-        target_state: State::Idle,
-        visible_state: State::Idle,
-        spawn_started: Instant::now(),
-        spawn_in: false,
-        frame: 0,
-        level: 0.0,
-        level_target: 0.0,
-        level_velocity: 0.0,
-        last_update: Instant::now(),
-        theme,
     };
 
     info!("recording overlay started");
     while !overlay.exit {
-        overlay.apply_state_updates();
+        overlay.renderer.apply_state_updates();
         event_queue.blocking_dispatch(&mut overlay)?;
     }
 
     Ok(())
+}
+
+fn run_x11_overlay(
+    state_rx: mpsc::Receiver<State>,
+    level_rx: mpsc::Receiver<f32>,
+    config: OverlayConfig,
+) -> Result<(), OverlayError> {
+    let width = config.clamped_width() as u16;
+    let height = config.clamped_height() as u16;
+    let theme = Theme::from_config(&config);
+
+    let (conn, screen_num) = RustConnection::connect(None)?;
+    let screen = &conn.setup().roots[screen_num];
+    let visual = find_argb_visual(screen).ok_or(OverlayError::X11Visual)?;
+    let atoms = X11Atoms::new(&conn)?;
+
+    let colormap = conn.generate_id()?;
+    conn.create_colormap(ColormapAlloc::NONE, colormap, screen.root, visual.visual_id)?;
+
+    let x = centered_x(screen, width);
+    let y = bottom_y(screen, height);
+    let window = conn.generate_id()?;
+    conn.create_window(
+        visual.depth,
+        window,
+        screen.root,
+        x,
+        y,
+        width,
+        height,
+        0,
+        WindowClass::INPUT_OUTPUT,
+        visual.visual_id,
+        &CreateWindowAux::default()
+            .background_pixel(0)
+            .border_pixel(0)
+            .colormap(colormap)
+            .override_redirect(1)
+            .event_mask(EventMask::EXPOSURE),
+    )?;
+
+    set_x11_window_hints(&conn, window, &atoms)?;
+    let shape_supported = make_x11_window_click_through(&conn, window)?;
+
+    let gc = conn.generate_id()?;
+    conn.create_gc(gc, window, &CreateGCAux::default().graphics_exposures(0))?;
+    conn.flush()?;
+
+    let mut renderer =
+        OverlayRenderer::new(state_rx, level_rx, width as u32, height as u32, theme)?;
+    let mut frame = vec![0_u8; width as usize * height as usize * 4];
+    let mut mapped = false;
+
+    info!("recording X11 overlay started");
+    loop {
+        while conn.poll_for_event()?.is_some() {}
+
+        renderer.draw_frame();
+        let visible_shape = alpha_shape_rectangles(&renderer.pixmap);
+        if visible_shape.is_empty() {
+            if mapped {
+                conn.unmap_window(window)?;
+                conn.flush()?;
+                mapped = false;
+            }
+            std::thread::sleep(Duration::from_millis(FRAME_MS as u64));
+            continue;
+        }
+
+        if shape_supported {
+            set_x11_bounding_shape(&conn, window, &visible_shape)?;
+        }
+        copy_pixmap_to_x11_zpixmap(&renderer.pixmap, visual, &mut frame);
+        if !mapped {
+            conn.map_window(window)?;
+            mapped = true;
+        }
+        conn.put_image(
+            ImageFormat::Z_PIXMAP,
+            window,
+            gc,
+            width,
+            height,
+            0,
+            0,
+            0,
+            visual.depth,
+            &frame,
+        )?;
+        conn.configure_window(
+            window,
+            &ConfigureWindowAux::default().stack_mode(StackMode::ABOVE),
+        )?;
+        conn.flush()?;
+        std::thread::sleep(Duration::from_millis(FRAME_MS as u64));
+    }
+}
+
+#[derive(Clone, Copy)]
+struct X11ArgbVisual {
+    depth: u8,
+    visual_id: Visualid,
+    red_mask: u32,
+    green_mask: u32,
+    blue_mask: u32,
+    alpha_mask: u32,
+}
+
+fn find_argb_visual(screen: &Screen) -> Option<X11ArgbVisual> {
+    screen.allowed_depths.iter().find_map(|depth| {
+        if depth.depth != 32 {
+            return None;
+        }
+        let full_mask = depth_mask(depth.depth);
+        depth.visuals.iter().find_map(|visual| {
+            if visual.class != VisualClass::TRUE_COLOR {
+                return None;
+            }
+            let color_mask = visual.red_mask | visual.green_mask | visual.blue_mask;
+            let alpha_mask = full_mask & !color_mask;
+            (alpha_mask != 0).then_some(X11ArgbVisual {
+                depth: depth.depth,
+                visual_id: visual.visual_id,
+                red_mask: visual.red_mask,
+                green_mask: visual.green_mask,
+                blue_mask: visual.blue_mask,
+                alpha_mask,
+            })
+        })
+    })
+}
+
+fn depth_mask(depth: u8) -> u32 {
+    if depth >= 32 {
+        u32::MAX
+    } else {
+        (1_u32 << depth) - 1
+    }
+}
+
+struct X11Atoms {
+    atom: u32,
+    net_wm_name: u32,
+    net_wm_window_type: u32,
+    net_wm_window_type_notification: u32,
+    net_wm_state: u32,
+    net_wm_state_above: u32,
+    net_wm_state_skip_pager: u32,
+    net_wm_state_skip_taskbar: u32,
+    net_wm_state_sticky: u32,
+    net_wm_bypass_compositor: u32,
+    utf8_string: u32,
+}
+
+impl X11Atoms {
+    fn new(conn: &RustConnection) -> Result<Self, OverlayError> {
+        Ok(Self {
+            atom: u32::from(AtomEnum::ATOM),
+            net_wm_name: intern_atom(conn, b"_NET_WM_NAME")?,
+            net_wm_window_type: intern_atom(conn, b"_NET_WM_WINDOW_TYPE")?,
+            net_wm_window_type_notification: intern_atom(
+                conn,
+                b"_NET_WM_WINDOW_TYPE_NOTIFICATION",
+            )?,
+            net_wm_state: intern_atom(conn, b"_NET_WM_STATE")?,
+            net_wm_state_above: intern_atom(conn, b"_NET_WM_STATE_ABOVE")?,
+            net_wm_state_skip_pager: intern_atom(conn, b"_NET_WM_STATE_SKIP_PAGER")?,
+            net_wm_state_skip_taskbar: intern_atom(conn, b"_NET_WM_STATE_SKIP_TASKBAR")?,
+            net_wm_state_sticky: intern_atom(conn, b"_NET_WM_STATE_STICKY")?,
+            net_wm_bypass_compositor: intern_atom(conn, b"_NET_WM_BYPASS_COMPOSITOR")?,
+            utf8_string: intern_atom(conn, b"UTF8_STRING")?,
+        })
+    }
+}
+
+fn intern_atom(conn: &RustConnection, name: &[u8]) -> Result<u32, OverlayError> {
+    Ok(conn.intern_atom(false, name)?.reply()?.atom)
+}
+
+fn set_x11_window_hints(
+    conn: &RustConnection,
+    window: Window,
+    atoms: &X11Atoms,
+) -> Result<(), OverlayError> {
+    conn.change_property8(
+        PropMode::REPLACE,
+        window,
+        atoms.net_wm_name,
+        atoms.utf8_string,
+        b"whisrs overlay",
+    )?;
+    conn.change_property8(
+        PropMode::REPLACE,
+        window,
+        AtomEnum::WM_NAME,
+        AtomEnum::STRING,
+        b"whisrs overlay",
+    )?;
+    conn.change_property32(
+        PropMode::REPLACE,
+        window,
+        atoms.net_wm_window_type,
+        atoms.atom,
+        &[atoms.net_wm_window_type_notification],
+    )?;
+    conn.change_property32(
+        PropMode::REPLACE,
+        window,
+        atoms.net_wm_state,
+        atoms.atom,
+        &[
+            atoms.net_wm_state_above,
+            atoms.net_wm_state_skip_pager,
+            atoms.net_wm_state_skip_taskbar,
+            atoms.net_wm_state_sticky,
+        ],
+    )?;
+    conn.change_property32(
+        PropMode::REPLACE,
+        window,
+        atoms.net_wm_bypass_compositor,
+        AtomEnum::CARDINAL,
+        &[2],
+    )?;
+    Ok(())
+}
+
+fn make_x11_window_click_through(
+    conn: &RustConnection,
+    window: Window,
+) -> Result<bool, OverlayError> {
+    if conn.extension_information(SHAPE_EXT)?.is_none() {
+        warn!("X11 SHAPE extension unavailable; overlay may intercept clicks");
+        return Ok(false);
+    }
+
+    conn.shape_rectangles(
+        SO::SET,
+        SK::INPUT,
+        ClipOrdering::UNSORTED,
+        window,
+        0,
+        0,
+        &[],
+    )?;
+    Ok(true)
+}
+
+fn set_x11_bounding_shape(
+    conn: &RustConnection,
+    window: Window,
+    rectangles: &[Rectangle],
+) -> Result<(), OverlayError> {
+    conn.shape_rectangles(
+        SO::SET,
+        SK::BOUNDING,
+        ClipOrdering::Y_SORTED,
+        window,
+        0,
+        0,
+        rectangles,
+    )?;
+    Ok(())
+}
+
+fn alpha_shape_rectangles(pixmap: &Pixmap) -> Vec<Rectangle> {
+    let width = pixmap.width() as usize;
+    let mut rectangles = Vec::new();
+
+    for (y, row) in pixmap.pixels().chunks_exact(width).enumerate() {
+        let Some(first) = row.iter().position(|px| px.alpha() != 0) else {
+            continue;
+        };
+        let last = row
+            .iter()
+            .rposition(|px| px.alpha() != 0)
+            .expect("row has a first alpha pixel");
+        rectangles.push(Rectangle {
+            x: first as i16,
+            y: y as i16,
+            width: (last - first + 1) as u16,
+            height: 1,
+        });
+    }
+
+    rectangles
+}
+
+fn centered_x(screen: &Screen, width: u16) -> i16 {
+    let x = (i32::from(screen.width_in_pixels) - i32::from(width)) / 2;
+    x.max(0).min(i32::from(i16::MAX)) as i16
+}
+
+fn bottom_y(screen: &Screen, height: u16) -> i16 {
+    let y = i32::from(screen.height_in_pixels) - i32::from(height) - BOTTOM_MARGIN;
+    y.max(0).min(i32::from(i16::MAX)) as i16
 }
 
 struct Overlay {
@@ -399,14 +751,18 @@ struct Overlay {
     output_state: OutputState,
     shm: Shm,
     pool: SlotPool,
-    pixmap: Pixmap,
     layer: LayerSurface,
-    state_rx: mpsc::Receiver<State>,
-    level_rx: mpsc::Receiver<f32>,
+    renderer: OverlayRenderer,
     exit: bool,
     first_configure: bool,
+}
+
+struct OverlayRenderer {
+    state_rx: mpsc::Receiver<State>,
+    level_rx: mpsc::Receiver<f32>,
     width: u32,
     height: u32,
+    pixmap: Pixmap,
     target_state: State,
     visible_state: State,
     /// Wall-clock instant when the current spawn animation started. The
@@ -452,7 +808,34 @@ struct AnimState {
     bars_locked: bool,
 }
 
-impl Overlay {
+impl OverlayRenderer {
+    fn new(
+        state_rx: mpsc::Receiver<State>,
+        level_rx: mpsc::Receiver<f32>,
+        width: u32,
+        height: u32,
+        theme: Theme,
+    ) -> Result<Self, OverlayError> {
+        let pixmap = Pixmap::new(width, height).ok_or(OverlayError::Pixmap(width, height))?;
+        Ok(Self {
+            state_rx,
+            level_rx,
+            width,
+            height,
+            pixmap,
+            target_state: State::Idle,
+            visible_state: State::Idle,
+            spawn_started: Instant::now(),
+            spawn_in: false,
+            frame: 0,
+            level: 0.0,
+            level_target: 0.0,
+            level_velocity: 0.0,
+            last_update: Instant::now(),
+            theme,
+        })
+    }
+
     fn apply_state_updates(&mut self) {
         while let Ok(state) = self.state_rx.try_recv() {
             let was_idle = self.target_state == State::Idle;
@@ -572,16 +955,10 @@ impl Overlay {
         }
     }
 
-    fn draw(&mut self, qh: &QueueHandle<Self>) {
+    fn draw_frame(&mut self) {
         self.apply_state_updates();
 
-        let width = self.width;
-        let height = self.height;
-        let stride = width as i32 * 4;
-
-        // Render into our owned pixmap first so the buffer borrow on the
-        // shm pool doesn't conflict with the pixmap borrow.
-        let anim = self.anim(height as f32);
+        let anim = self.anim(self.height as f32);
         let level_gated = if anim.bars_locked { 0.0 } else { self.level };
         draw_overlay(
             &mut self.pixmap,
@@ -592,6 +969,16 @@ impl Overlay {
             &self.theme,
         );
         self.frame = self.frame.wrapping_add(1);
+    }
+}
+
+impl Overlay {
+    fn draw(&mut self, qh: &QueueHandle<Self>) {
+        let width = self.renderer.width;
+        let height = self.renderer.height;
+        let stride = width as i32 * 4;
+
+        self.renderer.draw_frame();
 
         let Ok((buffer, canvas)) = self.pool.create_buffer(
             width as i32,
@@ -602,7 +989,7 @@ impl Overlay {
             warn!("failed to allocate overlay buffer");
             return;
         };
-        copy_pixmap_to_argb8888(&self.pixmap, canvas);
+        copy_pixmap_to_argb8888(&self.renderer.pixmap, canvas);
 
         self.layer
             .wl_surface()
@@ -649,10 +1036,34 @@ fn copy_pixmap_to_argb8888(pixmap: &Pixmap, canvas: &mut [u8]) {
     }
 }
 
+fn copy_pixmap_to_x11_zpixmap(pixmap: &Pixmap, visual: X11ArgbVisual, canvas: &mut [u8]) {
+    let src = pixmap.pixels();
+    debug_assert_eq!(src.len() * 4, canvas.len());
+    for (i, px) in src.iter().enumerate() {
+        let pre: PremultipliedColorU8 = *px;
+        let pixel = pack_masked_channel(pre.red(), visual.red_mask)
+            | pack_masked_channel(pre.green(), visual.green_mask)
+            | pack_masked_channel(pre.blue(), visual.blue_mask)
+            | pack_masked_channel(pre.alpha(), visual.alpha_mask);
+        canvas[i * 4..i * 4 + 4].copy_from_slice(&pixel.to_ne_bytes());
+    }
+}
+
+fn pack_masked_channel(value: u8, mask: u32) -> u32 {
+    if mask == 0 {
+        return 0;
+    }
+    let bits = mask.count_ones();
+    let shift = mask.trailing_zeros();
+    let max = (1_u64 << bits) - 1;
+    let scaled = (u64::from(value) * max + 127) / 255;
+    ((scaled << shift) as u32) & mask
+}
+
 impl CompositorHandler for Overlay {
     fn scale_factor_changed(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
         _surface: &wl_surface::WlSurface,
         _new_factor: i32,
@@ -661,7 +1072,7 @@ impl CompositorHandler for Overlay {
 
     fn transform_changed(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
         _surface: &wl_surface::WlSurface,
         _new_transform: wl_output::Transform,
@@ -670,7 +1081,7 @@ impl CompositorHandler for Overlay {
 
     fn frame(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         qh: &QueueHandle<Self>,
         _surface: &wl_surface::WlSurface,
         _time: u32,
@@ -680,7 +1091,7 @@ impl CompositorHandler for Overlay {
 
     fn surface_enter(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
         _surface: &wl_surface::WlSurface,
         _output: &wl_output::WlOutput,
@@ -689,7 +1100,7 @@ impl CompositorHandler for Overlay {
 
     fn surface_leave(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
         _surface: &wl_surface::WlSurface,
         _output: &wl_output::WlOutput,
@@ -704,7 +1115,7 @@ impl OutputHandler for Overlay {
 
     fn new_output(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
         _output: wl_output::WlOutput,
     ) {
@@ -712,7 +1123,7 @@ impl OutputHandler for Overlay {
 
     fn update_output(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
         _output: wl_output::WlOutput,
     ) {
@@ -720,7 +1131,7 @@ impl OutputHandler for Overlay {
 
     fn output_destroyed(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
         _output: wl_output::WlOutput,
     ) {
@@ -728,21 +1139,23 @@ impl OutputHandler for Overlay {
 }
 
 impl LayerShellHandler for Overlay {
-    fn closed(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _layer: &LayerSurface) {
+    fn closed(
+        &mut self,
+        _conn: &WaylandConnection,
+        _qh: &QueueHandle<Self>,
+        _layer: &LayerSurface,
+    ) {
         self.exit = true;
     }
 
     fn configure(
         &mut self,
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         qh: &QueueHandle<Self>,
         _layer: &LayerSurface,
-        configure: LayerSurfaceConfigure,
+        _configure: LayerSurfaceConfigure,
         _serial: u32,
     ) {
-        self.width = configure.new_size.0.max(self.width);
-        self.height = configure.new_size.1.max(self.height);
-
         if self.first_configure {
             self.first_configure = false;
             self.draw(qh);
@@ -762,7 +1175,7 @@ impl Dispatch<wl_region::WlRegion, ()> for Overlay {
         _proxy: &wl_region::WlRegion,
         _event: wl_region::Event,
         _data: &(),
-        _conn: &Connection,
+        _conn: &WaylandConnection,
         _qh: &QueueHandle<Self>,
     ) {
     }

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -60,6 +60,7 @@ use wayland_client::{
 };
 use x11rb::connection::{Connection as X11Connection, RequestConnection};
 use x11rb::protocol::{
+    randr::{ConnectionExt as X11RandrConnectionExt, MonitorInfo, X11_EXTENSION_NAME as RANDR_EXT},
     shape::{ConnectionExt as X11ShapeConnectionExt, SK, SO, X11_EXTENSION_NAME as SHAPE_EXT},
     xproto::{
         AtomEnum, ClipOrdering, ColormapAlloc, ConfigureWindowAux,
@@ -541,13 +542,18 @@ fn run_x11_overlay(
             last_shape.extend_from_slice(&visible_shape);
         }
         copy_pixmap_to_x11_zpixmap(&renderer.pixmap, visual, &mut frame);
-        let just_mapped = if !mapped {
+        if !mapped {
+            let (x, y) = x11_overlay_position(&conn, screen, &atoms, width, height);
+            conn.configure_window(
+                window,
+                &ConfigureWindowAux::default()
+                    .x(i32::from(x))
+                    .y(i32::from(y))
+                    .stack_mode(StackMode::ABOVE),
+            )?;
             conn.map_window(window)?;
             mapped = true;
-            true
-        } else {
-            false
-        };
+        }
         conn.put_image(
             ImageFormat::Z_PIXMAP,
             window,
@@ -560,14 +566,6 @@ fn run_x11_overlay(
             visual.depth,
             &frame,
         )?;
-        // Only re-assert stacking on map — the WM honors the initial
-        // request and re-issuing it every frame is pointless churn.
-        if just_mapped {
-            conn.configure_window(
-                window,
-                &ConfigureWindowAux::default().stack_mode(StackMode::ABOVE),
-            )?;
-        }
         conn.flush()?;
         std::thread::sleep(Duration::from_millis(FRAME_MS));
     }
@@ -623,6 +621,7 @@ fn depth_mask(depth: u8) -> u32 {
 
 struct X11Atoms {
     atom: u32,
+    net_active_window: u32,
     net_wm_name: u32,
     net_wm_window_type: u32,
     net_wm_window_type_notification: u32,
@@ -639,6 +638,7 @@ impl X11Atoms {
     fn new(conn: &RustConnection) -> Result<Self, OverlayError> {
         Ok(Self {
             atom: u32::from(AtomEnum::ATOM),
+            net_active_window: intern_atom(conn, b"_NET_ACTIVE_WINDOW")?,
             net_wm_name: intern_atom(conn, b"_NET_WM_NAME")?,
             net_wm_window_type: intern_atom(conn, b"_NET_WM_WINDOW_TYPE")?,
             net_wm_window_type_notification: intern_atom(
@@ -778,14 +778,160 @@ fn alpha_shape_rectangles(pixmap: &Pixmap) -> Vec<Rectangle> {
     rectangles
 }
 
+fn x11_overlay_position(
+    conn: &RustConnection,
+    screen: &Screen,
+    atoms: &X11Atoms,
+    width: u16,
+    height: u16,
+) -> (i16, i16) {
+    let monitors = match active_x11_monitors(conn, screen.root) {
+        Ok(monitors) => monitors,
+        Err(e) => {
+            warn!("failed to query XRandR monitors for overlay placement: {e:#}");
+            Vec::new()
+        }
+    };
+
+    if let Some((cx, cy)) = match active_x11_window_center(conn, screen.root, atoms) {
+        Ok(center) => center,
+        Err(e) => {
+            warn!("failed to query active X11 window for overlay placement: {e:#}");
+            None
+        }
+    } {
+        if let Some(monitor) = monitors
+            .iter()
+            .find(|m| point_in_rect(cx, cy, i32::from(m.x), i32::from(m.y), m.width, m.height))
+        {
+            return position_in_rect(
+                i32::from(monitor.x),
+                i32::from(monitor.y),
+                u32::from(monitor.width),
+                u32::from(monitor.height),
+                width,
+                height,
+            );
+        }
+    }
+
+    if let Some(monitor) = monitors
+        .iter()
+        .find(|m| m.primary)
+        .or_else(|| monitors.first())
+    {
+        return position_in_rect(
+            i32::from(monitor.x),
+            i32::from(monitor.y),
+            u32::from(monitor.width),
+            u32::from(monitor.height),
+            width,
+            height,
+        );
+    }
+
+    (centered_x(screen, width), bottom_y(screen, height))
+}
+
+fn active_x11_monitors(
+    conn: &RustConnection,
+    root: Window,
+) -> Result<Vec<MonitorInfo>, OverlayError> {
+    if conn.extension_information(RANDR_EXT)?.is_none() {
+        return Ok(Vec::new());
+    }
+
+    let reply = conn.randr_get_monitors(root, true)?.reply()?;
+    Ok(reply
+        .monitors
+        .into_iter()
+        .filter(|monitor| monitor.width > 0 && monitor.height > 0)
+        .collect())
+}
+
+fn active_x11_window_center(
+    conn: &RustConnection,
+    root: Window,
+    atoms: &X11Atoms,
+) -> Result<Option<(i32, i32)>, OverlayError> {
+    let reply = conn
+        .get_property(false, root, atoms.net_active_window, AtomEnum::WINDOW, 0, 1)?
+        .reply()?;
+
+    let Some(bytes) = reply.value.get(..4) else {
+        return Ok(None);
+    };
+    let window = u32::from_ne_bytes(bytes.try_into().expect("slice is exactly 4 bytes"));
+    if window == 0 {
+        return Ok(None);
+    }
+
+    let geometry = conn.get_geometry(window)?.reply()?;
+    let translated = conn.translate_coordinates(window, root, 0, 0)?.reply()?;
+    if !translated.same_screen {
+        return Ok(None);
+    }
+
+    Ok(Some((
+        i32::from(translated.dst_x) + i32::from(geometry.width / 2),
+        i32::from(translated.dst_y) + i32::from(geometry.height / 2),
+    )))
+}
+
+fn point_in_rect(x: i32, y: i32, rx: i32, ry: i32, width: u16, height: u16) -> bool {
+    let right = rx.saturating_add(i32::from(width));
+    let bottom = ry.saturating_add(i32::from(height));
+    x >= rx && x < right && y >= ry && y < bottom
+}
+
+fn position_in_rect(
+    x: i32,
+    y: i32,
+    rect_width: u32,
+    rect_height: u32,
+    width: u16,
+    height: u16,
+) -> (i16, i16) {
+    let width = i32::from(width);
+    let height = i32::from(height);
+    let rect_width = i32::try_from(rect_width).unwrap_or(i32::MAX);
+    let rect_height = i32::try_from(rect_height).unwrap_or(i32::MAX);
+
+    let min_x = x;
+    let max_x = x
+        .saturating_add(rect_width)
+        .saturating_sub(width)
+        .max(min_x);
+    let centered_x = x.saturating_add((rect_width - width) / 2);
+
+    let min_y = y;
+    let max_y = y
+        .saturating_add(rect_height)
+        .saturating_sub(height)
+        .max(min_y);
+    let bottom_y = y
+        .saturating_add(rect_height)
+        .saturating_sub(height)
+        .saturating_sub(BOTTOM_MARGIN);
+
+    (
+        to_i16_coord(centered_x.clamp(min_x, max_x)),
+        to_i16_coord(bottom_y.clamp(min_y, max_y)),
+    )
+}
+
 fn centered_x(screen: &Screen, width: u16) -> i16 {
     let x = (i32::from(screen.width_in_pixels) - i32::from(width)) / 2;
-    x.max(0).min(i32::from(i16::MAX)) as i16
+    to_i16_coord(x.max(0))
 }
 
 fn bottom_y(screen: &Screen, height: u16) -> i16 {
     let y = i32::from(screen.height_in_pixels) - i32::from(height) - BOTTOM_MARGIN;
-    y.max(0).min(i32::from(i16::MAX)) as i16
+    to_i16_coord(y.max(0))
+}
+
+fn to_i16_coord(value: i32) -> i16 {
+    value.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
 }
 
 struct Overlay {
@@ -1611,6 +1757,21 @@ mod tests {
         assert!((ease_out_back(1.0, 0.4) - 1.0).abs() < 1e-6);
         // The "back" curve is supposed to peak above 1 in the middle.
         assert!(ease_out_back(0.85, 0.4) > 1.0);
+    }
+
+    #[test]
+    fn x11_position_in_rect_uses_monitor_bounds() {
+        assert_eq!(
+            position_in_rect(1920, 360, 1920, 1200, 100, 40),
+            (2830, 1504)
+        );
+        assert_eq!(position_in_rect(3840, 0, 1200, 1920, 100, 40), (4390, 1864));
+    }
+
+    #[test]
+    fn x11_point_in_rect_uses_half_open_bounds() {
+        assert!(point_in_rect(2830, 1504, 1920, 360, 1920, 1200));
+        assert!(!point_in_rect(3840, 1504, 1920, 360, 1920, 1200));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a native X11 backend for the recording overlay so KDE/X11 and other X11 sessions do not try the Wayland layer-shell path.

## Changes

- Select Wayland or X11 overlay backend from the session environment
- Reuse the existing tiny-skia overlay renderer for both Wayland and X11
- Keep the X11 overlay window unmapped while idle, preventing a persistent black rectangle
- Apply X Shape input and bounding masks so the overlay does not intercept clicks and remains shaped when visible
- Start the GNOME D-Bus overlay broadcaster only on GNOME desktops

## Testing

- KDE Plasma on X11, Ubuntu-based desktop, default PipeWire/PulseAudio audio path
- Reproduced the previous failure mode where X11 showed a permanent black rectangle at the bottom of the screen
- Installed a local build with a user-systemd override and verified `whisrs.service` runs `~/.local/bin/whisrsd`
- Verified the idle X11 overlay window is `IsUnMapped`
- Verified manual recording shows the overlay without a persistent black rectangle
- `cargo fmt --check`
- `CMAKE=/usr/bin/cmake cargo clippy --all-targets -- -D warnings`
- `CMAKE=/usr/bin/cmake cargo test`

Runtime testing used this patch together with #34 because my local config uses OpenAI Realtime streaming.

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor
