### PR TITLE
ci: sync install.sh to gh-pages on push to main

### DIFF
--- a/.github/workflows/sync-installer.yml
+++ b/.github/workflows/sync-installer.yml
@@ -1,0 +1,42 @@
+name: Sync install.sh to gh-pages
+
+# Mirrors install.sh from main to gh-pages whenever it changes, so the
+# `curl | bash` recipe served from the landing page never drifts from the
+# canonical installer.
+
+on:
+  push:
+    branches: [main]
+    paths: [install.sh]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Copy install.sh from main
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          git checkout origin/main -- install.sh
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet --cached HEAD -- install.sh; then
+            echo "install.sh already in sync with main"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Sync install.sh from main"
+          git push origin gh-pages


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-installer.yml` which mirrors `install.sh` from `main` to `gh-pages` whenever it changes on `main`.
- Prevents drift between the canonical installer and the copy served from the landing page (the same drift PR #33 just fixed manually).
- Also triggerable manually via `workflow_dispatch`.

## Background
PR #33 manually re-synced `install.sh` on `gh-pages` after it had drifted from `main`. This workflow keeps the two in lockstep automatically so the same drift cannot recur.

## Test plan
- [ ] Merge to main
- [ ] Make a trivial edit to `install.sh` on `main` (or run the workflow manually) and confirm a "Sync install.sh from main" commit lands on `gh-pages`
- [ ] Confirm the workflow exits cleanly with "already in sync" when `install.sh` hasn't actually changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)