### PR TITLE
Detect XKB layout via localectl when X11 env vars are absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,38 @@ Per-release details: [docs/version-roadmap.md](docs/version-roadmap.md).
 
 ## Troubleshooting
 
-See [docs/troubleshooting.md](docs/troubleshooting.md).
+See [docs/troubleshooting.md](docs/troubleshooting.md) for the full list. Two issues come up often enough to call out here:
+
+### Garbled output / wrong characters on non-US layouts
+
+whisrs auto-detects your XKB layout via the active compositor (Hyprland / Sway), then `setxkbmap` (X11), then `localectl` (systemd), then the `XKB_DEFAULT_LAYOUT` / `XKB_DEFAULT_VARIANT` env vars — in that order. If none succeed, it falls back to US/QWERTY, and on a non-US layout that produces garbled output (e.g. `"this"` typed as `"èCDU"` on `fr(bepo)`).
+
+To diagnose, run the daemon in the foreground with debug logging and look for the detected layout:
+
+```bash
+RUST_LOG=debug whisrsd
+```
+
+If the layout is missing or wrong, fix it one of two ways:
+
+1. Make sure `localectl status` reports the right `X11 Layout` and `X11 Variant`. This is the system source-of-truth and works without any X session env vars.
+2. Force the layout via env vars in your systemd service override:
+
+   ```bash
+   systemctl --user edit whisrs.service
+   ```
+
+   ```ini
+   [Service]
+   Environment=XKB_DEFAULT_LAYOUT=fr
+   Environment=XKB_DEFAULT_VARIANT=bepo
+   ```
+
+   Then `systemctl --user restart whisrs.service`.
+
+### Hotkey keys are physical positions, not layout characters
+
+The configured hotkey trigger (e.g. `Ctrl+Shift+W`) is interpreted as the physical evdev keycode at the US/QWERTY `W` position, regardless of the active layout. This is intentional — the hotkey listener reads raw evdev events before any XKB translation, which is how every evdev-based hotkey tool works (xremap, sxhkd --evdev). On non-US layouts, pick the trigger by its physical position on a QWERTY keyboard.
 
 ---
 

--- a/contrib/whisrs.service
+++ b/contrib/whisrs.service
@@ -11,7 +11,7 @@ RestartSec=3
 
 # Import compositor environment variables so window tracking works.
 # These are set by the compositor/session and must be passed through.
-PassEnvironment=HYPRLAND_INSTANCE_SIGNATURE NIRI_SOCKET SWAYSOCK WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP XDG_RUNTIME_DIR
+PassEnvironment=HYPRLAND_INSTANCE_SIGNATURE NIRI_SOCKET SWAYSOCK WAYLAND_DISPLAY DISPLAY XAUTHORITY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP XDG_RUNTIME_DIR
 
 # Logging
 StandardOutput=journal

--- a/crates/xkb-type/src/keymap.rs
+++ b/crates/xkb-type/src/keymap.rs
@@ -21,6 +21,11 @@ pub struct KeyboardLayout {
 
 impl KeyboardLayout {
     pub fn detect() -> Self {
+        // Order matters: compositor IPC and X11 reflect the *currently active* session
+        // layout (honoring runtime switches via xkb-switch and friends), so they win when
+        // reachable. localectl is the systemd source-of-truth fallback for cases where
+        // X env vars aren't visible (e.g. running as a systemd --user service, issue #39).
+        // Env vars come last as an explicit user override escape hatch.
         if let Some(kl) = Self::from_hyprland() {
             return kl;
         }

--- a/crates/xkb-type/src/keymap.rs
+++ b/crates/xkb-type/src/keymap.rs
@@ -30,6 +30,9 @@ impl KeyboardLayout {
         if let Some(kl) = Self::from_x11() {
             return kl;
         }
+        if let Some(kl) = Self::from_localectl() {
+            return kl;
+        }
         if let Some(kl) = Self::from_env() {
             return kl;
         }
@@ -156,6 +159,48 @@ impl KeyboardLayout {
         parsed
     }
 
+    /// Query `localectl status` for the system X11 layout/variant.
+    ///
+    /// `localectl` is a systemd binary that doesn't need `DISPLAY` or
+    /// `XAUTHORITY`. On a systemd host this is the source-of-truth for
+    /// the system keyboard layout when the X11 environment isn't
+    /// available to the daemon (e.g. running under `systemd --user`
+    /// with `DISPLAY` not imported into the user manager).
+    fn from_localectl() -> Option<Self> {
+        let output = match Command::new("localectl").arg("status").output() {
+            Ok(out) => out,
+            Err(_e) => {
+                debug!("localectl probe failed to spawn: {_e}");
+                return None;
+            }
+        };
+        if !output.status.success() {
+            debug!(
+                "localectl status exited non-zero: status={:?}",
+                output.status.code()
+            );
+            return None;
+        }
+
+        let stdout = match String::from_utf8(output.stdout) {
+            Ok(s) => s,
+            Err(_e) => {
+                debug!("localectl status stdout was not valid utf-8: {_e}");
+                return None;
+            }
+        };
+        let parsed = parse_localectl_status(&stdout);
+        if let Some(_kl) = parsed.as_ref() {
+            debug!(
+                "layout detected via localectl: layout={} variant={}",
+                _kl.layout, _kl.variant
+            );
+        } else {
+            debug!("localectl status returned no parseable X11 layout");
+        }
+        parsed
+    }
+
     fn from_env() -> Option<Self> {
         let layout = std::env::var("XKB_DEFAULT_LAYOUT").ok()?;
         if layout.is_empty() {
@@ -177,6 +222,37 @@ fn parse_setxkbmap_query(output: &str) -> Option<KeyboardLayout> {
         match key.trim() {
             "layout" => layout = Some(value.trim().to_string()),
             "variant" => variant = Some(value.trim().to_string()),
+            _ => {}
+        }
+    }
+
+    let layout = layout.filter(|s| !s.is_empty())?;
+    Some(KeyboardLayout {
+        layout,
+        variant: variant.unwrap_or_default(),
+    })
+}
+
+/// Parse `localectl status` output for the X11 keyboard layout/variant.
+///
+/// `localectl` indents its key/value lines with a varying number of
+/// leading spaces (3 or 4 in practice). Trim each line before splitting
+/// on the first `:` to be robust against that. Only `X11 Layout` and
+/// `X11 Variant` are extracted — other keys (`System Locale`,
+/// `VC Keymap`, `X11 Model`, `X11 Options`) are intentionally ignored
+/// to keep this patch tightly scoped to the layout-detection bug.
+fn parse_localectl_status(output: &str) -> Option<KeyboardLayout> {
+    let mut layout = None;
+    let mut variant = None;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        match key.trim() {
+            "X11 Layout" => layout = Some(value.trim().to_string()),
+            "X11 Variant" => variant = Some(value.trim().to_string()),
             _ => {}
         }
     }
@@ -872,6 +948,113 @@ mod tests {
         assert!(
             result.is_none(),
             "from_sway must return None (display names ≠ XKB codes); got {result:?}"
+        );
+    }
+
+    // --- localectl parser tests ---
+
+    #[test]
+    fn parse_localectl_us_no_variant() {
+        let output = "\
+System Locale: LANG=en_US.UTF-8
+    VC Keymap: us
+   X11 Layout: us
+    X11 Model: pc105+inet
+  X11 Options: terminate:ctrl_alt_bksp
+";
+        let kl = parse_localectl_status(output).expect("should parse US layout");
+        assert_eq!(kl.layout, "us");
+        assert_eq!(kl.variant, "");
+    }
+
+    #[test]
+    fn parse_localectl_fr_bepo_full() {
+        let output = "\
+System Locale: LANG=en_US.UTF-8
+    VC Keymap: fr-bepo
+   X11 Layout: fr
+    X11 Model: pc104
+  X11 Variant: bepo
+  X11 Options: caps:swapescape,compose:rwin
+";
+        let kl = parse_localectl_status(output).expect("should parse fr(bepo)");
+        assert_eq!(kl.layout, "fr");
+        assert_eq!(kl.variant, "bepo");
+    }
+
+    #[test]
+    fn parse_localectl_empty_layout_returns_none() {
+        let output = "\
+System Locale: LANG=en_US.UTF-8
+    VC Keymap: us
+   X11 Layout:
+    X11 Model: pc105
+";
+        assert!(parse_localectl_status(output).is_none());
+    }
+
+    #[test]
+    fn parse_localectl_missing_x11_section_returns_none() {
+        let output = "\
+System Locale: LANG=en_US.UTF-8
+    VC Keymap: us
+";
+        assert!(parse_localectl_status(output).is_none());
+    }
+
+    #[test]
+    fn parse_localectl_tolerates_whitespace_variants() {
+        // Mix tabs, varying leading-space widths, and trailing whitespace.
+        let output = "System Locale: LANG=en_US.UTF-8\n\
+\t\tVC Keymap: fr-bepo\n\
+ X11 Layout:   fr  \n\
+      X11 Model: pc104\n\
+\tX11 Variant:\tbepo\n";
+        let kl = parse_localectl_status(output).expect("should tolerate whitespace mix");
+        assert_eq!(kl.layout, "fr");
+        assert_eq!(kl.variant, "bepo");
+    }
+
+    #[test]
+    fn parse_localectl_ignores_unknown_keys() {
+        let output = "\
+System Locale: LANG=en_US.UTF-8
+    VC Keymap: us
+          Foo: bar
+   X11 Layout: us
+    X11 Model: pc105
+       Random: line with: multiple colons
+  X11 Variant: dvorak
+";
+        let kl = parse_localectl_status(output).expect("should ignore unknown keys");
+        assert_eq!(kl.layout, "us");
+        assert_eq!(kl.variant, "dvorak");
+    }
+
+    // --- localectl chain-gap regression ---
+
+    /// Issue #39: detection must have at least one source that works
+    /// without any X session env vars on a systemd host. `from_localectl`
+    /// fills that gap. If `localectl` is installed (the case on every
+    /// systemd distro), it must return `Some(layout)` with a non-empty
+    /// layout code — this is what prevents the US/QWERTY fallback that
+    /// produced garbled output for fr(bepo) users running under
+    /// `systemd --user`.
+    #[test]
+    fn from_localectl_returns_layout_when_available() {
+        // Skip if the binary is unavailable (e.g. non-systemd CI image).
+        if Command::new("localectl").arg("--version").output().is_err() {
+            eprintln!("skipping: localectl not on PATH");
+            return;
+        }
+        let result = KeyboardLayout::from_localectl();
+        let kl = result.expect(
+            "from_localectl must return Some(_) on a systemd host — \
+             this is the detection-chain gap that allowed issue #39",
+        );
+        assert!(
+            !kl.layout.is_empty(),
+            "from_localectl returned Some with empty layout: {kl:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `KeyboardLayout::from_localectl()` between the X11 and env-var detection sources. `localectl` is the systemd source-of-truth for the X11 layout/variant and doesn't need `DISPLAY` or `XAUTHORITY` — closes the gap that left detection falling through to US/QWERTY when `whisrsd` runs under `systemd --user` on X11 (e.g. awesome-wm + xinit, the reproducer for #39).
- Passes `XAUTHORITY` through the systemd unit's `PassEnvironment=` so the existing X11 path is more robust when `DISPLAY` *is* imported into the user manager.
- Documents the detection chain order, the env-var override escape hatch, and the physical-evdev semantics of the hotkey listener in the README troubleshooting section.

Detection chain after this PR: `Hyprland → Sway → setxkbmap (X11) → localectl (systemd) → XKB_DEFAULT_*` env vars. X11 stays ahead of localectl so a runtime layout switch via `xkb-switch` etc. still wins when reachable; rationale is documented in the `detect()` source comment.

## Test plan

- [x] Unit tests for `parse_localectl_status`: US/no variant, fr+bepo full, empty layout, missing X11 section, whitespace tolerance, unknown keys
- [x] Chain-gap regression test (`from_localectl_returns_layout_when_available`): asserts `from_localectl()` returns a non-empty layout on a systemd host — this is the test that locks in "detection has at least one source that works without X session env vars," which is the actual gap that allowed this bug
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build` all clean locally
- [x] Manual smoke on Hyprland: daemon starts, layout detection succeeds via compositor IPC (highest-priority source), text injection works end-to-end (no regression on the unchanged paths)
- [ ] Awaiting reporter confirmation on awesome-wm + X11 + fr(bepo)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)