### PR TITLE
Stop auto-generating release notes in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,5 +80,4 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
           files: artifacts/*


### PR DESCRIPTION
## Summary

`softprops/action-gh-release@v2` with `generate_release_notes: true` appends GitHub's auto-generated "What's Changed" PR list (plus a duplicate Full Changelog line) to whatever body the release already has. Because the release body is curated manually before the workflow runs (Highlights + Install/Upgrade only, per the [release-notes convention](https://github.com/y0sif/whisrs/releases/tag/v0.1.14)), this produced a doubled changelog on v0.1.15 (now manually cleaned).

Dropping the flag — the action's default behavior is no auto-generation, so it just uploads binaries and leaves the body alone.

## Test plan

- [x] YAML parses
- [ ] Next release tag (v0.1.16+) creates a release with a single, curated body and no "What's Changed" suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)