### PR TITLE
Fix X11 AltGr typing for qwerty-fr

### DIFF
--- a/crates/xkb-type/src/keyboard.rs
+++ b/crates/xkb-type/src/keyboard.rs
@@ -24,8 +24,10 @@ macro_rules! warn {
 use crate::keymap::{KeyboardLayout, XkbKeymap};
 use crate::{default_clipboard, ClipboardBackend, KeyTap};
 
-/// Delay after creating the virtual device to let the kernel register it.
-const DEVICE_SETTLE_DELAY: Duration = Duration::from_millis(200);
+/// Delay after creating the virtual device to let X11/Wayland register its
+/// keymap before the first injected key. X11 clients otherwise can process
+/// text before the MappingNotify refresh that makes `<LVL3>` work.
+const DEVICE_SETTLE_DELAY: Duration = Duration::from_secs(1);
 
 /// Virtual keyboard that injects keystrokes via uinput.
 pub struct Keyboard {
@@ -126,6 +128,10 @@ impl Keyboard {
     // Public API
     // -----------------------------------------------------------------------
 
+    pub fn set_key_delay(&mut self, key_delay: Duration) {
+        self.key_delay = key_delay;
+    }
+
     /// Type `text` by injecting keystrokes through the virtual device.
     ///
     /// Characters found in the keymap are typed via direct key events
@@ -217,15 +223,18 @@ impl Keyboard {
 
     /// Press and release a single key, with Shift and/or AltGr held as needed.
     ///
-    /// AltGr is `KEY_RIGHTALT`. Both modifiers can be held together for
-    /// level-3 chars on layouts like `us:intl` (e.g. Shift+AltGr+something
-    /// for less common accented forms).
+    /// AltGr is the keycode XKB exposes for `ISO_Level3_Shift`. On some
+    /// X11 layouts that is a dedicated `<LVL3>` keycode rather than
+    /// `KEY_RIGHTALT`; using the XKB keycode keeps third-level characters
+    /// like `é` working with uinput.
     fn tap_key(&mut self, tap: &KeyTap) -> anyhow::Result<()> {
+        let level3_key = Key::new(self.keymap.level3_keycode());
+
         if tap.shift {
             self.set_modifier(Key::KEY_LEFTSHIFT, true)?;
         }
         if tap.altgr {
-            self.set_modifier(Key::KEY_RIGHTALT, true)?;
+            self.set_modifier(level3_key, true)?;
         }
 
         self.device
@@ -236,7 +245,7 @@ impl Keyboard {
         thread::sleep(self.key_delay);
 
         if tap.altgr {
-            self.set_modifier(Key::KEY_RIGHTALT, false)?;
+            self.set_modifier(level3_key, false)?;
         }
         if tap.shift {
             self.set_modifier(Key::KEY_LEFTSHIFT, false)?;
@@ -247,6 +256,7 @@ impl Keyboard {
 
     /// Release all modifier keys to prevent interference with injected text.
     fn release_all_modifiers(&mut self) -> anyhow::Result<()> {
+        let level3_key = Key::new(self.keymap.level3_keycode());
         let modifiers = [
             Key::KEY_LEFTSHIFT,
             Key::KEY_RIGHTSHIFT,
@@ -254,6 +264,7 @@ impl Keyboard {
             Key::KEY_RIGHTCTRL,
             Key::KEY_LEFTALT,
             Key::KEY_RIGHTALT,
+            level3_key,
             Key::KEY_LEFTMETA,
             Key::KEY_RIGHTMETA,
         ];

--- a/crates/xkb-type/src/keyboard.rs
+++ b/crates/xkb-type/src/keyboard.rs
@@ -24,10 +24,18 @@ macro_rules! warn {
 use crate::keymap::{KeyboardLayout, XkbKeymap};
 use crate::{default_clipboard, ClipboardBackend, KeyTap};
 
-/// Delay after creating the virtual device to let X11/Wayland register its
-/// keymap before the first injected key. X11 clients otherwise can process
-/// text before the MappingNotify refresh that makes `<LVL3>` work.
-const DEVICE_SETTLE_DELAY: Duration = Duration::from_secs(1);
+/// Delay after creating the virtual device on the runtime path (e.g. when
+/// the daemon re-creates the keyboard after an error). Short, because this
+/// runs on the user's typing path — every error-recovery would otherwise
+/// stall typing.
+const DEVICE_SETTLE_DELAY: Duration = Duration::from_millis(200);
+
+/// Longer delay used at daemon startup (prewarm), so X11 has time to
+/// process MappingNotify and attach the new device's keymap before the
+/// first character is typed. Without this, the very first typed character
+/// after boot can race the X11 keymap refresh and drop accented keys
+/// (notably `<LVL3>` characters like `é` on `us:qwerty-fr`).
+const INITIAL_WARMUP_DELAY: Duration = Duration::from_secs(1);
 
 /// Virtual keyboard that injects keystrokes via uinput.
 pub struct Keyboard {
@@ -57,6 +65,21 @@ impl Keyboard {
         let layout = KeyboardLayout::detect();
         let keymap = XkbKeymap::from_layout(&layout)?;
         Self::with_components(keymap, default_clipboard(), key_delay)
+    }
+
+    /// Like [`Keyboard::new`], but uses a longer post-creation settle
+    /// delay suited for the **first** virtual keyboard created in a
+    /// process. Call this from a startup prewarm so X11 has time to
+    /// process MappingNotify and attach the new device's keymap before
+    /// any character is typed.
+    ///
+    /// Subsequent recreates (e.g. on error recovery) should keep using
+    /// [`Keyboard::new`], which uses a shorter settle so the user's
+    /// typing path is not stalled by 1s on every recovery.
+    pub fn new_prewarm(key_delay: Duration) -> anyhow::Result<Self> {
+        let layout = KeyboardLayout::detect();
+        let keymap = XkbKeymap::from_layout(&layout)?;
+        Self::with_components_settle(keymap, default_clipboard(), key_delay, INITIAL_WARMUP_DELAY)
     }
 
     /// Create a virtual keyboard for a specific XKB layout (and optional
@@ -96,6 +119,19 @@ impl Keyboard {
         clipboard: Box<dyn ClipboardBackend>,
         key_delay: Duration,
     ) -> anyhow::Result<Self> {
+        Self::with_components_settle(keymap, clipboard, key_delay, DEVICE_SETTLE_DELAY)
+    }
+
+    /// Same as [`Keyboard::with_components`], but with an explicit
+    /// post-creation settle delay. Kept private — callers should pick
+    /// between [`Keyboard::new`] (short settle, runtime path) and
+    /// [`Keyboard::new_prewarm`] (long settle, startup path).
+    fn with_components_settle(
+        keymap: XkbKeymap,
+        clipboard: Box<dyn ClipboardBackend>,
+        key_delay: Duration,
+        settle: Duration,
+    ) -> anyhow::Result<Self> {
         // Register all key codes we might need (1..=247 covers standard
         // keys; KEY_MAX on Linux is ~767 but codes beyond 247 are rare).
         let mut keys = AttributeSet::<Key>::new();
@@ -111,8 +147,9 @@ impl Keyboard {
             .build()
             .context("failed to build uinput virtual device — check /dev/uinput permissions")?;
 
-        // Give the kernel time to register the new device.
-        thread::sleep(DEVICE_SETTLE_DELAY);
+        // Give the kernel (and on X11, the server) time to register the
+        // new device and refresh its keymap before any keys are sent.
+        thread::sleep(settle);
 
         debug!("uinput virtual keyboard created");
 

--- a/crates/xkb-type/src/keymap.rs
+++ b/crates/xkb-type/src/keymap.rs
@@ -4,6 +4,15 @@ use crate::{KeyMapping, KeyTap};
 use std::collections::HashMap;
 use std::process::Command;
 
+// Logging via the `log` crate (only active with `logging` feature),
+// matching the conditional shim used in `keyboard.rs`.
+#[cfg(feature = "logging")]
+use log::debug;
+#[cfg(not(feature = "logging"))]
+macro_rules! debug {
+    ($($arg:tt)*) => {};
+}
+
 #[derive(Debug, Clone)]
 pub struct KeyboardLayout {
     pub layout: String,
@@ -113,13 +122,38 @@ impl KeyboardLayout {
             return None;
         }
 
-        let output = Command::new("setxkbmap").arg("-query").output().ok()?;
+        let output = match Command::new("setxkbmap").arg("-query").output() {
+            Ok(out) => out,
+            Err(_e) => {
+                debug!("setxkbmap probe failed to spawn: {_e}");
+                return None;
+            }
+        };
         if !output.status.success() {
+            debug!(
+                "setxkbmap -query exited non-zero: status={:?}",
+                output.status.code()
+            );
             return None;
         }
 
-        let stdout = String::from_utf8(output.stdout).ok()?;
-        parse_setxkbmap_query(&stdout)
+        let stdout = match String::from_utf8(output.stdout) {
+            Ok(s) => s,
+            Err(_e) => {
+                debug!("setxkbmap -query stdout was not valid utf-8: {_e}");
+                return None;
+            }
+        };
+        let parsed = parse_setxkbmap_query(&stdout);
+        if let Some(_kl) = parsed.as_ref() {
+            debug!(
+                "x11 layout detected via setxkbmap: layout={} variant={}",
+                _kl.layout, _kl.variant
+            );
+        } else {
+            debug!("setxkbmap -query returned no parseable layout");
+        }
+        parsed
     }
 
     fn from_env() -> Option<Self> {
@@ -178,7 +212,12 @@ impl XkbKeymap {
                 detected.variant
             )
         })?;
-        let level3_keycode = find_level3_keycode(&keymap);
+        // Fall back to KEY_RIGHTALT when no dedicated `<LVL3>` key exists
+        // — that's the common case on plain `us`, `de`, etc. where AltGr
+        // *is* RightAlt. Dedicated `<LVL3>` keycodes show up on layouts
+        // like `us:qwerty-fr`.
+        let level3_keycode =
+            find_level3_keycode(&keymap).unwrap_or_else(|| evdev::Key::KEY_RIGHTALT.code());
         let map = build_reverse_map(&keymap);
         Ok(Self {
             map,
@@ -246,30 +285,39 @@ const ACCENTED_VIA_DEAD_KEY: &[(char, char, u32)] = &[
     ('Ç', 'C', KEY_dead_cedilla),
 ];
 
-fn find_level3_keycode(keymap: &xkbcommon::xkb::Keymap) -> u16 {
+/// Scan the keymap for a key whose **base-level** (layout 0, level 0)
+/// keysym is `ISO_Level3_Shift`. Returns the evdev keycode of the first
+/// such key that is **not** `KEY_RIGHTALT` — that's the dedicated
+/// `<LVL3>` key on layouts like `us:qwerty-fr`.
+///
+/// Returns `None` when there is no dedicated `<LVL3>` key (the common
+/// case: `ISO_Level3_Shift` is bound to `KEY_RIGHTALT` itself, or not at
+/// all). Callers fall back to `KEY_RIGHTALT` in that case.
+///
+/// Restricted to layout 0 / level 0 because `ISO_Level3_Shift` is a
+/// modifier and lives at the base level — scanning every level would
+/// occasionally pick up keys that *produce* a Level3 modifier as a
+/// shifted symbol, which is not what we want.
+fn find_level3_keycode(keymap: &xkbcommon::xkb::Keymap) -> Option<u16> {
     let right_alt = evdev::Key::KEY_RIGHTALT.code();
-    let mut fallback = None;
 
     for raw_keycode in keymap.min_keycode().raw()..=keymap.max_keycode().raw() {
         let keycode = xkbcommon::xkb::Keycode::new(raw_keycode);
         let evdev_keycode: u16 = raw_keycode.saturating_sub(8).try_into().unwrap_or(u16::MAX);
 
-        for layout in 0..keymap.num_layouts() {
-            for level in 0..keymap.num_levels_for_key(keycode, layout) {
-                let syms = keymap.key_get_syms_by_level(keycode, layout, level);
-                if !syms.iter().any(|sym| sym.raw() == KEY_ISO_Level3_Shift) {
-                    continue;
-                }
+        // Restrict to layout 0 / level 0 — `ISO_Level3_Shift` is a
+        // modifier at the base level.
+        let syms = keymap.key_get_syms_by_level(keycode, 0, 0);
+        if !syms.iter().any(|sym| sym.raw() == KEY_ISO_Level3_Shift) {
+            continue;
+        }
 
-                if evdev_keycode != right_alt {
-                    return evdev_keycode;
-                }
-                fallback.get_or_insert(evdev_keycode);
-            }
+        if evdev_keycode != right_alt {
+            return Some(evdev_keycode);
         }
     }
 
-    fallback.unwrap_or(right_alt)
+    None
 }
 
 #[allow(non_upper_case_globals)]
@@ -461,10 +509,16 @@ mod tests {
     fn us_qwerty_fr_typeable_via_uinput() {
         let km = XkbKeymap::from_layout(&layout("us", "qwerty-fr")).unwrap();
 
-        assert_eq!(
+        // The real contract: on us:qwerty-fr, AltGr lives behind a
+        // dedicated `<LVL3>` keycode that is *not* KEY_RIGHTALT. The
+        // exact evdev keycode (currently 84 / KEY_KP4) is an XKB-
+        // implementation detail and could shift between xkbcommon
+        // versions, so assert the property rather than the number.
+        assert_ne!(
             km.level3_keycode(),
-            84,
-            "us:qwerty-fr must use the XKB <LVL3> keycode for AltGr, not KEY_RIGHTALT"
+            evdev::Key::KEY_RIGHTALT.code(),
+            "us:qwerty-fr must use the dedicated XKB <LVL3> keycode for \
+             AltGr, not KEY_RIGHTALT"
         );
         assert_key_full(&km, 'é', 17, false, true, "US qwerty-fr");
 

--- a/crates/xkb-type/src/keymap.rs
+++ b/crates/xkb-type/src/keymap.rs
@@ -18,6 +18,9 @@ impl KeyboardLayout {
         if let Some(kl) = Self::from_sway() {
             return kl;
         }
+        if let Some(kl) = Self::from_x11() {
+            return kl;
+        }
         if let Some(kl) = Self::from_env() {
             return kl;
         }
@@ -71,8 +74,8 @@ impl KeyboardLayout {
     ///
     /// We therefore confirm Sway is reachable (so the function is not
     /// dead code) but always return `None`, letting the caller fall
-    /// through to `from_env`. If a real display-name → XKB-code lookup
-    /// table is added later, this is the place to wire it up.
+    /// through to the next fallback. If a real display-name → XKB-code
+    /// lookup table is added later, this is the place to wire it up.
     fn from_sway() -> Option<Self> {
         let output = Command::new("swaymsg")
             .args(["-t", "get_inputs", "--raw"])
@@ -105,6 +108,20 @@ impl KeyboardLayout {
         None
     }
 
+    fn from_x11() -> Option<Self> {
+        if std::env::var_os("DISPLAY").is_none() || std::env::var_os("WAYLAND_DISPLAY").is_some() {
+            return None;
+        }
+
+        let output = Command::new("setxkbmap").arg("-query").output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let stdout = String::from_utf8(output.stdout).ok()?;
+        parse_setxkbmap_query(&stdout)
+    }
+
     fn from_env() -> Option<Self> {
         let layout = std::env::var("XKB_DEFAULT_LAYOUT").ok()?;
         if layout.is_empty() {
@@ -115,8 +132,31 @@ impl KeyboardLayout {
     }
 }
 
+fn parse_setxkbmap_query(output: &str) -> Option<KeyboardLayout> {
+    let mut layout = None;
+    let mut variant = None;
+
+    for line in output.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        match key.trim() {
+            "layout" => layout = Some(value.trim().to_string()),
+            "variant" => variant = Some(value.trim().to_string()),
+            _ => {}
+        }
+    }
+
+    let layout = layout.filter(|s| !s.is_empty())?;
+    Some(KeyboardLayout {
+        layout,
+        variant: variant.unwrap_or_default(),
+    })
+}
+
 pub struct XkbKeymap {
     map: HashMap<char, KeyMapping>,
+    level3_keycode: u16,
 }
 
 impl XkbKeymap {
@@ -138,12 +178,19 @@ impl XkbKeymap {
                 detected.variant
             )
         })?;
+        let level3_keycode = find_level3_keycode(&keymap);
         let map = build_reverse_map(&keymap);
-        Ok(Self { map })
+        Ok(Self {
+            map,
+            level3_keycode,
+        })
     }
 
     pub fn lookup(&self, ch: char) -> Option<&KeyMapping> {
         self.map.get(&ch)
+    }
+    pub fn level3_keycode(&self) -> u16 {
+        self.level3_keycode
     }
     pub fn len(&self) -> usize {
         self.map.len()
@@ -154,8 +201,8 @@ impl XkbKeymap {
 }
 
 use xkbcommon::xkb::keysyms::{
-    KEY_dead_acute, KEY_dead_cedilla, KEY_dead_circumflex, KEY_dead_diaeresis, KEY_dead_grave,
-    KEY_dead_tilde,
+    KEY_ISO_Level3_Shift, KEY_dead_acute, KEY_dead_cedilla, KEY_dead_circumflex,
+    KEY_dead_diaeresis, KEY_dead_grave, KEY_dead_tilde,
 };
 
 const ACCENTED_VIA_DEAD_KEY: &[(char, char, u32)] = &[
@@ -198,6 +245,32 @@ const ACCENTED_VIA_DEAD_KEY: &[(char, char, u32)] = &[
     ('ç', 'c', KEY_dead_cedilla),
     ('Ç', 'C', KEY_dead_cedilla),
 ];
+
+fn find_level3_keycode(keymap: &xkbcommon::xkb::Keymap) -> u16 {
+    let right_alt = evdev::Key::KEY_RIGHTALT.code();
+    let mut fallback = None;
+
+    for raw_keycode in keymap.min_keycode().raw()..=keymap.max_keycode().raw() {
+        let keycode = xkbcommon::xkb::Keycode::new(raw_keycode);
+        let evdev_keycode: u16 = raw_keycode.saturating_sub(8).try_into().unwrap_or(u16::MAX);
+
+        for layout in 0..keymap.num_layouts() {
+            for level in 0..keymap.num_levels_for_key(keycode, layout) {
+                let syms = keymap.key_get_syms_by_level(keycode, layout, level);
+                if !syms.iter().any(|sym| sym.raw() == KEY_ISO_Level3_Shift) {
+                    continue;
+                }
+
+                if evdev_keycode != right_alt {
+                    return evdev_keycode;
+                }
+                fallback.get_or_insert(evdev_keycode);
+            }
+        }
+    }
+
+    fallback.unwrap_or(right_alt)
+}
 
 #[allow(non_upper_case_globals)]
 pub(crate) fn build_reverse_map(keymap: &xkbcommon::xkb::Keymap) -> HashMap<char, KeyMapping> {
@@ -370,6 +443,36 @@ mod tests {
         if let Ok(km) = km {
             assert!(!km.is_empty(), "keymap should not be empty");
             assert!(km.lookup('a').is_some(), "'a' should be in the keymap");
+        }
+    }
+
+    #[test]
+    fn parse_x11_setxkbmap_query() {
+        let layout = parse_setxkbmap_query(
+            "rules:      evdev\nmodel:      pc104\nlayout:     us\nvariant:    qwerty-fr\n",
+        )
+        .unwrap();
+
+        assert_eq!(layout.layout, "us");
+        assert_eq!(layout.variant, "qwerty-fr");
+    }
+
+    #[test]
+    fn us_qwerty_fr_typeable_via_uinput() {
+        let km = XkbKeymap::from_layout(&layout("us", "qwerty-fr")).unwrap();
+
+        assert_eq!(
+            km.level3_keycode(),
+            84,
+            "us:qwerty-fr must use the XKB <LVL3> keycode for AltGr, not KEY_RIGHTALT"
+        );
+        assert_key_full(&km, 'é', 17, false, true, "US qwerty-fr");
+
+        for ch in ['ç', 'à', 'é', 'è', 'ù'] {
+            assert!(
+                km.lookup(ch).is_some(),
+                "'{ch}' must be reachable via uinput on us:qwerty-fr"
+            );
         }
     }
 

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -1402,7 +1402,11 @@ fn type_text_at_cursor(text: &str, key_delay: std::time::Duration) -> Result<()>
         .map_err(|_| anyhow::anyhow!("keyboard mutex poisoned"))?;
 
     if keyboard_guard.is_none() {
-        *keyboard_guard = Some(new_keyboard(key_delay)?);
+        // Runtime path: short settle delay. The startup prewarm in
+        // `warm_keyboard` is what gives X11 time to attach its keymap;
+        // we don't want every error-recovery to stall the user's typing
+        // path for 1s.
+        *keyboard_guard = Some(new_keyboard(key_delay, /* prewarm = */ false)?);
     }
 
     let keyboard = keyboard_guard
@@ -1429,7 +1433,9 @@ fn warm_keyboard(key_delay: std::time::Duration) {
         return;
     }
 
-    match new_keyboard(key_delay) {
+    // Startup path: long settle delay so X11 has time to process
+    // MappingNotify and attach the device keymap before the first key.
+    match new_keyboard(key_delay, /* prewarm = */ true) {
         Ok(kb) => {
             *keyboard_guard = Some(kb);
             info!("virtual keyboard initialized");
@@ -1440,8 +1446,13 @@ fn warm_keyboard(key_delay: std::time::Duration) {
     }
 }
 
-fn new_keyboard(key_delay: std::time::Duration) -> Result<xkb_type::Keyboard> {
-    match xkb_type::Keyboard::new(key_delay) {
+fn new_keyboard(key_delay: std::time::Duration, prewarm: bool) -> Result<xkb_type::Keyboard> {
+    let result = if prewarm {
+        xkb_type::Keyboard::new_prewarm(key_delay)
+    } else {
+        xkb_type::Keyboard::new(key_delay)
+    };
+    match result {
         Ok(kb) => Ok(kb),
         Err(e) => {
             let msg = format!("{e:#}");

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -26,6 +26,8 @@ use whisrs::transcription::openai_rest::OpenAIRestBackend;
 use whisrs::transcription::{TranscriptionBackend, TranscriptionConfig};
 use whisrs::window::{self, WindowTracker};
 use whisrs::{encode_message, read_message, socket_path, Command, Config, Response, State};
+
+static KEYBOARD: OnceLock<StdMutex<Option<xkb_type::Keyboard>>> = OnceLock::new();
 
 /// Context saved when command mode starts recording.
 struct CommandModeContext {
@@ -584,6 +586,7 @@ async fn main() -> Result<()> {
     // Wait for compositor environment on boot (WAYLAND_DISPLAY, etc.).
     // Must run before window tracker detection and any clipboard operations.
     import_compositor_env().await;
+    warm_keyboard(std::time::Duration::from_millis(config.input.key_delay_ms));
 
     let window_tracker: Arc<dyn WindowTracker> = Arc::from(window::detect_tracker());
     info!(
@@ -1393,8 +1396,53 @@ fn format_api_error(err: &anyhow::Error) -> String {
 
 /// Type text at the cursor using uinput (keyboard injection) or clipboard paste.
 fn type_text_at_cursor(text: &str, key_delay: std::time::Duration) -> Result<()> {
-    let mut keyboard = match xkb_type::Keyboard::new(key_delay) {
-        Ok(kb) => kb,
+    let keyboard_slot = KEYBOARD.get_or_init(|| StdMutex::new(None));
+    let mut keyboard_guard = keyboard_slot
+        .lock()
+        .map_err(|_| anyhow::anyhow!("keyboard mutex poisoned"))?;
+
+    if keyboard_guard.is_none() {
+        *keyboard_guard = Some(new_keyboard(key_delay)?);
+    }
+
+    let keyboard = keyboard_guard
+        .as_mut()
+        .expect("keyboard exists after initialization");
+    keyboard.set_key_delay(key_delay);
+
+    let result = keyboard.type_text(text).context("failed to type text");
+    if result.is_err() {
+        *keyboard_guard = None;
+    }
+    result?;
+    Ok(())
+}
+
+fn warm_keyboard(key_delay: std::time::Duration) {
+    let keyboard_slot = KEYBOARD.get_or_init(|| StdMutex::new(None));
+    let Ok(mut keyboard_guard) = keyboard_slot.lock() else {
+        warn!("failed to initialize virtual keyboard: keyboard mutex poisoned");
+        return;
+    };
+
+    if keyboard_guard.is_some() {
+        return;
+    }
+
+    match new_keyboard(key_delay) {
+        Ok(kb) => {
+            *keyboard_guard = Some(kb);
+            info!("virtual keyboard initialized");
+        }
+        Err(e) => {
+            warn!("failed to initialize virtual keyboard: {e:#}");
+        }
+    }
+}
+
+fn new_keyboard(key_delay: std::time::Duration) -> Result<xkb_type::Keyboard> {
+    match xkb_type::Keyboard::new(key_delay) {
+        Ok(kb) => Ok(kb),
         Err(e) => {
             let msg = format!("{e:#}");
             if msg.contains("Permission denied") || msg.contains("permission") {
@@ -1403,12 +1451,9 @@ fn type_text_at_cursor(text: &str, key_delay: std::time::Duration) -> Result<()>
                      Fix: sudo usermod -aG input $USER"
                 );
             }
-            return Err(e.context("failed to create virtual keyboard"));
+            Err(e.context("failed to create virtual keyboard"))
         }
-    };
-
-    keyboard.type_text(text).context("failed to type text")?;
-    Ok(())
+    }
 }
 
 fn build_transcription_config(config: &Config) -> TranscriptionConfig {


### PR DESCRIPTION
## Summary

Fix X11 keyboard injection for accented characters on layouts where AltGr is not the physical `KEY_RIGHTALT`.

On KDE/X11 with `us:qwerty-fr`, streaming transcription produced accented text correctly, but the target app stopped at the first accented character. The daemon logged chunks like `" expiré"`, while the visible text only reached `expir`.

The cause was in the uinput/XKB path:

- `é` is the third-level symbol on `w` for `us:qwerty-fr`.
- X11 exposes that third level through the XKB `<LVL3>` keycode.
- Sending hardcoded `KEY_RIGHTALT + w` arrived as Alt-modified plain `w`.
- Sending `<LVL3> + w` arrived as keysym `eacute`.

This branch is stacked on the open X11 overlay and Realtime GA fixes so it matches the build used for live testing. The keyboard-specific fix is the top commit.

## Changes

- Detect X11 layouts via `setxkbmap -query` before falling back to `XKB_DEFAULT_*` environment variables.
- Store the XKB keycode that exposes `ISO_Level3_Shift` and use that key for AltGr mappings instead of assuming `KEY_RIGHTALT`.
- Keep one daemon-wide virtual keyboard instance and prewarm it at startup, so X11 has time to attach the correct keymap before dictation starts.
- Reset the cached keyboard if typing fails, so later attempts can recreate the device.
- Add a regression check for `us:qwerty-fr` where `é` must be reachable via AltGr and the level-three keycode is the XKB `<LVL3>` key.

## Testing

Tested on KDE/X11 with `setxkbmap -query` reporting:

```text
layout:     us
variant:    qwerty-fr
```

Reproduction and verification:

- Before the fix, `xev` showed `KEY_RIGHTALT + w` arriving as Alt-modified `w`.
- Probing the active XKB map showed `<LVL3> + w` arriving as keysym `eacute`.
- After the fix, `Keyboard::type_text("é")` arrived in `xev` as keysym `eacute`.
- Installed and restarted the daemon locally; startup logs include `virtual keyboard initialized`, and `whisrs status` returns `idle`.

Checks run:

- `cargo fmt --all --check`
- `CMAKE=/usr/bin/cmake cargo clippy --all-targets -- -D warnings`
- `CMAKE=/usr/bin/cmake cargo test`

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor
