### PR TITLE
feat(tts): read selection aloud (Groq, OpenAI, Deepgram, local sidecar) with overlay + tray

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ systemctl --user enable --now whisrs.service
 # Use the CLI (bind to a hotkey)
 whisrs toggle    # start/stop recording
 whisrs cancel    # cancel and discard audio
+whisrs speak     # read the selected text aloud via TTS (alias: read; press again to stop)
 whisrs status    # query daemon state
 whisrs restart   # restart the daemon (wraps systemctl --user when present)
 
@@ -70,6 +71,11 @@ src/
 │   ├── local_vosk.rs       # Vosk backend stub (coming soon)
 │   ├── local_parakeet.rs   # Parakeet/NVIDIA backend stub (coming soon)
 │   └── dedup.rs            # Timestamp + n-gram deduplication for chunked APIs
+├── tts/
+│   ├── mod.rs              # TtsBackend trait + create_backend (read selection aloud)
+│   ├── groq.rs             # Groq TTS (OpenAI-compatible /v1/audio/speech)
+│   ├── openai_compat.rs    # OpenAI + tts-sidecar (local OpenAI-compatible server)
+│   └── deepgram_aura.rs    # Deepgram Aura-2 TTS (voice encoded in model id)
 ├── input/
 │   ├── mod.rs              # KeyInjector trait
 │   ├── uinput.rs           # Virtual keyboard via evdev UinputDevice
@@ -84,7 +90,8 @@ src/
 ├── config/
 │   ├── mod.rs              # Config module exports
 │   └── setup.rs            # Interactive onboarding (whisrs setup)
-└── state.rs                # State machine (Idle → Recording → Transcribing → Idle)
+└── state.rs                # State machine (Idle → Recording → Transcribing → Idle;
+                            #   read-aloud: Idle → Synthesizing → Speaking → Idle)
 ```
 
 ### Supporting Files
@@ -128,12 +135,14 @@ Responses: `{"status": "ok", "state": "idle"}`, `{"status": "error", "message": 
 
 Path: `~/.config/whisrs/config.toml` (permissions: 0600)
 
-Backends: `deepgram`, `deepgram-streaming`, `groq`, `openai-realtime`, `openai`, `local-whisper`, `local-vosk`, `local-parakeet`, `asr-sidecar`
+Transcription backends: `deepgram`, `deepgram-streaming`, `groq`, `openai-realtime`, `openai`, `local-whisper`, `local-vosk`, `local-parakeet`, `asr-sidecar`
+
+TTS (read selection aloud): the `[tts]` section (`enabled` off by default) drives `whisrs speak` / `read` and `[hotkeys] speak`. Backends: `groq`, `openai`, `deepgram`, `tts-sidecar` (local OpenAI-compatible server, alias `openai-compat`). The TTS key falls back to the matching transcription key (`[groq]`/`[openai]`/`[deepgram]`) unless `[tts] api_key` is set; `tts-sidecar` needs none.
 
 Environment variable overrides:
-- `WHISRS_DEEPGRAM_API_KEY` — overrides `[deepgram] api_key`
-- `WHISRS_GROQ_API_KEY` — overrides `[groq] api_key`
-- `WHISRS_OPENAI_API_KEY` — overrides `[openai] api_key`
+- `WHISRS_DEEPGRAM_API_KEY` — overrides `[deepgram] api_key` (also used by the `deepgram` TTS backend)
+- `WHISRS_GROQ_API_KEY` — overrides `[groq] api_key` (also used by the `groq` TTS backend)
+- `WHISRS_OPENAI_API_KEY` — overrides `[openai] api_key` (also used by the `openai` TTS backend)
 - `RUST_LOG` — controls daemon log verbosity
 
 ## CI Checks

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **Linux-first voice-to-text dictation tool, written in Rust.**
 
-Speech-to-text for Wayland, X11, Hyprland, Sway, Niri, GNOME, and KDE. Press a hotkey, speak, and your words appear at the cursor. Works with any app, any window manager, any desktop environment. Supports cloud transcription (Groq, Deepgram, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source.
+Speech-to-text for Wayland, X11, Hyprland, Sway, Niri, GNOME, and KDE. Press a hotkey, speak, and your words appear at the cursor. Works with any app, any window manager, any desktop environment. Supports cloud transcription (Groq, Deepgram, OpenAI) and fully offline local transcription via whisper.cpp. Fast, private, open source. It can also read the selected text back aloud (text-to-speech via Groq, OpenAI, Deepgram, or a local sidecar).
 
 ---
 
@@ -195,6 +195,7 @@ whisrs cancel    # Cancel recording, discard audio
 whisrs status    # Query daemon state
 whisrs restart   # Restart the daemon (uses the systemd user service when present)
 whisrs command   # Command mode: select text + speak instruction → LLM rewrite
+whisrs speak     # Read the selected text aloud (alias: whisrs read; press again to stop)
 whisrs log       # Show recent transcription history
 whisrs log -n 5  # Show last 5 entries
 whisrs log --clear  # Clear all history
@@ -221,7 +222,7 @@ whisrs log --clear  # Clear all history
 
 ## Project Status
 
-whisrs is functional and usable for daily dictation. Streaming transcription, command mode, multi-language support, system tray, OSD overlay, layout-aware injection (incl. AltGr + dead keys), the generic ASR sidecar backend (Moonshine, Parakeet, VibeVoice-ASR), and packaging for AUR / Nix / crates.io all ship today. Native local Vosk and Parakeet backends are next.
+whisrs is functional and usable for daily dictation. Streaming transcription, command mode, read-selection-aloud (TTS via Groq, OpenAI, Deepgram, or a local sidecar), multi-language support, system tray, OSD overlay, layout-aware injection (incl. AltGr + dead keys), the generic ASR sidecar backend (Moonshine, Parakeet, VibeVoice-ASR), and packaging for AUR / Nix / crates.io all ship today. Native local Vosk and Parakeet backends are next.
 
 Per-release details: [docs/version-roadmap.md](docs/version-roadmap.md).
 

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -39,12 +39,22 @@ cursor in the previously focused window.
 Cancel the current recording and discard captured audio. Returns the
 daemon to the idle state. Has no effect if the daemon is not recording.
 .TP
+.B speak
+Read the current text selection aloud via text-to-speech. A second
+.B speak
+or a
+.B cancel
+stops playback. Alias:
+.BR read .
+.TP
 .B status
 Query the daemon state. Prints one of:
 .BR idle ,
 .BR recording ,
+.BR transcribing ,
+.BR synthesizing ,
 or
-.BR transcribing .
+.BR speaking .
 .TP
 .B restart
 Restart the whisrs daemon. Uses

--- a/contrib/whisrsd.1
+++ b/contrib/whisrsd.1
@@ -29,7 +29,7 @@ Initializes the selected transcription backend
 .IP \(bu 2
 Binds the Unix domain socket and begins accepting commands
 .SH STATE MACHINE
-The daemon maintains one of three states:
+The daemon maintains one of five states:
 .TP
 .B idle
 Waiting for a toggle command. No audio is being captured.
@@ -41,6 +41,12 @@ command transitions out of this state.
 .B transcribing
 Audio has been sent to the transcription backend. The daemon is waiting
 for results. Text is typed at the cursor as it becomes available.
+.TP
+.B synthesizing
+Read-aloud: generating speech from the selected text.
+.TP
+.B speaking
+Read-aloud: playing synthesized speech; a second speak or a cancel stops it.
 .SH TRANSCRIPTION BACKENDS
 .TP
 .B groq

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,11 +35,14 @@ height = 40                 # 36..=48 (clamped)
 
 # When theme = "custom", these override the named theme. Hex strings:
 # #RGB, #RRGGBB, or #RRGGBBAA. Anything missing falls back to carbon.
+# The transcribing color is reused for the read-aloud synthesizing sweep;
+# speaking overrides the read-aloud audio-reactive bar color.
 # [overlay.colors]
 # background   = "#0E0E10EB"
 # ring         = "#3A3A4050"
 # recording    = "#F0EDF5"
 # transcribing = "#9CA3AF"
+# speaking     = "#5EEAD4"
 # glow         = "#F0EDF5"
 
 [audio]
@@ -80,11 +83,29 @@ api_key = "sk-..."
 model = "gpt-4o-mini"
 api_url = "https://api.openai.com/v1/chat/completions"
 
+# Text-to-speech: read the current selection aloud (`whisrs speak`).
+# Opt-in. model/voice are optional; each backend has its own default,
+# so switching `backend` works without re-editing model/voice.
+[tts]
+enabled = false             # off by default
+backend = "groq"            # groq | openai | deepgram | tts-sidecar
+# model = "..."             # optional; backend default when unset.
+#                           #   groq: canopylabs/orpheus-v1-english, openai: gpt-4o-mini-tts,
+#                           #   deepgram: aura-2-thalia-en, tts-sidecar: kokoro
+# voice = "..."             # optional; backend default (groq: autumn, openai: alloy,
+#                           #   tts-sidecar: af_heart). Ignored by deepgram (voice is in the model id).
+response_format = "wav"     # audio format requested from the API
+# api_key = "..."           # optional; falls back to the backend's transcription key
+#                           #   ([groq]/[openai]/[deepgram]). tts-sidecar needs none.
+# url = "http://127.0.0.1:8880/v1/audio/speech"  # tts-sidecar only: local
+#                           #   OpenAI-compatible server (Kokoro, Supertonic, ...)
+
 # Built-in global hotkeys (optional, works without WM keybinds)
 [hotkeys]
 toggle = "Super+Shift+W"
 cancel = "Super+Shift+D"
 command = "Super+Shift+G"
+speak = "Super+Shift+R"
 ```
 
 ## Environment variables
@@ -94,6 +115,8 @@ The following variables override the matching `api_key` in `config.toml`:
 - `WHISRS_GROQ_API_KEY`
 - `WHISRS_DEEPGRAM_API_KEY`
 - `WHISRS_OPENAI_API_KEY`
+
+These provider keys are also used by the matching TTS backend (`groq`/`openai`/`deepgram`) unless `[tts] api_key` is set. The `tts-sidecar` backend needs no key.
 
 `RUST_LOG` controls daemon log verbosity (e.g. `RUST_LOG=debug whisrsd`).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,9 @@ Six backends: Groq (cloud, free tier), Deepgram Nova REST and Streaming (cloud, 
 **How does whisrs type text into applications?**
 whisrs creates a virtual keyboard using Linux's uinput subsystem and performs XKB reverse lookups to find the correct keycode and modifier combination for each character. This means it respects your keyboard layout and works in any application, including terminals, editors, and browsers.
 
+**Can whisrs read text back to me?**
+Yes. Select some text, then run `whisrs speak` (alias `read`, or bind `[hotkeys] speak`) and whisrs reads the selection aloud. Press the speak hotkey again or run `whisrs cancel` to stop playback. Supported backends are Groq, OpenAI, Deepgram, and a local OpenAI-compatible `tts-sidecar` (Kokoro, Supertonic, etc.). It is off by default; enable it with `[tts] enabled = true`.
+
 **Is whisrs a replacement for Wispr Flow or Superwhisper on Linux?**
 Yes. Wispr Flow ships clients for macOS and Windows; Superwhisper is macOS-only. Neither has a Linux client. whisrs brings the same workflow to Linux: press a hotkey, speak, and text appears at your cursor. It supports both cloud and local transcription backends.
 

--- a/docs/version-roadmap.md
+++ b/docs/version-roadmap.md
@@ -66,6 +66,12 @@ historical record; current development happens against the v0.1.x patch line.
 
 ---
 
+## Read selection aloud (TTS) ✓
+
+- [x] **Read-selection-aloud (TTS)**: New `whisrs speak` command (alias `read`, plus `[hotkeys] speak`) reads the current text selection aloud. Press speak again or `whisrs cancel` to stop playback. Configured via the `[tts]` section (`enabled` off by default). Backends: `groq`, `openai`, `deepgram`, and a local OpenAI-compatible `tts-sidecar` (Kokoro, Supertonic, etc.). `model`/`voice` are optional and default per backend; the TTS key falls back to the matching transcription key unless `[tts] api_key` is set. Adds `synthesizing` and `speaking` daemon states, reflected in the tray icon and the overlay (a sweep while synthesizing, distinct-colored audio-reactive bars while speaking, with a `[overlay.colors] speaking` override).
+
+---
+
 ## Upcoming
 
 - [ ] **Local Vosk backend**: CPU-only local speech recognition via `vosk` crate — true streaming, small models (~40 MB), works on Intel (no GPU required)

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod capture;
 pub mod feedback;
+pub mod playback;
 pub mod recovery;
 
 /// A chunk of 16-bit PCM audio samples.

--- a/src/audio/playback.rs
+++ b/src/audio/playback.rs
@@ -1,0 +1,258 @@
+//! Interruptible WAV playback on the default audio output device.
+//!
+//! Used by the read-selection-aloud feature to play TTS audio of arbitrary
+//! sample rate / channel count. Unlike [`crate::audio::feedback`] (mono /
+//! 44.1 kHz / 2-second timeout), this plays the clip to completion and can be
+//! stopped early via a shared [`AtomicBool`].
+
+use std::io::Cursor;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{SampleRate, StreamConfig};
+use tracing::{debug, warn};
+
+use crate::WhisrsError;
+
+/// Decoded PCM audio: interleaved f32 samples plus the stream format.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedWav {
+    /// Interleaved samples in `[-1.0, 1.0]`, channel-major per frame.
+    pub samples: Vec<f32>,
+    /// Sample rate in Hz.
+    pub sample_rate: u32,
+    /// Number of channels.
+    pub channels: u16,
+}
+
+impl DecodedWav {
+    /// Number of frames (samples per channel).
+    pub fn frames(&self) -> usize {
+        if self.channels == 0 {
+            0
+        } else {
+            self.samples.len() / self.channels as usize
+        }
+    }
+}
+
+/// Decode WAV bytes into interleaved f32 samples plus format metadata.
+///
+/// Handles 16-bit integer and 32-bit float WAV files (the formats Groq's TTS
+/// endpoint returns); other integer bit depths (8/24/32) are also supported by
+/// scaling to f32. This is a pure function with no audio device access so it
+/// can be unit-tested.
+pub fn decode_wav(wav_bytes: &[u8]) -> Result<DecodedWav, WhisrsError> {
+    let reader = hound::WavReader::new(Cursor::new(wav_bytes))
+        .map_err(|e| WhisrsError::Audio(format!("failed to read WAV header: {e}")))?;
+    let spec = reader.spec();
+
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Float => reader
+            .into_samples::<f32>()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| WhisrsError::Audio(format!("failed to decode float WAV samples: {e}")))?,
+        hound::SampleFormat::Int => {
+            // Normalize integer samples by the full-scale value for the bit depth.
+            let max_amp = (1i64 << (spec.bits_per_sample - 1)) as f32;
+            reader
+                .into_samples::<i32>()
+                .map(|s| s.map(|v| v as f32 / max_amp))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| {
+                    WhisrsError::Audio(format!("failed to decode integer WAV samples: {e}"))
+                })?
+        }
+    };
+
+    if spec.channels == 0 {
+        return Err(WhisrsError::Audio("WAV reports zero channels".to_string()));
+    }
+
+    Ok(DecodedWav {
+        samples,
+        sample_rate: spec.sample_rate,
+        channels: spec.channels,
+    })
+}
+
+/// Play WAV-encoded audio on the default output device, blocking until the clip
+/// finishes or `stop` is set to `true`.
+///
+/// Builds a cpal output stream matching the WAV's sample rate and channel count.
+/// The stream callback advances through the decoded samples; when they are
+/// exhausted (or `stop` is set) it emits silence and signals completion. This
+/// function is intended to be run on a blocking task (`spawn_blocking`).
+pub fn play_wav(wav_bytes: &[u8], stop: Arc<AtomicBool>) -> Result<(), WhisrsError> {
+    let decoded = decode_wav(wav_bytes)?;
+    play_decoded(decoded, stop)
+}
+
+/// Play already-decoded PCM on the default output device. See [`play_wav`].
+fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), WhisrsError> {
+    if decoded.samples.is_empty() {
+        return Ok(());
+    }
+
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| WhisrsError::Audio("no default audio output device".to_string()))?;
+
+    let config = StreamConfig {
+        channels: decoded.channels,
+        sample_rate: SampleRate(decoded.sample_rate),
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    let samples = decoded.samples;
+    let samples_len = samples.len();
+    let sample_idx = Arc::new(AtomicUsize::new(0));
+    let sample_idx_cb = Arc::clone(&sample_idx);
+    let done = Arc::new(AtomicBool::new(false));
+    let done_cb = Arc::clone(&done);
+    let stop_cb = Arc::clone(&stop);
+
+    let stream = device
+        .build_output_stream(
+            &config,
+            move |data: &mut [f32], _info: &cpal::OutputCallbackInfo| {
+                if stop_cb.load(Ordering::Acquire) {
+                    for sample in data.iter_mut() {
+                        *sample = 0.0;
+                    }
+                    done_cb.store(true, Ordering::Release);
+                    return;
+                }
+                for sample in data.iter_mut() {
+                    let idx = sample_idx_cb.fetch_add(1, Ordering::Relaxed);
+                    if idx < samples_len {
+                        *sample = samples[idx];
+                    } else {
+                        *sample = 0.0;
+                        done_cb.store(true, Ordering::Release);
+                    }
+                }
+            },
+            |err| {
+                warn!("TTS playback stream error: {err}");
+            },
+            None,
+        )
+        .map_err(|e| WhisrsError::Audio(format!("failed to build output stream: {e}")))?;
+
+    stream
+        .play()
+        .map_err(|e| WhisrsError::Audio(format!("failed to start playback: {e}")))?;
+
+    // Compute a generous upper bound on playback duration so a stuck stream
+    // can't block forever.
+    let frames = (samples_len / decoded.channels.max(1) as usize) as f64;
+    let clip_secs = frames / decoded.sample_rate.max(1) as f64;
+    let timeout = Duration::from_secs_f64(clip_secs + 2.0);
+    let start = Instant::now();
+
+    while !done.load(Ordering::Acquire) {
+        if stop.load(Ordering::Acquire) {
+            debug!("TTS playback interrupted");
+            break;
+        }
+        if start.elapsed() > timeout {
+            debug!("TTS playback timed out after {:.1}s", timeout.as_secs_f64());
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // Let the final buffer drain.
+    std::thread::sleep(Duration::from_millis(50));
+    drop(stream);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode a short stereo i16 tone WAV in memory for decode round-trip tests.
+    fn make_i16_wav(sample_rate: u32, channels: u16, frames: usize) -> Vec<u8> {
+        let spec = hound::WavSpec {
+            channels,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = hound::WavWriter::new(&mut buf, spec).unwrap();
+            for i in 0..frames {
+                let v = ((i as f32 * 0.01).sin() * i16::MAX as f32) as i16;
+                for _ in 0..channels {
+                    writer.write_sample(v).unwrap();
+                }
+            }
+            writer.finalize().unwrap();
+        }
+        buf.into_inner()
+    }
+
+    fn make_f32_wav(sample_rate: u32, channels: u16, frames: usize) -> Vec<u8> {
+        let spec = hound::WavSpec {
+            channels,
+            sample_rate,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = hound::WavWriter::new(&mut buf, spec).unwrap();
+            for i in 0..frames {
+                let v = (i as f32 * 0.01).sin() * 0.5;
+                for _ in 0..channels {
+                    writer.write_sample(v).unwrap();
+                }
+            }
+            writer.finalize().unwrap();
+        }
+        buf.into_inner()
+    }
+
+    #[test]
+    fn decode_i16_stereo_wav() {
+        let wav = make_i16_wav(24_000, 2, 100);
+        let decoded = decode_wav(&wav).unwrap();
+        assert_eq!(decoded.sample_rate, 24_000);
+        assert_eq!(decoded.channels, 2);
+        assert_eq!(decoded.samples.len(), 200);
+        assert_eq!(decoded.frames(), 100);
+        // Normalized into [-1.0, 1.0].
+        assert!(decoded.samples.iter().all(|s| (-1.0..=1.0).contains(s)));
+    }
+
+    #[test]
+    fn decode_i16_mono_wav() {
+        let wav = make_i16_wav(16_000, 1, 50);
+        let decoded = decode_wav(&wav).unwrap();
+        assert_eq!(decoded.sample_rate, 16_000);
+        assert_eq!(decoded.channels, 1);
+        assert_eq!(decoded.samples.len(), 50);
+        assert_eq!(decoded.frames(), 50);
+    }
+
+    #[test]
+    fn decode_f32_wav() {
+        let wav = make_f32_wav(44_100, 1, 64);
+        let decoded = decode_wav(&wav).unwrap();
+        assert_eq!(decoded.sample_rate, 44_100);
+        assert_eq!(decoded.channels, 1);
+        assert_eq!(decoded.samples.len(), 64);
+    }
+
+    #[test]
+    fn decode_rejects_garbage() {
+        let err = decode_wav(b"not a wav file at all").unwrap_err();
+        assert!(err.to_string().contains("WAV header"));
+    }
+}

--- a/src/audio/playback.rs
+++ b/src/audio/playback.rs
@@ -45,7 +45,15 @@ impl DecodedWav {
 /// scaling to f32. This is a pure function with no audio device access so it
 /// can be unit-tested.
 pub fn decode_wav(wav_bytes: &[u8]) -> Result<DecodedWav, WhisrsError> {
-    let reader = hound::WavReader::new(Cursor::new(wav_bytes))
+    // Some encoders (ffmpeg/Lavf, which Groq's TTS endpoint uses) stream WAV to
+    // a non-seekable output and leave the RIFF and `data` chunk sizes as the
+    // 0xFFFFFFFF "unknown length" sentinel. hound then rejects the file
+    // ("data chunk length is not a multiple of sample size"). Repair the length
+    // fields to the real byte counts before parsing.
+    let repaired = repair_streaming_wav(wav_bytes);
+    let bytes: &[u8] = repaired.as_deref().unwrap_or(wav_bytes);
+
+    let reader = hound::WavReader::new(Cursor::new(bytes))
         .map_err(|e| WhisrsError::Audio(format!("failed to read WAV header: {e}")))?;
     let spec = reader.spec();
 
@@ -78,6 +86,58 @@ pub fn decode_wav(wav_bytes: &[u8]) -> Result<DecodedWav, WhisrsError> {
     })
 }
 
+/// Repair WAV files written to a non-seekable stream, where the `RIFF` and
+/// `data` chunk sizes are left as the 0xFFFFFFFF "unknown length" sentinel (or
+/// otherwise overrun the buffer). Rewrites both to the real byte counts.
+///
+/// Returns `Some(fixed_bytes)` when a repair was applied, or `None` when the
+/// input is already well-formed or is not a recognizable RIFF/WAVE stream (in
+/// which case the caller passes the original bytes through to the parser).
+fn repair_streaming_wav(bytes: &[u8]) -> Option<Vec<u8>> {
+    const SENTINEL: u32 = 0xFFFF_FFFF;
+    if bytes.len() < 44 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+        return None;
+    }
+    let read_u32 =
+        |o: usize| u32::from_le_bytes([bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]]);
+
+    let mut block_align: usize = 0;
+    let mut off = 12usize;
+    while off + 8 <= bytes.len() {
+        let id = &bytes[off..off + 4];
+        let len = read_u32(off + 4);
+        let payload = off + 8;
+
+        if id == b"fmt " && payload + 16 <= bytes.len() {
+            // blockAlign sits at offset 12..14 within the fmt payload.
+            block_align = u16::from_le_bytes([bytes[payload + 12], bytes[payload + 13]]) as usize;
+        }
+
+        if id == b"data" {
+            let avail = bytes.len() - payload;
+            // Only repair a clearly-bogus length; leave well-formed files alone.
+            if len != SENTINEL && (len as usize) <= avail {
+                return None;
+            }
+            let ba = block_align.max(1);
+            let fixed = avail - (avail % ba);
+            let mut out = bytes.to_vec();
+            out[payload - 4..payload].copy_from_slice(&(fixed as u32).to_le_bytes());
+            // RIFF size = everything after the leading 8 bytes, through the data payload.
+            let riff = (payload + fixed - 8) as u32;
+            out[4..8].copy_from_slice(&riff.to_le_bytes());
+            return Some(out);
+        }
+
+        // Can't safely walk past a sentinel-length chunk that precedes `data`.
+        if len == SENTINEL {
+            return None;
+        }
+        off = off.checked_add(8 + len as usize + (len as usize & 1))?;
+    }
+    None
+}
+
 /// Play WAV-encoded audio on the default output device, blocking until the clip
 /// finishes or `stop` is set to `true`.
 ///
@@ -88,6 +148,64 @@ pub fn decode_wav(wav_bytes: &[u8]) -> Result<DecodedWav, WhisrsError> {
 pub fn play_wav(wav_bytes: &[u8], stop: Arc<AtomicBool>) -> Result<(), WhisrsError> {
     let decoded = decode_wav(wav_bytes)?;
     play_decoded(decoded, stop)
+}
+
+/// Resample interleaved f32 audio from `(src_rate, src_channels)` to
+/// `(dst_rate, dst_channels)`.
+///
+/// The source is downmixed to mono and then fanned out across the destination
+/// channels, with linear interpolation for the rate conversion. This is aimed
+/// at speech (Groq's TTS is mono); a stereo music source would lose its imaging,
+/// which is acceptable for this playback path.
+fn resample_remap(
+    src: &[f32],
+    src_channels: u16,
+    src_rate: u32,
+    dst_channels: u16,
+    dst_rate: u32,
+) -> Vec<f32> {
+    let src_ch = src_channels.max(1) as usize;
+    let dst_ch = dst_channels.max(1) as usize;
+    let src_frames = src.len() / src_ch;
+    if src_frames == 0 || src_rate == 0 || dst_rate == 0 {
+        return Vec::new();
+    }
+
+    // Downmix to a mono signal.
+    let mono: Vec<f32> = (0..src_frames)
+        .map(|i| {
+            let acc: f32 = (0..src_ch).map(|c| src[i * src_ch + c]).sum();
+            acc / src_ch as f32
+        })
+        .collect();
+
+    // Fan a mono frame value out across all destination channels.
+    let fan = |out: &mut Vec<f32>, v: f32| {
+        for _ in 0..dst_ch {
+            out.push(v);
+        }
+    };
+
+    if src_rate == dst_rate {
+        let mut out = Vec::with_capacity(mono.len() * dst_ch);
+        for v in mono {
+            fan(&mut out, v);
+        }
+        return out;
+    }
+
+    let dst_frames = ((src_frames as u64 * dst_rate as u64) / src_rate as u64).max(1) as usize;
+    let ratio = src_rate as f64 / dst_rate as f64;
+    let mut out = Vec::with_capacity(dst_frames * dst_ch);
+    for j in 0..dst_frames {
+        let pos = j as f64 * ratio;
+        let i0 = pos.floor() as usize;
+        let frac = (pos - i0 as f64) as f32;
+        let a = mono[i0.min(src_frames - 1)];
+        let b = mono[(i0 + 1).min(src_frames - 1)];
+        fan(&mut out, a + (b - a) * frac);
+    }
+    out
 }
 
 /// Play already-decoded PCM on the default output device. See [`play_wav`].
@@ -101,13 +219,33 @@ fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), Whisrs
         .default_output_device()
         .ok_or_else(|| WhisrsError::Audio("no default audio output device".to_string()))?;
 
+    // Play at the device's preferred rate/channels and resample/remap the clip
+    // to match. Forcing the clip's native format (e.g. Groq's 24 kHz mono) can
+    // fail to build a stream on devices that only advertise their default rate.
+    let (target_rate, target_channels) = match device.default_output_config() {
+        Ok(cfg) => (cfg.sample_rate().0, cfg.channels().max(1)),
+        Err(e) => {
+            debug!("no default output config ({e}); using clip's native format");
+            (decoded.sample_rate, decoded.channels.max(1))
+        }
+    };
+
     let config = StreamConfig {
-        channels: decoded.channels,
-        sample_rate: SampleRate(decoded.sample_rate),
+        channels: target_channels,
+        sample_rate: SampleRate(target_rate),
         buffer_size: cpal::BufferSize::Default,
     };
 
-    let samples = decoded.samples;
+    let samples = resample_remap(
+        &decoded.samples,
+        decoded.channels,
+        decoded.sample_rate,
+        target_channels,
+        target_rate,
+    );
+    if samples.is_empty() {
+        return Ok(());
+    }
     let samples_len = samples.len();
     let sample_idx = Arc::new(AtomicUsize::new(0));
     let sample_idx_cb = Arc::clone(&sample_idx);
@@ -149,8 +287,8 @@ fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), Whisrs
 
     // Compute a generous upper bound on playback duration so a stuck stream
     // can't block forever.
-    let frames = (samples_len / decoded.channels.max(1) as usize) as f64;
-    let clip_secs = frames / decoded.sample_rate.max(1) as f64;
+    let frames = (samples_len / target_channels.max(1) as usize) as f64;
+    let clip_secs = frames / target_rate.max(1) as f64;
     let timeout = Duration::from_secs_f64(clip_secs + 2.0);
     let start = Instant::now();
 
@@ -254,5 +392,52 @@ mod tests {
     fn decode_rejects_garbage() {
         let err = decode_wav(b"not a wav file at all").unwrap_err();
         assert!(err.to_string().contains("WAV header"));
+    }
+
+    /// A WAV streamed by ffmpeg/Lavf (as Groq returns) leaves the RIFF and data
+    /// chunk lengths as the 0xFFFFFFFF sentinel; hound rejects it raw, but
+    /// `decode_wav` repairs the lengths first.
+    #[test]
+    fn decode_repairs_streaming_sentinel_lengths() {
+        let mut wav = make_i16_wav(24_000, 1, 100);
+        let dpos = wav
+            .windows(4)
+            .position(|w| w == b"data")
+            .expect("data chunk header");
+        wav[4..8].copy_from_slice(&u32::MAX.to_le_bytes()); // RIFF size sentinel
+        wav[dpos + 4..dpos + 8].copy_from_slice(&u32::MAX.to_le_bytes()); // data size sentinel
+
+        // Raw hound rejects the sentinel data length...
+        assert!(hound::WavReader::new(Cursor::new(&wav)).is_err());
+        // ...but decode_wav repairs and reads it.
+        let decoded = decode_wav(&wav).unwrap();
+        assert_eq!(decoded.sample_rate, 24_000);
+        assert_eq!(decoded.channels, 1);
+        assert_eq!(decoded.frames(), 100);
+    }
+
+    #[test]
+    fn resample_noop_when_format_matches() {
+        let mono = vec![0.1f32, 0.2, 0.3, 0.4];
+        assert_eq!(resample_remap(&mono, 1, 16_000, 1, 16_000), mono);
+    }
+
+    #[test]
+    fn resample_changes_rate_and_upmixes_channels() {
+        // 24 kHz mono -> 48 kHz stereo: frame count doubles, channels double.
+        let mono: Vec<f32> = (0..100).map(|i| (i as f32 * 0.1).sin()).collect();
+        let out = resample_remap(&mono, 1, 24_000, 2, 48_000);
+        assert_eq!(out.len(), 200 * 2);
+        // Left/right are identical (mono fanned out).
+        assert_eq!(out[0], out[1]);
+    }
+
+    #[test]
+    fn resample_downmix_stereo_to_mono() {
+        // Interleaved stereo [1.0, -1.0, ...] downmixes to ~0.0 mono, same rate.
+        let stereo = vec![1.0f32, -1.0, 1.0, -1.0];
+        let out = resample_remap(&stereo, 2, 16_000, 1, 16_000);
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|s| s.abs() < 1e-6));
     }
 }

--- a/src/audio/playback.rs
+++ b/src/audio/playback.rs
@@ -145,9 +145,31 @@ fn repair_streaming_wav(bytes: &[u8]) -> Option<Vec<u8>> {
 /// The stream callback advances through the decoded samples; when they are
 /// exhausted (or `stop` is set) it emits silence and signals completion. This
 /// function is intended to be run on a blocking task (`spawn_blocking`).
-pub fn play_wav(wav_bytes: &[u8], stop: Arc<AtomicBool>) -> Result<(), WhisrsError> {
+///
+/// When `level_tx` is `Some`, a normalized amplitude (0..=1) computed from each
+/// emitted buffer is published so a speaking overlay can react to the audio.
+/// The watch channel coalesces, so no throttling is needed.
+pub fn play_wav(
+    wav_bytes: &[u8],
+    stop: Arc<AtomicBool>,
+    level_tx: Option<tokio::sync::watch::Sender<f32>>,
+) -> Result<(), WhisrsError> {
     let decoded = decode_wav(wav_bytes)?;
-    play_decoded(decoded, stop)
+    play_decoded(decoded, stop, level_tx)
+}
+
+/// Normalized playback amplitude from a buffer of interleaved f32 samples.
+///
+/// Mirrors [`crate::audio::capture`]'s level mapping: RMS through a soft
+/// compressor `1 - exp(-rms * 18)` so typical speech reaches the upper part
+/// of the visualizer's dynamic range.
+fn playback_level(data: &[f32]) -> f32 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    let sum_squares: f32 = data.iter().map(|s| s * s).sum();
+    let rms = (sum_squares / data.len() as f32).sqrt();
+    (1.0 - (-rms * 18.0).exp()).clamp(0.0, 1.0)
 }
 
 /// Resample interleaved f32 audio from `(src_rate, src_channels)` to
@@ -209,7 +231,11 @@ fn resample_remap(
 }
 
 /// Play already-decoded PCM on the default output device. See [`play_wav`].
-fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), WhisrsError> {
+fn play_decoded(
+    decoded: DecodedWav,
+    stop: Arc<AtomicBool>,
+    level_tx: Option<tokio::sync::watch::Sender<f32>>,
+) -> Result<(), WhisrsError> {
     if decoded.samples.is_empty() {
         return Ok(());
     }
@@ -253,6 +279,7 @@ fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), Whisrs
     let done_cb = Arc::clone(&done);
     let stop_cb = Arc::clone(&stop);
 
+    let level_tx_cb = level_tx.clone();
     let stream = device
         .build_output_stream(
             &config,
@@ -262,6 +289,9 @@ fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), Whisrs
                         *sample = 0.0;
                     }
                     done_cb.store(true, Ordering::Release);
+                    if let Some(tx) = &level_tx_cb {
+                        let _ = tx.send(0.0);
+                    }
                     return;
                 }
                 for sample in data.iter_mut() {
@@ -272,6 +302,11 @@ fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), Whisrs
                         *sample = 0.0;
                         done_cb.store(true, Ordering::Release);
                     }
+                }
+                // Publish the amplitude of the buffer we just emitted so a
+                // speaking overlay can react. Best-effort; watch coalesces.
+                if let Some(tx) = &level_tx_cb {
+                    let _ = tx.send(playback_level(data));
                 }
             },
             |err| {
@@ -307,6 +342,10 @@ fn play_decoded(decoded: DecodedWav, stop: Arc<AtomicBool>) -> Result<(), Whisrs
     // Let the final buffer drain.
     std::thread::sleep(Duration::from_millis(50));
     drop(stream);
+    // Reset the visualizer to silence once playback ends.
+    if let Some(tx) = &level_tx {
+        let _ = tx.send(0.0);
+    }
     Ok(())
 }
 
@@ -430,6 +469,21 @@ mod tests {
         assert_eq!(out.len(), 200 * 2);
         // Left/right are identical (mono fanned out).
         assert_eq!(out[0], out[1]);
+    }
+
+    #[test]
+    fn playback_level_silence_is_zero() {
+        assert_eq!(playback_level(&[]), 0.0);
+        assert_eq!(playback_level(&[0.0, 0.0, 0.0, 0.0]), 0.0);
+    }
+
+    #[test]
+    fn playback_level_loud_is_higher_than_quiet() {
+        let quiet = playback_level(&[0.01, -0.01, 0.01, -0.01]);
+        let loud = playback_level(&[0.8, -0.8, 0.8, -0.8]);
+        assert!(loud > quiet);
+        assert!((0.0..=1.0).contains(&loud));
+        assert!((0.0..=1.0).contains(&quiet));
     }
 
     #[test]

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -64,6 +64,9 @@ enum SubCmd {
     },
     /// Command mode: select text, speak an instruction, LLM rewrites it in place
     Command,
+    /// Read the selected text aloud via TTS (press again to stop playback)
+    #[command(alias = "read")]
+    Speak,
     /// Restart the whisrs daemon (uses the systemd user service when present)
     Restart,
 }
@@ -130,6 +133,9 @@ async fn main() -> anyhow::Result<()> {
         }
         SubCmd::Command => {
             send_command(Command::CommandMode).await?;
+        }
+        SubCmd::Speak => {
+            send_command(Command::Speak).await?;
         }
         SubCmd::Restart => {
             cmd_restart()?;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -27,6 +27,7 @@ const ASCII_BANNER: &str = concat!(
 const GREEN: &str = "\x1b[32m";
 const YELLOW: &str = "\x1b[33m";
 const RED: &str = "\x1b[31m";
+const CYAN: &str = "\x1b[36m";
 const BOLD: &str = "\x1b[1m";
 const RESET: &str = "\x1b[0m";
 
@@ -87,6 +88,8 @@ fn format_state(state: State, use_color: bool) -> String {
         State::Idle => format!("{BOLD}idle{RESET}"),
         State::Recording => format!("{BOLD}{GREEN}recording{RESET}"),
         State::Transcribing => format!("{BOLD}{YELLOW}transcribing{RESET}"),
+        State::Synthesizing => format!("{BOLD}{CYAN}synthesizing{RESET}"),
+        State::Speaking => format!("{BOLD}{GREEN}speaking{RESET}"),
     }
 }
 

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -118,6 +118,7 @@ fn default_config() -> Config {
         local_parakeet: None,
         asr_sidecar: None,
         llm: None,
+        tts: None,
         hotkeys: None,
         overlay: None,
     }

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -40,6 +40,10 @@ pub fn run_config_menu() -> Result<()> {
     loop {
         print_summary(&config);
 
+        // TODO(tts): add a "Text-to-speech (read aloud)" menu entry here
+        // (enable / backend / model / voice / url) once the read-aloud feature
+        // stabilizes. Skipped for now to keep this change focused; the [tts]
+        // section can still be edited via "Open in $EDITOR".
         let choices = &[
             "Backend & API keys",
             "Language",

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -150,6 +150,7 @@ pub fn run_setup() -> Result<()> {
         local_parakeet: None,
         asr_sidecar: asr_sidecar_config,
         llm: llm_config,
+        tts: None,
         hotkeys: None,
         overlay: if overlay { overlay_config } else { None },
     };

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -50,6 +50,13 @@ struct DaemonState {
     recording_started_at: Option<std::time::Instant>,
     /// Active command mode context (set when command mode is recording).
     command_mode: Option<CommandModeContext>,
+    /// Stop flag for in-progress TTS playback (read-selection-aloud).
+    ///
+    /// Set when a `Speak` synthesis succeeds and playback begins; cleared when
+    /// playback finishes. `Cancel` and a repeat `Speak` both flip it to `true`
+    /// to interrupt playback. Read-aloud runs independently of the recording
+    /// state machine, so there is no dedicated `State` variant.
+    tts_stop: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl DaemonState {
@@ -61,6 +68,7 @@ impl DaemonState {
             streaming_task: None,
             recording_started_at: None,
             command_mode: None,
+            tts_stop: None,
         }
     }
 }
@@ -146,6 +154,7 @@ fn load_config() -> (Config, Option<String>) {
                             local_parakeet: None,
                             asr_sidecar: None,
                             llm: None,
+                            tts: None,
                             hotkeys: None,
                             overlay: None,
                         },
@@ -172,6 +181,7 @@ fn load_config() -> (Config, Option<String>) {
                         local_parakeet: None,
                         asr_sidecar: None,
                         llm: None,
+                        tts: None,
                         hotkeys: None,
                         overlay: None,
                     },
@@ -198,6 +208,7 @@ fn load_config() -> (Config, Option<String>) {
             local_parakeet: None,
             asr_sidecar: None,
             llm: None,
+            tts: None,
             hotkeys: None,
             overlay: None,
         },
@@ -366,6 +377,17 @@ fn resolve_groq_api_key(config: &Config) -> Option<String> {
         }
     }
     config.groq.as_ref().map(|g| g.api_key.clone())
+}
+
+/// Resolve the API key used for TTS: the dedicated `[tts] api_key` when set,
+/// otherwise the Groq key (`[groq] api_key` / `WHISRS_GROQ_API_KEY`).
+fn resolve_tts_api_key(config: &Config) -> Option<String> {
+    if let Some(tts) = &config.tts {
+        if let Some(key) = tts.api_key.as_ref().filter(|k| !k.is_empty()) {
+            return Some(key.clone());
+        }
+    }
+    resolve_groq_api_key(config)
 }
 
 fn resolve_openai_api_key(config: &Config) -> Option<String> {
@@ -739,6 +761,7 @@ async fn handle_command(
             },
         },
         Command::CommandMode => handle_command_mode(daemon_state, context).await,
+        Command::Speak => handle_speak(daemon_state, context).await,
     }
 }
 
@@ -2096,11 +2119,180 @@ fn leads_with_punct(text: &str) -> bool {
     ])
 }
 
+/// Read the selected text aloud via TTS.
+///
+/// Mirrors `command_mode_start`'s selection-capture path (primary selection +
+/// simulated copy fallback + clipboard read), then synthesizes speech via the
+/// configured TTS backend and plays it on the default output device. Playback
+/// is interruptible: a repeat `Speak` (or a `Cancel`) sets the shared stop flag
+/// to halt it. Runs independently of the recording state machine.
+async fn handle_speak(
+    daemon_state: Arc<Mutex<DaemonState>>,
+    context: Arc<DaemonContext>,
+) -> Response {
+    // Toggle behavior: if playback is already in progress, a second press stops
+    // it (and does not start a new synthesis).
+    {
+        let mut ds = daemon_state.lock().await;
+        if let Some(stop) = ds.tts_stop.take() {
+            stop.store(true, std::sync::atomic::Ordering::Release);
+            info!("speak: stopped in-progress playback");
+            return Response::Ok {
+                state: ds.state_machine.state(),
+            };
+        }
+    }
+
+    // Verify TTS is configured and enabled.
+    let tts_config = match &context.config.tts {
+        Some(t) if t.enabled => t.clone(),
+        Some(_) => {
+            return Response::Error {
+                message: "TTS is disabled — set [tts] enabled = true in config.toml".to_string(),
+            };
+        }
+        None => {
+            return Response::Error {
+                message: "TTS is not configured — add a [tts] section to config.toml".to_string(),
+            };
+        }
+    };
+
+    let api_key = resolve_tts_api_key(&context.config);
+    let backend = match whisrs::tts::create_backend(&tts_config, api_key) {
+        Ok(b) => b,
+        Err(e) => {
+            return Response::Error {
+                message: e.to_string(),
+            };
+        }
+    };
+
+    // Capture the selected text (same approach as command mode).
+    info!("speak: getting selected text");
+    let clipboard = xkb_type::default_clipboard();
+    let saved_clipboard = clipboard.get_text().unwrap_or_default();
+
+    let is_terminal = context
+        .window_tracker
+        .get_focused_window_class()
+        .map(|c| is_terminal_class(&c))
+        .unwrap_or(false);
+
+    let selected_text = clipboard.get_primary_selection().unwrap_or_default();
+
+    let copy_fn = if is_terminal {
+        simulate_terminal_copy
+    } else {
+        simulate_copy
+    };
+
+    match tokio::task::spawn_blocking(copy_fn).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            if selected_text.is_empty() {
+                return Response::Error {
+                    message: format!("failed to copy selection: {e}"),
+                };
+            }
+            warn!("copy simulation failed ({e}), using primary selection text");
+        }
+        Err(e) => {
+            if selected_text.is_empty() {
+                return Response::Error {
+                    message: format!("copy task panicked: {e}"),
+                };
+            }
+            warn!("copy task panicked ({e}), using primary selection text");
+        }
+    }
+
+    let selected_text = if selected_text.is_empty() {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        match clipboard.get_text() {
+            Ok(text) => text,
+            Err(e) => {
+                return Response::Error {
+                    message: format!("failed to read clipboard: {e}"),
+                };
+            }
+        }
+    } else {
+        selected_text
+    };
+
+    if selected_text.is_empty() || selected_text == saved_clipboard {
+        return Response::Error {
+            message: "no text selected — select text before using read-aloud".to_string(),
+        };
+    }
+
+    info!("speak: synthesizing {} chars", selected_text.len());
+    if context.notify_state() {
+        send_notification("whisrs", "Reading selection aloud...");
+    }
+
+    // Synthesize speech.
+    let wav_bytes = match backend.synthesize(&selected_text).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            error!("speak: synthesis failed: {e}");
+            if context.notify_error() {
+                send_notification("whisrs", &format!("Read-aloud failed: {e}"));
+            }
+            return Response::Error {
+                message: format!("TTS synthesis failed: {e}"),
+            };
+        }
+    };
+
+    // Store a fresh stop flag and spawn interruptible playback.
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    {
+        let mut ds = daemon_state.lock().await;
+        ds.tts_stop = Some(Arc::clone(&stop));
+    }
+
+    let ds_ref = Arc::clone(&daemon_state);
+    let playback_stop = Arc::clone(&stop);
+    tokio::spawn(async move {
+        let result = tokio::task::spawn_blocking(move || {
+            whisrs::audio::playback::play_wav(&wav_bytes, stop)
+        })
+        .await;
+        match result {
+            Ok(Ok(())) => debug!("speak: playback finished"),
+            Ok(Err(e)) => warn!("speak: playback failed: {e}"),
+            Err(e) => warn!("speak: playback task panicked: {e}"),
+        }
+        // Clear the stop flag from daemon state if it is still ours (i.e. a new
+        // Speak hasn't replaced it).
+        let mut ds = ds_ref.lock().await;
+        if let Some(current) = &ds.tts_stop {
+            if Arc::ptr_eq(current, &playback_stop) {
+                ds.tts_stop = None;
+            }
+        }
+    });
+
+    let state = daemon_state.lock().await.state_machine.state();
+    Response::Ok { state }
+}
+
 async fn handle_cancel(
     daemon_state: Arc<Mutex<DaemonState>>,
     context: Arc<DaemonContext>,
 ) -> Response {
     let mut ds = daemon_state.lock().await;
+
+    // Stop any in-progress TTS playback regardless of recording state.
+    let stopped_tts = if let Some(stop) = ds.tts_stop.take() {
+        stop.store(true, std::sync::atomic::Ordering::Release);
+        info!("cancel: stopped TTS playback");
+        true
+    } else {
+        false
+    };
 
     match ds.state_machine.transition(Action::Cancel) {
         Ok(new_state) => {
@@ -2121,6 +2313,12 @@ async fn handle_cancel(
             }
             Response::Ok { state: new_state }
         }
+        // Nothing was recording. If we still interrupted TTS playback, that's a
+        // successful cancel — report the current (Idle) state rather than the
+        // invalid-transition error.
+        Err(_) if stopped_tts => Response::Ok {
+            state: ds.state_machine.state(),
+        },
         Err(e) => Response::Error {
             message: e.to_string(),
         },

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -382,11 +382,12 @@ fn resolve_groq_api_key(config: &Config) -> Option<String> {
 /// Resolve the API key used for TTS.
 ///
 /// The dedicated `[tts] api_key` always wins. Otherwise the key is resolved
-/// per the configured `[tts] backend`:
-/// - `openai`      → OpenAI key
-/// - `deepgram`    → Deepgram key
-/// - `tts-sidecar` → no key (local servers usually need none)
-/// - `groq` (else) → Groq key
+/// per the configured `[tts] backend`, falling back to that provider's
+/// transcription key (env var or `config.toml`):
+/// - `groq`                       → Groq key (`[groq]` / `WHISRS_GROQ_API_KEY`)
+/// - `openai`                     → OpenAI key (`[openai]` / `WHISRS_OPENAI_API_KEY`)
+/// - `deepgram`                   → Deepgram key (`[deepgram]` / `WHISRS_DEEPGRAM_API_KEY`)
+/// - `tts-sidecar` / `openai-compat` → no key (local servers usually need none)
 fn resolve_tts_api_key(config: &Config) -> Option<String> {
     if let Some(tts) = &config.tts {
         if let Some(key) = tts.api_key.as_ref().filter(|k| !k.is_empty()) {

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -2164,18 +2164,31 @@ fn leads_with_punct(text: &str) -> bool {
 
 /// Capture the currently-selected text for read-aloud.
 ///
-/// Prefers the primary selection (works everywhere, no key simulation). When
-/// that's empty it falls back to a simulated Ctrl+C (Ctrl+Shift+C in terminals)
-/// and reads the clipboard. A short settle delay precedes the simulated copy:
-/// the read-aloud hotkey is typically a modifier combo (e.g. Alt+Shift+A), and
-/// if the user is still physically holding those modifiers when Ctrl+C fires,
-/// the app receives a garbled combo and the copy silently fails. The delay
-/// lets a briefly-held hotkey clear before we synthesize keystrokes.
+/// The primary selection (highlighted text) is authoritative when present: it
+/// needs no key simulation, so a non-empty primary selection is returned
+/// directly. This also avoids the clipboard-equality heuristic below — which
+/// only makes sense in the copy-fallback path — wrongly rejecting a selection
+/// that happens to equal the current clipboard.
+///
+/// When the primary selection is empty, fall back to a simulated Ctrl+C
+/// (Ctrl+Shift+C in terminals) and read the clipboard. A short settle delay
+/// precedes the simulated copy: the read-aloud hotkey is typically a modifier
+/// combo (e.g. Alt+Shift+A), and if the user is still physically holding those
+/// modifiers when Ctrl+C fires, the app receives a garbled combo and the copy
+/// silently fails. The delay lets a briefly-held hotkey clear first.
 ///
 /// Returns `Ok(text)` on success, or `Err(message)` describing why nothing was
 /// captured (caller surfaces this as a `Response::Error` + notification).
 async fn capture_selection_for_speak(context: &DaemonContext) -> Result<String, String> {
     let clipboard = xkb_type::default_clipboard();
+
+    // Trust a non-empty primary selection directly — no copy, no equality check.
+    let primary = clipboard.get_primary_selection().unwrap_or_default();
+    if !primary.is_empty() {
+        return Ok(primary);
+    }
+
+    // No primary selection: fall back to a simulated copy + clipboard read.
     let saved_clipboard = clipboard.get_text().unwrap_or_default();
 
     let is_terminal = context
@@ -2184,13 +2197,8 @@ async fn capture_selection_for_speak(context: &DaemonContext) -> Result<String, 
         .map(|c| is_terminal_class(&c))
         .unwrap_or(false);
 
-    let selected_text = clipboard.get_primary_selection().unwrap_or_default();
-
-    // Only simulate a copy when the primary selection didn't already give us
-    // the text — and let any briefly-held hotkey modifiers clear first.
-    if selected_text.is_empty() {
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-    }
+    // Let any briefly-held hotkey modifiers clear before synthesizing Ctrl+C.
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let copy_fn = if is_terminal {
         simulate_terminal_copy
@@ -2200,34 +2208,22 @@ async fn capture_selection_for_speak(context: &DaemonContext) -> Result<String, 
 
     match tokio::task::spawn_blocking(copy_fn).await {
         Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            if selected_text.is_empty() {
-                return Err(format!("failed to copy selection: {e}"));
-            }
-            warn!("copy simulation failed ({e}), using primary selection text");
-        }
-        Err(e) => {
-            if selected_text.is_empty() {
-                return Err(format!("copy task panicked: {e}"));
-            }
-            warn!("copy task panicked ({e}), using primary selection text");
-        }
+        Ok(Err(e)) => return Err(format!("failed to copy selection: {e}")),
+        Err(e) => return Err(format!("copy task panicked: {e}")),
     }
 
-    let selected_text = if selected_text.is_empty() {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        clipboard
-            .get_text()
-            .map_err(|e| format!("failed to read clipboard: {e}"))?
-    } else {
-        selected_text
-    };
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let copied = clipboard
+        .get_text()
+        .map_err(|e| format!("failed to read clipboard: {e}"))?;
 
-    if selected_text.is_empty() || selected_text == saved_clipboard {
+    // With no primary selection, an unchanged clipboard means the copy captured
+    // nothing (nothing selected, or the held hotkey garbled Ctrl+C).
+    if copied.is_empty() || copied == saved_clipboard {
         return Err("no text selected — select text before using read-aloud".to_string());
     }
 
-    Ok(selected_text)
+    Ok(copied)
 }
 
 /// Read the selected text aloud via TTS.

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -379,12 +379,24 @@ fn resolve_groq_api_key(config: &Config) -> Option<String> {
     config.groq.as_ref().map(|g| g.api_key.clone())
 }
 
-/// Resolve the API key used for TTS: the dedicated `[tts] api_key` when set,
-/// otherwise the Groq key (`[groq] api_key` / `WHISRS_GROQ_API_KEY`).
+/// Resolve the API key used for TTS.
+///
+/// The dedicated `[tts] api_key` always wins. Otherwise the key is resolved
+/// per the configured `[tts] backend`:
+/// - `openai`      → OpenAI key
+/// - `deepgram`    → Deepgram key
+/// - `tts-sidecar` → no key (local servers usually need none)
+/// - `groq` (else) → Groq key
 fn resolve_tts_api_key(config: &Config) -> Option<String> {
     if let Some(tts) = &config.tts {
         if let Some(key) = tts.api_key.as_ref().filter(|k| !k.is_empty()) {
             return Some(key.clone());
+        }
+        match tts.backend.as_str() {
+            "openai" => return resolve_openai_api_key(config),
+            "deepgram" => return resolve_deepgram_api_key(config),
+            "tts-sidecar" | "openai-compat" => return None,
+            _ => {}
         }
     }
     resolve_groq_api_key(config)
@@ -989,6 +1001,28 @@ async fn handle_toggle(
                                 }
                             }
                         }
+                        // For STREAMING backends, run_streaming_pipeline's tail
+                        // often already moved Transcribing → Idle, so this
+                        // second TranscriptionDone is invalid. That is not an
+                        // error — the pipeline finalized everything (history,
+                        // done-tone, toast). Report success without double-
+                        // saving or double-notifying.
+                        Err(_) if ds.state_machine.state() == State::Idle => {
+                            let _ = context.state_tx.send(State::Idle);
+                            if let Some(level_tx) = &context.overlay_level_tx {
+                                let _ = level_tx.send(0.0);
+                            }
+                            match &result {
+                                Ok(text) => {
+                                    info!(
+                                        "transcription complete (pipeline-finalized): {} chars",
+                                        text.len()
+                                    )
+                                }
+                                Err(e) => error!("transcription failed: {e:#}"),
+                            }
+                            Response::Ok { state: State::Idle }
+                        }
                         Err(e) => Response::Error {
                             message: e.to_string(),
                         },
@@ -1001,6 +1035,10 @@ async fn handle_toggle(
         }
         State::Transcribing => Response::Error {
             message: "cannot toggle while transcribing".to_string(),
+        },
+        // Recording is refused while read-aloud is active.
+        State::Synthesizing | State::Speaking => Response::Error {
+            message: "cannot toggle while reading aloud — cancel read-aloud first".to_string(),
         },
     }
 }
@@ -1577,6 +1615,11 @@ async fn handle_command_mode(
         State::Transcribing => Response::Error {
             message: "cannot start command mode while transcribing".to_string(),
         },
+        // Command mode is a recording flow — refused while read-aloud is active.
+        State::Synthesizing | State::Speaking => Response::Error {
+            message: "cannot start command mode while reading aloud — cancel read-aloud first"
+                .to_string(),
+        },
     }
 }
 
@@ -2119,31 +2162,120 @@ fn leads_with_punct(text: &str) -> bool {
     ])
 }
 
+/// Capture the currently-selected text for read-aloud.
+///
+/// Prefers the primary selection (works everywhere, no key simulation). When
+/// that's empty it falls back to a simulated Ctrl+C (Ctrl+Shift+C in terminals)
+/// and reads the clipboard. A short settle delay precedes the simulated copy:
+/// the read-aloud hotkey is typically a modifier combo (e.g. Alt+Shift+A), and
+/// if the user is still physically holding those modifiers when Ctrl+C fires,
+/// the app receives a garbled combo and the copy silently fails. The delay
+/// lets a briefly-held hotkey clear before we synthesize keystrokes.
+///
+/// Returns `Ok(text)` on success, or `Err(message)` describing why nothing was
+/// captured (caller surfaces this as a `Response::Error` + notification).
+async fn capture_selection_for_speak(context: &DaemonContext) -> Result<String, String> {
+    let clipboard = xkb_type::default_clipboard();
+    let saved_clipboard = clipboard.get_text().unwrap_or_default();
+
+    let is_terminal = context
+        .window_tracker
+        .get_focused_window_class()
+        .map(|c| is_terminal_class(&c))
+        .unwrap_or(false);
+
+    let selected_text = clipboard.get_primary_selection().unwrap_or_default();
+
+    // Only simulate a copy when the primary selection didn't already give us
+    // the text — and let any briefly-held hotkey modifiers clear first.
+    if selected_text.is_empty() {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+
+    let copy_fn = if is_terminal {
+        simulate_terminal_copy
+    } else {
+        simulate_copy
+    };
+
+    match tokio::task::spawn_blocking(copy_fn).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            if selected_text.is_empty() {
+                return Err(format!("failed to copy selection: {e}"));
+            }
+            warn!("copy simulation failed ({e}), using primary selection text");
+        }
+        Err(e) => {
+            if selected_text.is_empty() {
+                return Err(format!("copy task panicked: {e}"));
+            }
+            warn!("copy task panicked ({e}), using primary selection text");
+        }
+    }
+
+    let selected_text = if selected_text.is_empty() {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        clipboard
+            .get_text()
+            .map_err(|e| format!("failed to read clipboard: {e}"))?
+    } else {
+        selected_text
+    };
+
+    if selected_text.is_empty() || selected_text == saved_clipboard {
+        return Err("no text selected — select text before using read-aloud".to_string());
+    }
+
+    Ok(selected_text)
+}
+
 /// Read the selected text aloud via TTS.
 ///
-/// Mirrors `command_mode_start`'s selection-capture path (primary selection +
-/// simulated copy fallback + clipboard read), then synthesizes speech via the
-/// configured TTS backend and plays it on the default output device. Playback
-/// is interruptible: a repeat `Speak` (or a `Cancel`) sets the shared stop flag
-/// to halt it. Runs independently of the recording state machine.
+/// FSM-authoritative: read-aloud has its own `Synthesizing`/`Speaking` states,
+/// so "is read-aloud active" is determined by [`State`], not the `tts_stop`
+/// flag (which now exists purely as the low-level playback interrupt). This
+/// removes the race where a `Speak` press landing in the gap between playback
+/// finishing and the cleanup task clearing `tts_stop` was swallowed as a stop.
+///
+/// The daemon mutex is never held across the synth or playback `.await`.
 async fn handle_speak(
     daemon_state: Arc<Mutex<DaemonState>>,
     context: Arc<DaemonContext>,
 ) -> Response {
-    // Toggle behavior: if playback is already in progress, a second press stops
-    // it (and does not start a new synthesis).
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    // (a) Inspect the FSM. A second press while read-aloud is active is a
+    // deterministic stop, regardless of playback timing.
     {
         let mut ds = daemon_state.lock().await;
-        if let Some(stop) = ds.tts_stop.take() {
-            stop.store(true, std::sync::atomic::Ordering::Release);
-            info!("speak: stopped in-progress playback");
-            return Response::Ok {
-                state: ds.state_machine.state(),
-            };
+        match ds.state_machine.state() {
+            State::Speaking | State::Synthesizing => {
+                if let Some(stop) = ds.tts_stop.take() {
+                    stop.store(true, Ordering::Release);
+                }
+                let _ = ds.state_machine.transition(Action::Cancel);
+                let new_state = ds.state_machine.state();
+                let _ = context.state_tx.send(new_state);
+                if let Some(level_tx) = &context.overlay_level_tx {
+                    let _ = level_tx.send(0.0);
+                }
+                info!("speak: stopped in-progress read-aloud");
+                return Response::Ok { state: new_state };
+            }
+            State::Recording | State::Transcribing => {
+                return Response::Error {
+                    message: "busy — finish or cancel recording first".to_string(),
+                };
+            }
+            State::Idle => {
+                // Fall through; do NOT transition yet.
+            }
         }
     }
 
-    // Verify TTS is configured and enabled.
+    // (b) Verify TTS is configured/enabled and build the backend. State is
+    // still Idle on any error here — nothing to unwind.
     let tts_config = match &context.config.tts {
         Some(t) if t.enabled => t.clone(),
         Some(_) => {
@@ -2168,63 +2300,30 @@ async fn handle_speak(
         }
     };
 
-    // Capture the selected text (same approach as command mode).
+    // (c) Capture the selection. On failure (incl. empty), surface an error
+    // and — since this is hotkey-triggered — notify so the user sees why.
     info!("speak: getting selected text");
-    let clipboard = xkb_type::default_clipboard();
-    let saved_clipboard = clipboard.get_text().unwrap_or_default();
-
-    let is_terminal = context
-        .window_tracker
-        .get_focused_window_class()
-        .map(|c| is_terminal_class(&c))
-        .unwrap_or(false);
-
-    let selected_text = clipboard.get_primary_selection().unwrap_or_default();
-
-    let copy_fn = if is_terminal {
-        simulate_terminal_copy
-    } else {
-        simulate_copy
+    let selected_text = match capture_selection_for_speak(&context).await {
+        Ok(text) => text,
+        Err(message) => {
+            if context.notify_error() {
+                send_notification("whisrs", &format!("Read-aloud: {message}"));
+            }
+            return Response::Error { message };
+        }
     };
 
-    match tokio::task::spawn_blocking(copy_fn).await {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            if selected_text.is_empty() {
-                return Response::Error {
-                    message: format!("failed to copy selection: {e}"),
-                };
-            }
-            warn!("copy simulation failed ({e}), using primary selection text");
+    // (d) Re-lock; only begin synthesizing if still Idle (a concurrent command
+    // may have intervened). Do NOT proceed otherwise.
+    {
+        let mut ds = daemon_state.lock().await;
+        if ds.state_machine.state() != State::Idle {
+            return Response::Ok {
+                state: ds.state_machine.state(),
+            };
         }
-        Err(e) => {
-            if selected_text.is_empty() {
-                return Response::Error {
-                    message: format!("copy task panicked: {e}"),
-                };
-            }
-            warn!("copy task panicked ({e}), using primary selection text");
-        }
-    }
-
-    let selected_text = if selected_text.is_empty() {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        match clipboard.get_text() {
-            Ok(text) => text,
-            Err(e) => {
-                return Response::Error {
-                    message: format!("failed to read clipboard: {e}"),
-                };
-            }
-        }
-    } else {
-        selected_text
-    };
-
-    if selected_text.is_empty() || selected_text == saved_clipboard {
-        return Response::Error {
-            message: "no text selected — select text before using read-aloud".to_string(),
-        };
+        let _ = ds.state_machine.transition(Action::SpeakStart);
+        let _ = context.state_tx.send(ds.state_machine.state());
     }
 
     info!("speak: synthesizing {} chars", selected_text.len());
@@ -2232,51 +2331,85 @@ async fn handle_speak(
         send_notification("whisrs", "Reading selection aloud...");
     }
 
-    // Synthesize speech.
-    let wav_bytes = match backend.synthesize(&selected_text).await {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            error!("speak: synthesis failed: {e}");
-            if context.notify_error() {
-                send_notification("whisrs", &format!("Read-aloud failed: {e}"));
-            }
-            return Response::Error {
-                message: format!("TTS synthesis failed: {e}"),
+    // (e) Synthesize (no lock held).
+    let synth_result = backend.synthesize(&selected_text).await;
+
+    // (f) Re-lock to decide whether to play.
+    let final_state = {
+        let mut ds = daemon_state.lock().await;
+
+        // A second press during synthesis cancelled us — state is no longer
+        // Synthesizing. Don't play; report the current state.
+        if ds.state_machine.state() != State::Synthesizing {
+            info!("speak: synthesis superseded by a concurrent command");
+            return Response::Ok {
+                state: ds.state_machine.state(),
             };
         }
+
+        let wav_bytes = match synth_result {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!("speak: synthesis failed: {e}");
+                let _ = ds.state_machine.transition(Action::SpeakDone);
+                let _ = context.state_tx.send(ds.state_machine.state());
+                if let Some(level_tx) = &context.overlay_level_tx {
+                    let _ = level_tx.send(0.0);
+                }
+                drop(ds);
+                if context.notify_error() {
+                    send_notification("whisrs", &format!("Read-aloud failed: {e}"));
+                }
+                return Response::Error {
+                    message: format!("TTS synthesis failed: {e}"),
+                };
+            }
+        };
+
+        let stop = Arc::new(AtomicBool::new(false));
+        ds.tts_stop = Some(Arc::clone(&stop));
+        let _ = ds.state_machine.transition(Action::SpeakPlaying);
+        let new_state = ds.state_machine.state();
+        let _ = context.state_tx.send(new_state);
+
+        // (g) Spawn interruptible playback feeding the speaking overlay.
+        let ds_ref = Arc::clone(&daemon_state);
+        let context_for_cleanup = Arc::clone(&context);
+        let playback_stop = Arc::clone(&stop);
+        let level_tx = context.overlay_level_tx.clone();
+        tokio::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                whisrs::audio::playback::play_wav(&wav_bytes, stop, level_tx)
+            })
+            .await;
+            match result {
+                Ok(Ok(())) => debug!("speak: playback finished"),
+                Ok(Err(e)) => warn!("speak: playback failed: {e}"),
+                Err(e) => warn!("speak: playback task panicked: {e}"),
+            }
+
+            // On finish/interrupt: only finalize if we still own playback and
+            // the FSM is still Speaking. A second Speak / Cancel already
+            // transitioned to Idle and replaced/cleared tts_stop.
+            let mut ds = ds_ref.lock().await;
+            let still_ours = ds
+                .tts_stop
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, &playback_stop));
+            if ds.state_machine.state() == State::Speaking && still_ours {
+                let _ = ds.state_machine.transition(Action::SpeakDone);
+                ds.tts_stop = None;
+                let _ = context_for_cleanup.state_tx.send(ds.state_machine.state());
+                if let Some(level_tx) = &context_for_cleanup.overlay_level_tx {
+                    let _ = level_tx.send(0.0);
+                }
+            }
+        });
+
+        new_state
     };
 
-    // Store a fresh stop flag and spawn interruptible playback.
-    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    {
-        let mut ds = daemon_state.lock().await;
-        ds.tts_stop = Some(Arc::clone(&stop));
-    }
-
-    let ds_ref = Arc::clone(&daemon_state);
-    let playback_stop = Arc::clone(&stop);
-    tokio::spawn(async move {
-        let result = tokio::task::spawn_blocking(move || {
-            whisrs::audio::playback::play_wav(&wav_bytes, stop)
-        })
-        .await;
-        match result {
-            Ok(Ok(())) => debug!("speak: playback finished"),
-            Ok(Err(e)) => warn!("speak: playback failed: {e}"),
-            Err(e) => warn!("speak: playback task panicked: {e}"),
-        }
-        // Clear the stop flag from daemon state if it is still ours (i.e. a new
-        // Speak hasn't replaced it).
-        let mut ds = ds_ref.lock().await;
-        if let Some(current) = &ds.tts_stop {
-            if Arc::ptr_eq(current, &playback_stop) {
-                ds.tts_stop = None;
-            }
-        }
-    });
-
-    let state = daemon_state.lock().await.state_machine.state();
-    Response::Ok { state }
+    Response::Ok { state: final_state }
 }
 
 async fn handle_cancel(

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -76,6 +76,19 @@ pub async fn start_hotkey_listener(config: &HotkeyConfig, cmd_tx: mpsc::Sender<C
         }
     }
 
+    if let Some(ref s) = config.speak {
+        match parse_hotkey(s) {
+            Ok(binding) => {
+                info!("hotkey: speak = {s}");
+                actions.push(HotkeyAction {
+                    binding,
+                    command: Command::Speak,
+                });
+            }
+            Err(e) => warn!("invalid speak hotkey '{s}': {e}"),
+        }
+    }
+
     if actions.is_empty() {
         debug!("no hotkeys configured");
         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod overlay;
 pub mod state;
 pub mod transcription;
 pub mod tray;
+pub mod tts;
 pub mod window;
 
 use serde::{Deserialize, Serialize};
@@ -36,6 +37,10 @@ pub enum Command {
     /// Start command mode: copy selection → record voice instruction → LLM rewrite → paste.
     #[serde(rename = "command")]
     CommandMode,
+    /// Read the selected text aloud via TTS. A repeat `Speak` (or `Cancel`)
+    /// stops any in-progress playback.
+    #[serde(alias = "read")]
+    Speak,
 }
 
 fn default_log_limit() -> usize {
@@ -100,6 +105,9 @@ pub struct Config {
     /// LLM configuration for command mode (text rewriting).
     #[serde(default)]
     pub llm: Option<llm::LlmConfig>,
+    /// Text-to-speech configuration for read-selection-aloud.
+    #[serde(default)]
+    pub tts: Option<TtsConfig>,
     /// Global hotkey configuration.
     #[serde(default)]
     pub hotkeys: Option<HotkeyConfig>,
@@ -117,6 +125,9 @@ pub struct HotkeyConfig {
     pub cancel: Option<String>,
     /// Hotkey to start command mode (e.g. "Super+Shift+C").
     pub command: Option<String>,
+    /// Hotkey to read the selected text aloud (e.g. "Super+Shift+R").
+    #[serde(alias = "read")]
+    pub speak: Option<String>,
 }
 
 /// Visual configuration for the bottom recording overlay.
@@ -325,6 +336,42 @@ pub struct OpenAiConfig {
     pub model: String,
 }
 
+/// Text-to-speech configuration for the read-selection-aloud feature.
+///
+/// Opt-in (`enabled` defaults to `false`). v1 uses the Groq TTS endpoint;
+/// when `api_key` is absent the daemon falls back to the `[groq]` api_key /
+/// `WHISRS_GROQ_API_KEY` env var (TTS runs on the same Groq account).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TtsConfig {
+    /// Whether read-selection-aloud is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+    /// TTS model identifier (backend-specific).
+    #[serde(default = "default_tts_model")]
+    pub model: String,
+    /// Voice name.
+    #[serde(default = "default_tts_voice")]
+    pub voice: String,
+    /// Audio response format requested from the API (we decode WAV).
+    #[serde(default = "default_tts_response_format")]
+    pub response_format: String,
+    /// Optional dedicated API key; falls back to the Groq key when absent.
+    #[serde(default)]
+    pub api_key: Option<String>,
+}
+
+impl Default for TtsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            model: default_tts_model(),
+            voice: default_tts_voice(),
+            response_format: default_tts_response_format(),
+            api_key: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalWhisperConfig {
     pub model_path: String,
@@ -377,6 +424,15 @@ fn default_groq_model() -> String {
 }
 fn default_openai_model() -> String {
     "gpt-4o-mini-transcribe".to_string()
+}
+fn default_tts_model() -> String {
+    "canopylabs/orpheus-v1-english".to_string()
+}
+fn default_tts_voice() -> String {
+    "autumn".to_string()
+}
+fn default_tts_response_format() -> String {
+    "wav".to_string()
 }
 fn default_asr_sidecar_url() -> String {
     "http://127.0.0.1:8765/transcribe".to_string()
@@ -759,6 +815,93 @@ mod tests {
     }
 
     #[test]
+    fn speak_command_serializes_lowercase() {
+        let cmd = Command::Speak;
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(json, r#"{"cmd":"speak"}"#);
+    }
+
+    #[test]
+    fn speak_command_roundtrip() {
+        let parsed: Command = serde_json::from_str(r#"{"cmd":"speak"}"#).unwrap();
+        assert!(matches!(parsed, Command::Speak));
+    }
+
+    #[test]
+    fn speak_command_read_alias() {
+        let parsed: Command = serde_json::from_str(r#"{"cmd":"read"}"#).unwrap();
+        assert!(matches!(parsed, Command::Speak));
+    }
+
+    #[test]
+    fn config_tts_section_roundtrip() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+
+            [tts]
+            enabled = true
+            model = "canopylabs/orpheus-v1-english"
+            voice = "autumn"
+            response_format = "wav"
+            "#,
+        )
+        .unwrap();
+
+        let tts = config.tts.as_ref().expect("tts section parsed");
+        assert!(tts.enabled);
+        assert_eq!(tts.model, "canopylabs/orpheus-v1-english");
+        assert_eq!(tts.voice, "autumn");
+        assert_eq!(tts.response_format, "wav");
+        assert!(tts.api_key.is_none());
+
+        // Round-trips back out and parses again identically.
+        let serialized = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        assert!(reparsed.tts.unwrap().enabled);
+    }
+
+    #[test]
+    fn config_tts_defaults_when_minimal() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+
+            [tts]
+            enabled = true
+            "#,
+        )
+        .unwrap();
+
+        let tts = config.tts.unwrap();
+        assert!(tts.enabled);
+        // Defaults applied for omitted fields.
+        assert_eq!(tts.model, "canopylabs/orpheus-v1-english");
+        assert_eq!(tts.voice, "autumn");
+        assert_eq!(tts.response_format, "wav");
+    }
+
+    #[test]
+    fn config_without_tts_is_none() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+            "#,
+        )
+        .unwrap();
+        assert!(config.tts.is_none());
+    }
+
+    #[test]
+    fn hotkey_speak_read_alias() {
+        let hotkeys: HotkeyConfig = toml::from_str(r#"read = "Super+Shift+R""#).unwrap();
+        assert_eq!(hotkeys.speak.as_deref(), Some("Super+Shift+R"));
+    }
+
+    #[test]
     fn response_json_format() {
         let resp = Response::Ok { state: State::Idle };
         let json = serde_json::to_string(&resp).unwrap();
@@ -869,6 +1012,7 @@ mod tests {
             local_parakeet: None,
             asr_sidecar: None,
             llm: None,
+            tts: None,
             hotkeys: None,
             overlay: None,
         };
@@ -911,6 +1055,7 @@ mod tests {
             local_parakeet: None,
             asr_sidecar: None,
             llm: None,
+            tts: None,
             hotkeys: None,
             overlay: None,
         };
@@ -938,6 +1083,7 @@ mod tests {
             local_parakeet: None,
             asr_sidecar: None,
             llm: None,
+            tts: None,
             hotkeys: None,
             overlay: None,
         };
@@ -982,6 +1128,7 @@ mod tests {
                 model: "microsoft/VibeVoice-ASR-HF".to_string(),
             }),
             llm: None,
+            tts: None,
             hotkeys: None,
             overlay: None,
         };
@@ -1028,6 +1175,7 @@ mod tests {
             local_parakeet: None,
             asr_sidecar: None,
             llm: None,
+            tts: None,
             hotkeys: None,
             overlay: None,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,10 @@ pub enum State {
     Idle,
     Recording,
     Transcribing,
+    /// Read-aloud: synthesizing speech from the selection (no audio yet).
+    Synthesizing,
+    /// Read-aloud: playing the synthesized speech.
+    Speaking,
 }
 
 impl std::fmt::Display for State {
@@ -71,6 +75,8 @@ impl std::fmt::Display for State {
             State::Idle => write!(f, "idle"),
             State::Recording => write!(f, "recording"),
             State::Transcribing => write!(f, "transcribing"),
+            State::Synthesizing => write!(f, "synthesizing"),
+            State::Speaking => write!(f, "speaking"),
         }
     }
 }
@@ -159,6 +165,8 @@ pub struct OverlayColors {
     pub ring: Option<String>,
     pub recording: Option<String>,
     pub transcribing: Option<String>,
+    /// Override color for the read-aloud "speaking" bars.
+    pub speaking: Option<String>,
     pub glow: Option<String>,
 }
 
@@ -346,6 +354,11 @@ pub struct TtsConfig {
     /// Whether read-selection-aloud is enabled.
     #[serde(default)]
     pub enabled: bool,
+    /// TTS backend: `"groq"` (default), `"openai"`, `"tts-sidecar"`
+    /// (alias `"openai-compat"`, for local Kokoro/Supertonic servers), or
+    /// `"deepgram"` (Aura-2).
+    #[serde(default = "default_tts_backend")]
+    pub backend: String,
     /// TTS model identifier (backend-specific).
     #[serde(default = "default_tts_model")]
     pub model: String,
@@ -355,19 +368,25 @@ pub struct TtsConfig {
     /// Audio response format requested from the API (we decode WAV).
     #[serde(default = "default_tts_response_format")]
     pub response_format: String,
-    /// Optional dedicated API key; falls back to the Groq key when absent.
+    /// Optional dedicated API key; falls back to the backend's key when absent.
     #[serde(default)]
     pub api_key: Option<String>,
+    /// Endpoint URL for the `tts-sidecar` backend (OpenAI-compatible
+    /// `/v1/audio/speech`). Ignored by other backends.
+    #[serde(default)]
+    pub url: Option<String>,
 }
 
 impl Default for TtsConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            backend: default_tts_backend(),
             model: default_tts_model(),
             voice: default_tts_voice(),
             response_format: default_tts_response_format(),
             api_key: None,
+            url: None,
         }
     }
 }
@@ -424,6 +443,9 @@ fn default_groq_model() -> String {
 }
 fn default_openai_model() -> String {
     "gpt-4o-mini-transcribe".to_string()
+}
+fn default_tts_backend() -> String {
+    "groq".to_string()
 }
 fn default_tts_model() -> String {
     "canopylabs/orpheus-v1-english".to_string()
@@ -863,6 +885,56 @@ mod tests {
     }
 
     #[test]
+    fn config_tts_backend_and_url_roundtrip() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+
+            [tts]
+            enabled = true
+            backend = "tts-sidecar"
+            model = "kokoro"
+            voice = "af_heart"
+            url = "http://127.0.0.1:8880/v1/audio/speech"
+            "#,
+        )
+        .unwrap();
+
+        let tts = config.tts.as_ref().expect("tts section parsed");
+        assert_eq!(tts.backend, "tts-sidecar");
+        assert_eq!(
+            tts.url.as_deref(),
+            Some("http://127.0.0.1:8880/v1/audio/speech")
+        );
+
+        // Round-trips back out and parses again identically.
+        let serialized = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        let tts = reparsed.tts.unwrap();
+        assert_eq!(tts.backend, "tts-sidecar");
+        assert_eq!(
+            tts.url.as_deref(),
+            Some("http://127.0.0.1:8880/v1/audio/speech")
+        );
+    }
+
+    #[test]
+    fn config_tts_backend_defaults_to_groq() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+
+            [tts]
+            enabled = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(config.tts.unwrap().backend, "groq");
+    }
+
+    #[test]
     fn config_tts_defaults_when_minimal() {
         let config: Config = toml::from_str(
             r#"
@@ -922,6 +994,23 @@ mod tests {
         assert_eq!(State::Idle.to_string(), "idle");
         assert_eq!(State::Recording.to_string(), "recording");
         assert_eq!(State::Transcribing.to_string(), "transcribing");
+        assert_eq!(State::Synthesizing.to_string(), "synthesizing");
+        assert_eq!(State::Speaking.to_string(), "speaking");
+    }
+
+    #[test]
+    fn state_serde_wire_format() {
+        // serde rename_all = "lowercase" governs the IPC wire form.
+        assert_eq!(
+            serde_json::to_string(&State::Synthesizing).unwrap(),
+            r#""synthesizing""#
+        );
+        assert_eq!(
+            serde_json::to_string(&State::Speaking).unwrap(),
+            r#""speaking""#
+        );
+        let parsed: State = serde_json::from_str(r#""speaking""#).unwrap();
+        assert_eq!(parsed, State::Speaking);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,12 +359,15 @@ pub struct TtsConfig {
     /// `"deepgram"` (Aura-2).
     #[serde(default = "default_tts_backend")]
     pub backend: String,
-    /// TTS model identifier (backend-specific).
-    #[serde(default = "default_tts_model")]
-    pub model: String,
-    /// Voice name.
-    #[serde(default = "default_tts_voice")]
-    pub voice: String,
+    /// TTS model identifier (backend-specific). When omitted, each backend
+    /// applies its own sensible default (see [`crate::tts::create_backend`]),
+    /// so switching `backend` works without also hand-editing the model.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Voice name (backend-specific). When omitted, the backend's default
+    /// voice is used.
+    #[serde(default)]
+    pub voice: Option<String>,
     /// Audio response format requested from the API (we decode WAV).
     #[serde(default = "default_tts_response_format")]
     pub response_format: String,
@@ -382,8 +385,8 @@ impl Default for TtsConfig {
         Self {
             enabled: false,
             backend: default_tts_backend(),
-            model: default_tts_model(),
-            voice: default_tts_voice(),
+            model: None,
+            voice: None,
             response_format: default_tts_response_format(),
             api_key: None,
             url: None,
@@ -446,12 +449,6 @@ fn default_openai_model() -> String {
 }
 fn default_tts_backend() -> String {
     "groq".to_string()
-}
-fn default_tts_model() -> String {
-    "canopylabs/orpheus-v1-english".to_string()
-}
-fn default_tts_voice() -> String {
-    "autumn".to_string()
 }
 fn default_tts_response_format() -> String {
     "wav".to_string()
@@ -873,8 +870,8 @@ mod tests {
 
         let tts = config.tts.as_ref().expect("tts section parsed");
         assert!(tts.enabled);
-        assert_eq!(tts.model, "canopylabs/orpheus-v1-english");
-        assert_eq!(tts.voice, "autumn");
+        assert_eq!(tts.model.as_deref(), Some("canopylabs/orpheus-v1-english"));
+        assert_eq!(tts.voice.as_deref(), Some("autumn"));
         assert_eq!(tts.response_format, "wav");
         assert!(tts.api_key.is_none());
 
@@ -949,9 +946,11 @@ mod tests {
 
         let tts = config.tts.unwrap();
         assert!(tts.enabled);
-        // Defaults applied for omitted fields.
-        assert_eq!(tts.model, "canopylabs/orpheus-v1-english");
-        assert_eq!(tts.voice, "autumn");
+        // model/voice are left unset in config — each backend supplies its own
+        // default at build time (see tts::create_backend), so switching backend
+        // doesn't require also overriding the model.
+        assert!(tts.model.is_none());
+        assert!(tts.voice.is_none());
         assert_eq!(tts.response_format, "wav");
     }
 

--- a/src/overlay/service.rs
+++ b/src/overlay/service.rs
@@ -122,6 +122,9 @@ struct Theme {
     ring: [u8; 4],
     rec_bar: [u8; 4],
     trans_bar: [u8; 4],
+    /// Read-aloud "speaking" bar color — a distinct hue from `rec_bar` so the
+    /// user can tell dictation from read-aloud at a glance.
+    speak_bar: [u8; 4],
     glow: [u8; 4],
 }
 
@@ -133,6 +136,7 @@ impl Theme {
             ring: [64, 249, 115, 22],        // #F97316 @ 25%
             rec_bar: [255, 249, 115, 22],    // #F97316
             trans_bar: [255, 240, 237, 245], // #F0EDF5
+            speak_bar: [255, 52, 211, 153],  // #34D399 emerald — distinct from amber
             glow: [60, 249, 115, 22],
         }
     }
@@ -144,6 +148,7 @@ impl Theme {
             ring: [80, 58, 58, 64],          // hairline gray
             rec_bar: [255, 240, 237, 245],   // soft white
             trans_bar: [255, 156, 163, 175], // warm gray
+            speak_bar: [255, 45, 212, 191],  // #2DD4BF teal — pops against the grays
             glow: [40, 240, 237, 245],
         }
     }
@@ -155,6 +160,7 @@ impl Theme {
             ring: [64, 34, 211, 238], // #22D3EE @ 25%
             rec_bar: [255, 34, 211, 238],
             trans_bar: [255, 56, 189, 248], // #38BDF8
+            speak_bar: [255, 74, 222, 128], // #4ADE80 green — distinct from cyan
             glow: [50, 34, 211, 238],
         }
     }
@@ -196,6 +202,11 @@ impl Theme {
                 .as_deref()
                 .and_then(crate::parse_hex_color)
                 .unwrap_or(base.trans_bar),
+            speak_bar: c
+                .speaking
+                .as_deref()
+                .and_then(crate::parse_hex_color)
+                .unwrap_or(base.speak_bar),
             glow: c
                 .glow
                 .as_deref()
@@ -1474,10 +1485,20 @@ fn draw_overlay(
     // visually; the bars just don't follow its center-of-mass.
     let pill_cy = surface_h / 2.0;
     match state {
-        State::Recording => draw_bars(pixmap, theme, level, anim, pill_cy),
-        State::Transcribing => draw_sweep(pixmap, theme, frame, anim, pill_cy),
+        State::Recording => draw_bars(pixmap, theme, theme.rec_bar, level, anim, pill_cy),
+        // Read-aloud playback reuses the equalizer bars in a distinct hue,
+        // driven by the spoken audio amplitude.
+        State::Speaking => draw_bars(pixmap, theme, theme.speak_bar, level, anim, pill_cy),
+        // Synthesizing reuses the transcribing "working on it" shimmer.
+        State::Transcribing | State::Synthesizing => {
+            draw_sweep(pixmap, theme, frame, anim, pill_cy)
+        }
         State::Idle => {}
     }
+    // NOTE: the external GNOME Shell extension (not in this repo) only renders
+    // recording/transcribing today; it would need a separate update to draw
+    // the synthesizing/speaking states. The native Wayland/X11 paths above
+    // handle them fully.
 }
 
 /// Build a stadium / pill path: rectangle + two end-cap circles, joined by
@@ -1567,7 +1588,14 @@ fn taper_factor(i: u32, count: u32) -> f32 {
 /// the dominant driver — only ~15 % of the bar height comes from the
 /// per-bar phase animation, so silence reads as actually quiet and loud
 /// speech reaches near the pill edge.
-fn draw_bars(pixmap: &mut Pixmap, theme: &Theme, level: f32, anim: AnimState, pill_cy: f32) {
+fn draw_bars(
+    pixmap: &mut Pixmap,
+    theme: &Theme,
+    bar_color: [u8; 4],
+    level: f32,
+    anim: AnimState,
+    pill_cy: f32,
+) {
     let surface_w = pixmap.width() as f32;
     // Track the *currently displayed* pill height so bars stay within the
     // pill while it's still growing during the spawn animation.
@@ -1620,7 +1648,7 @@ fn draw_bars(pixmap: &mut Pixmap, theme: &Theme, level: f32, anim: AnimState, pi
                 anti_alias: true,
                 ..Default::default()
             };
-            paint.set_color(theme_color(theme.rec_bar, anim.bar_alpha));
+            paint.set_color(theme_color(bar_color, anim.bar_alpha));
             pixmap.fill_path(
                 &path,
                 &paint,
@@ -1735,6 +1763,40 @@ mod tests {
         let t = Theme::ember();
         draw_overlay(&mut pm, State::Recording, 0, 1.0, shown(), &t);
         // tiny-skia stores premultiplied RGBA; alpha lives in the 4th byte.
+        assert!(pm.data().chunks_exact(4).any(|px| px[3] != 0));
+    }
+
+    #[test]
+    fn speaking_uses_distinct_bar_color_from_recording() {
+        // Recording bars are amber (#F97316: high R, mid G, low B); speaking
+        // bars are emerald (#34D399: low R, high G, mid B). Confirm the
+        // speaking frame paints green-dominant bar pixels that the recording
+        // frame does not.
+        fn green_dominant(data: &[u8]) -> usize {
+            data.chunks_exact(4)
+                .filter(|px| px[1] > 150 && px[0] < 120 && px[1] > px[0])
+                .count()
+        }
+
+        let t = Theme::ember();
+        let mut rec = fresh_pixmap();
+        let mut spk = fresh_pixmap();
+        draw_overlay(&mut rec, State::Recording, 0, 1.0, shown(), &t);
+        draw_overlay(&mut spk, State::Speaking, 0, 1.0, shown(), &t);
+        let rec_green = green_dominant(rec.data());
+        let spk_green = green_dominant(spk.data());
+        assert!(
+            spk_green > rec_green,
+            "speaking should paint more green-dominant pixels than recording \
+             (recording={rec_green}, speaking={spk_green})"
+        );
+    }
+
+    #[test]
+    fn synthesizing_draws_visible_pixels() {
+        let mut pm = fresh_pixmap();
+        let t = Theme::ember();
+        draw_overlay(&mut pm, State::Synthesizing, 0, 0.0, shown(), &t);
         assert!(pm.data().chunks_exact(4).any(|px| px[3] != 0));
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,10 @@
-//! Daemon state machine: Idle → Recording → Transcribing → Idle.
+//! Daemon state machine.
+//!
+//! Dictation: Idle → Recording → Transcribing → Idle.
+//! Read-aloud: Idle → Synthesizing → Speaking → Idle.
+//!
+//! The two flows are mutually exclusive: recording is refused while
+//! read-aloud is active, and a read-aloud request is refused while recording.
 
 use crate::{State, WhisrsError};
 
@@ -8,6 +14,12 @@ pub enum Action {
     Toggle,
     Cancel,
     TranscriptionDone,
+    /// Read-aloud: begin synthesizing the selection.
+    SpeakStart,
+    /// Read-aloud: synthesis finished, playback begins.
+    SpeakPlaying,
+    /// Read-aloud: playback finished (or synthesis produced nothing).
+    SpeakDone,
 }
 
 impl std::fmt::Display for Action {
@@ -16,6 +28,9 @@ impl std::fmt::Display for Action {
             Action::Toggle => write!(f, "toggle"),
             Action::Cancel => write!(f, "cancel"),
             Action::TranscriptionDone => write!(f, "transcription_done"),
+            Action::SpeakStart => write!(f, "speak_start"),
+            Action::SpeakPlaying => write!(f, "speak_playing"),
+            Action::SpeakDone => write!(f, "speak_done"),
         }
     }
 }
@@ -43,12 +58,28 @@ impl StateMachine {
     /// - Toggle:            Recording → Transcribing
     /// - Cancel:            Recording → Idle
     /// - TranscriptionDone: Transcribing → Idle
+    /// - SpeakStart:        Idle → Synthesizing
+    /// - SpeakPlaying:      Synthesizing → Speaking
+    /// - SpeakDone:         Synthesizing → Idle
+    /// - SpeakDone:         Speaking → Idle
+    /// - Cancel:            Synthesizing → Idle
+    /// - Cancel:            Speaking → Idle
+    ///
+    /// Recording is intentionally refused while read-aloud is active
+    /// (Toggle/CommandMode from Synthesizing/Speaking are invalid).
     pub fn transition(&mut self, action: Action) -> Result<State, WhisrsError> {
         let new_state = match (self.state, action) {
             (State::Idle, Action::Toggle) => State::Recording,
             (State::Recording, Action::Toggle) => State::Transcribing,
             (State::Recording, Action::Cancel) => State::Idle,
             (State::Transcribing, Action::TranscriptionDone) => State::Idle,
+            // Read-aloud flow.
+            (State::Idle, Action::SpeakStart) => State::Synthesizing,
+            (State::Synthesizing, Action::SpeakPlaying) => State::Speaking,
+            (State::Synthesizing, Action::SpeakDone) => State::Idle,
+            (State::Speaking, Action::SpeakDone) => State::Idle,
+            (State::Synthesizing, Action::Cancel) => State::Idle,
+            (State::Speaking, Action::Cancel) => State::Idle,
             (from, action) => {
                 return Err(WhisrsError::InvalidTransition {
                     from,
@@ -188,5 +219,104 @@ mod tests {
         sm.transition(Action::Cancel).unwrap(); // → Idle
         sm.transition(Action::Toggle).unwrap(); // → Recording again
         assert_eq!(sm.state(), State::Recording);
+    }
+
+    // --- Read-aloud flow ---
+
+    #[test]
+    fn speak_full_cycle() {
+        let mut sm = StateMachine::new();
+        assert_eq!(
+            sm.transition(Action::SpeakStart).unwrap(),
+            State::Synthesizing
+        );
+        assert_eq!(
+            sm.transition(Action::SpeakPlaying).unwrap(),
+            State::Speaking
+        );
+        assert_eq!(sm.transition(Action::SpeakDone).unwrap(), State::Idle);
+    }
+
+    #[test]
+    fn speak_done_from_synthesizing() {
+        // Synthesis produced nothing / was cancelled before playback began.
+        let mut sm = StateMachine::new();
+        sm.transition(Action::SpeakStart).unwrap();
+        assert_eq!(sm.transition(Action::SpeakDone).unwrap(), State::Idle);
+    }
+
+    #[test]
+    fn cancel_synthesizing_to_idle() {
+        let mut sm = StateMachine::new();
+        sm.transition(Action::SpeakStart).unwrap();
+        assert_eq!(sm.transition(Action::Cancel).unwrap(), State::Idle);
+    }
+
+    #[test]
+    fn cancel_speaking_to_idle() {
+        let mut sm = StateMachine::new();
+        sm.transition(Action::SpeakStart).unwrap();
+        sm.transition(Action::SpeakPlaying).unwrap();
+        assert_eq!(sm.transition(Action::Cancel).unwrap(), State::Idle);
+    }
+
+    #[test]
+    fn speak_then_speak_again() {
+        // After a read-aloud cycle finishes, a fresh read-aloud can start.
+        let mut sm = StateMachine::new();
+        sm.transition(Action::SpeakStart).unwrap();
+        sm.transition(Action::SpeakPlaying).unwrap();
+        sm.transition(Action::SpeakDone).unwrap(); // → Idle
+        assert_eq!(
+            sm.transition(Action::SpeakStart).unwrap(),
+            State::Synthesizing
+        );
+    }
+
+    #[test]
+    fn invalid_toggle_while_speaking() {
+        // Recording is refused while read-aloud is playing.
+        let mut sm = StateMachine::new();
+        sm.transition(Action::SpeakStart).unwrap();
+        sm.transition(Action::SpeakPlaying).unwrap();
+        let err = sm.transition(Action::Toggle).unwrap_err();
+        assert!(matches!(
+            err,
+            WhisrsError::InvalidTransition {
+                from: State::Speaking,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn invalid_toggle_while_synthesizing() {
+        let mut sm = StateMachine::new();
+        sm.transition(Action::SpeakStart).unwrap();
+        let err = sm.transition(Action::Toggle).unwrap_err();
+        assert!(matches!(
+            err,
+            WhisrsError::InvalidTransition {
+                from: State::Synthesizing,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn invalid_speak_start_while_recording() {
+        // Read-aloud is refused while recording (handler maps this to a
+        // "busy" error without mutating the FSM, but the transition itself
+        // is also invalid as a defence in depth).
+        let mut sm = StateMachine::new();
+        sm.transition(Action::Toggle).unwrap(); // → Recording
+        let err = sm.transition(Action::SpeakStart).unwrap_err();
+        assert!(matches!(
+            err,
+            WhisrsError::InvalidTransition {
+                from: State::Recording,
+                ..
+            }
+        ));
     }
 }

--- a/src/tray/service.rs
+++ b/src/tray/service.rs
@@ -49,6 +49,16 @@ mod icons {
     pub fn transcribing() -> Vec<u8> {
         circle_icon(0xFF_E0_A0_20)
     }
+
+    /// Read-aloud: synthesizing speech (blue/purple).
+    pub fn synthesizing() -> Vec<u8> {
+        circle_icon(0xFF_7C_5C_FF)
+    }
+
+    /// Read-aloud: playing speech (green).
+    pub fn speaking() -> Vec<u8> {
+        circle_icon(0xFF_34_D3_99)
+    }
 }
 
 /// Shared state that the tray reads.
@@ -72,6 +82,8 @@ impl ksni::Tray for WhisrsTray {
             State::Idle => "whisrs — idle".to_string(),
             State::Recording => "whisrs — recording".to_string(),
             State::Transcribing => "whisrs — transcribing".to_string(),
+            State::Synthesizing => "whisrs — synthesizing".to_string(),
+            State::Speaking => "whisrs — speaking".to_string(),
         }
     }
 
@@ -81,6 +93,8 @@ impl ksni::Tray for WhisrsTray {
             State::Idle => icons::idle(),
             State::Recording => icons::recording(),
             State::Transcribing => icons::transcribing(),
+            State::Synthesizing => icons::synthesizing(),
+            State::Speaking => icons::speaking(),
         };
         vec![Icon {
             width: 16,
@@ -95,6 +109,8 @@ impl ksni::Tray for WhisrsTray {
             State::Idle => "Idle — ready to record",
             State::Recording => "Recording...",
             State::Transcribing => "Transcribing...",
+            State::Synthesizing => "Synthesizing…",
+            State::Speaking => "Reading aloud…",
         };
         ToolTip {
             title: "whisrs".to_string(),

--- a/src/tts/deepgram_aura.rs
+++ b/src/tts/deepgram_aura.rs
@@ -1,0 +1,155 @@
+//! Deepgram Aura-2 text-to-speech backend.
+//!
+//! POSTs to Deepgram's `/v1/speak` endpoint requesting 24 kHz linear16 audio
+//! wrapped in a WAV container, so the bytes can be decoded by
+//! [`crate::audio::playback::decode_wav`] without further conversion.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use tracing::debug;
+
+use crate::WhisrsError;
+
+use super::TtsBackend;
+
+/// Deepgram speak endpoint (model + audio params are passed as query params).
+const DEEPGRAM_SPEAK_URL: &str = "https://api.deepgram.com/v1/speak";
+
+/// Default Aura-2 voice/model.
+pub const DEFAULT_MODEL: &str = "aura-2-thalia-en";
+
+/// Deepgram Aura-2 text-to-speech backend.
+pub struct DeepgramAuraTts {
+    client: reqwest::Client,
+    api_key: String,
+    model: String,
+}
+
+impl DeepgramAuraTts {
+    /// Create a new Deepgram Aura-2 TTS backend. A blank `model` falls back to
+    /// [`DEFAULT_MODEL`].
+    pub fn new(api_key: String, model: String) -> Self {
+        let model = if model.trim().is_empty() {
+            DEFAULT_MODEL.to_string()
+        } else {
+            model
+        };
+        Self {
+            client: reqwest::Client::new(),
+            api_key,
+            model,
+        }
+    }
+
+    /// Build the JSON request body for the given input text.
+    ///
+    /// Exposed for unit testing the wire format without hitting the network.
+    fn request_body<'a>(&self, text: &'a str) -> SpeechRequest<'a> {
+        SpeechRequest { text }
+    }
+
+    /// The fully-qualified request URL including query parameters. Exposed for
+    /// unit testing.
+    fn request_url(&self) -> String {
+        format!(
+            "{DEEPGRAM_SPEAK_URL}?model={}&encoding=linear16&container=wav",
+            self.model
+        )
+    }
+}
+
+/// Request body for Deepgram's text-to-speech endpoint.
+#[derive(Debug, Serialize)]
+struct SpeechRequest<'a> {
+    text: &'a str,
+}
+
+#[async_trait]
+impl TtsBackend for DeepgramAuraTts {
+    async fn synthesize(&self, text: &str) -> Result<Vec<u8>, WhisrsError> {
+        if text.trim().is_empty() {
+            return Err(WhisrsError::Transcription(
+                "cannot synthesize empty text".to_string(),
+            ));
+        }
+
+        let url = self.request_url();
+        debug!(
+            "sending {} chars to Deepgram Aura (model={})",
+            text.len(),
+            self.model
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Token {}", self.api_key))
+            .json(&self.request_body(text))
+            .send()
+            .await
+            .map_err(|e| WhisrsError::Transcription(format!("Deepgram TTS request failed: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WhisrsError::Transcription(format!(
+                "Deepgram TTS error ({}): {}",
+                status.as_u16(),
+                body
+            )));
+        }
+
+        let bytes = response.bytes().await.map_err(|e| {
+            WhisrsError::Transcription(format!("Deepgram TTS read body failed: {e}"))
+        })?;
+
+        Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_url_has_model_and_wav_params() {
+        let backend = DeepgramAuraTts::new("test-key".to_string(), "aura-2-thalia-en".to_string());
+        let url = backend.request_url();
+        assert!(url.starts_with("https://api.deepgram.com/v1/speak?"));
+        assert!(url.contains("model=aura-2-thalia-en"));
+        assert!(url.contains("encoding=linear16"));
+        assert!(url.contains("container=wav"));
+    }
+
+    #[test]
+    fn blank_model_falls_back_to_default() {
+        let backend = DeepgramAuraTts::new("test-key".to_string(), String::new());
+        assert_eq!(backend.model, DEFAULT_MODEL);
+        assert!(backend.request_url().contains("model=aura-2-thalia-en"));
+    }
+
+    #[test]
+    fn request_body_serializes_text_only() {
+        let backend = DeepgramAuraTts::new("test-key".to_string(), "aura-2-thalia-en".to_string());
+        let json = serde_json::to_value(backend.request_body("hello world")).unwrap();
+        assert_eq!(json["text"], "hello world");
+        // Body must not leak the key or model — those go in the header/query.
+        assert!(json.get("model").is_none());
+    }
+
+    #[test]
+    fn auth_header_uses_token_scheme() {
+        // Deepgram uses `Token <key>`, not `Bearer <key>`. The header is built
+        // inline in synthesize(); assert the scheme prefix here as a guard.
+        let backend = DeepgramAuraTts::new("secret".to_string(), "aura-2-thalia-en".to_string());
+        let header = format!("Token {}", backend.api_key);
+        assert_eq!(header, "Token secret");
+    }
+
+    #[tokio::test]
+    async fn synthesize_rejects_empty_text() {
+        let backend = DeepgramAuraTts::new("test-key".to_string(), "aura-2-thalia-en".to_string());
+        let err = backend.synthesize("   ").await.unwrap_err();
+        assert!(err.to_string().contains("empty text"));
+    }
+}

--- a/src/tts/groq.rs
+++ b/src/tts/groq.rs
@@ -1,0 +1,135 @@
+//! Groq text-to-speech backend.
+//!
+//! Sends text to Groq's `/openai/v1/audio/speech` endpoint and returns the
+//! synthesized speech as WAV-encoded audio bytes.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use tracing::debug;
+
+use crate::WhisrsError;
+
+use super::TtsBackend;
+
+/// Groq API endpoint for text-to-speech.
+const GROQ_SPEECH_URL: &str = "https://api.groq.com/openai/v1/audio/speech";
+
+/// Groq text-to-speech backend.
+pub struct GroqTts {
+    client: reqwest::Client,
+    api_key: String,
+    model: String,
+    voice: String,
+    response_format: String,
+}
+
+impl GroqTts {
+    /// Create a new Groq TTS backend.
+    pub fn new(api_key: String, model: String, voice: String, response_format: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key,
+            model,
+            voice,
+            response_format,
+        }
+    }
+
+    /// Build the JSON request body for the given input text.
+    ///
+    /// Exposed for unit testing the wire format without hitting the network.
+    fn request_body<'a>(&'a self, text: &'a str) -> SpeechRequest<'a> {
+        SpeechRequest {
+            model: &self.model,
+            voice: &self.voice,
+            input: text,
+            response_format: &self.response_format,
+        }
+    }
+}
+
+/// Request body for Groq's text-to-speech endpoint.
+#[derive(Debug, Serialize)]
+struct SpeechRequest<'a> {
+    model: &'a str,
+    voice: &'a str,
+    input: &'a str,
+    response_format: &'a str,
+}
+
+#[async_trait]
+impl TtsBackend for GroqTts {
+    async fn synthesize(&self, text: &str) -> Result<Vec<u8>, WhisrsError> {
+        if text.trim().is_empty() {
+            return Err(WhisrsError::Transcription(
+                "cannot synthesize empty text".to_string(),
+            ));
+        }
+
+        debug!(
+            "sending {} chars to Groq TTS (model={}, voice={}, format={})",
+            text.len(),
+            self.model,
+            self.voice,
+            self.response_format
+        );
+
+        let response = self
+            .client
+            .post(GROQ_SPEECH_URL)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&self.request_body(text))
+            .send()
+            .await
+            .map_err(|e| WhisrsError::Transcription(format!("Groq TTS request failed: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WhisrsError::Transcription(format!(
+                "Groq TTS error ({}): {}",
+                status.as_u16(),
+                body
+            )));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| WhisrsError::Transcription(format!("Groq TTS read body failed: {e}")))?;
+
+        Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_body_serializes_expected_shape() {
+        let backend = GroqTts::new(
+            "test-key".to_string(),
+            "canopylabs/orpheus-v1-english".to_string(),
+            "autumn".to_string(),
+            "wav".to_string(),
+        );
+        let json = serde_json::to_value(backend.request_body("hello world")).unwrap();
+        assert_eq!(json["model"], "canopylabs/orpheus-v1-english");
+        assert_eq!(json["voice"], "autumn");
+        assert_eq!(json["input"], "hello world");
+        assert_eq!(json["response_format"], "wav");
+    }
+
+    #[tokio::test]
+    async fn synthesize_rejects_empty_text() {
+        let backend = GroqTts::new(
+            "test-key".to_string(),
+            "canopylabs/orpheus-v1-english".to_string(),
+            "autumn".to_string(),
+            "wav".to_string(),
+        );
+        let err = backend.synthesize("   ").await.unwrap_err();
+        assert!(err.to_string().contains("empty text"));
+    }
+}

--- a/src/tts/groq.rs
+++ b/src/tts/groq.rs
@@ -1,129 +1,40 @@
 //! Groq text-to-speech backend.
 //!
-//! Sends text to Groq's `/openai/v1/audio/speech` endpoint and returns the
-//! synthesized speech as WAV-encoded audio bytes.
+//! Groq's `/openai/v1/audio/speech` endpoint speaks the OpenAI request shape,
+//! so a Groq backend is just an [`OpenAiCompatTts`] pinned to the Groq base
+//! URL. The base URL is shared with [`super::create_backend`]; this module
+//! also offers a named constructor for clarity and tests.
 
-use async_trait::async_trait;
-use serde::Serialize;
-use tracing::debug;
-
-use crate::WhisrsError;
-
-use super::TtsBackend;
+use super::openai_compat::OpenAiCompatTts;
 
 /// Groq API endpoint for text-to-speech.
-const GROQ_SPEECH_URL: &str = "https://api.groq.com/openai/v1/audio/speech";
+pub const GROQ_SPEECH_URL: &str = "https://api.groq.com/openai/v1/audio/speech";
 
-/// Groq text-to-speech backend.
-pub struct GroqTts {
-    client: reqwest::Client,
+/// Build a Groq TTS backend (an [`OpenAiCompatTts`] pinned to Groq). Groq
+/// always requires an API key.
+pub fn groq_backend(
     api_key: String,
     model: String,
     voice: String,
     response_format: String,
-}
-
-impl GroqTts {
-    /// Create a new Groq TTS backend.
-    pub fn new(api_key: String, model: String, voice: String, response_format: String) -> Self {
-        Self {
-            client: reqwest::Client::new(),
-            api_key,
-            model,
-            voice,
-            response_format,
-        }
-    }
-
-    /// Build the JSON request body for the given input text.
-    ///
-    /// Exposed for unit testing the wire format without hitting the network.
-    fn request_body<'a>(&'a self, text: &'a str) -> SpeechRequest<'a> {
-        SpeechRequest {
-            model: &self.model,
-            voice: &self.voice,
-            input: text,
-            response_format: &self.response_format,
-        }
-    }
-}
-
-/// Request body for Groq's text-to-speech endpoint.
-#[derive(Debug, Serialize)]
-struct SpeechRequest<'a> {
-    model: &'a str,
-    voice: &'a str,
-    input: &'a str,
-    response_format: &'a str,
-}
-
-#[async_trait]
-impl TtsBackend for GroqTts {
-    async fn synthesize(&self, text: &str) -> Result<Vec<u8>, WhisrsError> {
-        if text.trim().is_empty() {
-            return Err(WhisrsError::Transcription(
-                "cannot synthesize empty text".to_string(),
-            ));
-        }
-
-        debug!(
-            "sending {} chars to Groq TTS (model={}, voice={}, format={})",
-            text.len(),
-            self.model,
-            self.voice,
-            self.response_format
-        );
-
-        let response = self
-            .client
-            .post(GROQ_SPEECH_URL)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .json(&self.request_body(text))
-            .send()
-            .await
-            .map_err(|e| WhisrsError::Transcription(format!("Groq TTS request failed: {e}")))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(WhisrsError::Transcription(format!(
-                "Groq TTS error ({}): {}",
-                status.as_u16(),
-                body
-            )));
-        }
-
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| WhisrsError::Transcription(format!("Groq TTS read body failed: {e}")))?;
-
-        Ok(bytes.to_vec())
-    }
+) -> OpenAiCompatTts {
+    OpenAiCompatTts::new(
+        GROQ_SPEECH_URL.to_string(),
+        Some(api_key),
+        model,
+        voice,
+        response_format,
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn request_body_serializes_expected_shape() {
-        let backend = GroqTts::new(
-            "test-key".to_string(),
-            "canopylabs/orpheus-v1-english".to_string(),
-            "autumn".to_string(),
-            "wav".to_string(),
-        );
-        let json = serde_json::to_value(backend.request_body("hello world")).unwrap();
-        assert_eq!(json["model"], "canopylabs/orpheus-v1-english");
-        assert_eq!(json["voice"], "autumn");
-        assert_eq!(json["input"], "hello world");
-        assert_eq!(json["response_format"], "wav");
-    }
+    use crate::tts::TtsBackend;
 
     #[tokio::test]
     async fn synthesize_rejects_empty_text() {
-        let backend = GroqTts::new(
+        let backend = groq_backend(
             "test-key".to_string(),
             "canopylabs/orpheus-v1-english".to_string(),
             "autumn".to_string(),

--- a/src/tts/mod.rs
+++ b/src/tts/mod.rs
@@ -1,0 +1,47 @@
+//! Text-to-speech backends: trait definition and implementations.
+//!
+//! The synthesis stage of the "read selection aloud" feature lives behind a
+//! small [`TtsBackend`] trait (mirroring [`crate::transcription::TranscriptionBackend`])
+//! so a local backend (piper/espeak) can be added later. v1 ships the Groq
+//! backend only.
+
+pub mod groq;
+
+use async_trait::async_trait;
+
+use crate::{TtsConfig, WhisrsError};
+
+/// Trait for text-to-speech backends.
+///
+/// Each backend takes input text and returns synthesized speech as WAV bytes,
+/// ready to be decoded and played by [`crate::audio::playback::play_wav`].
+#[async_trait]
+pub trait TtsBackend: Send + Sync {
+    /// Synthesize `text` into speech, returning WAV-encoded audio bytes.
+    async fn synthesize(&self, text: &str) -> Result<Vec<u8>, WhisrsError>;
+}
+
+/// Build the configured TTS backend.
+///
+/// `api_key` should already be resolved (TTS-specific key, falling back to the
+/// Groq key / `WHISRS_GROQ_API_KEY`). Returns an error when no key is available.
+/// v1 always builds the Groq backend.
+pub fn create_backend(
+    config: &TtsConfig,
+    api_key: Option<String>,
+) -> Result<Box<dyn TtsBackend>, WhisrsError> {
+    let api_key = api_key.filter(|k| !k.is_empty()).ok_or_else(|| {
+        WhisrsError::Config(
+            "TTS is enabled but no API key is configured.\n\
+             Add an api_key to [tts], or configure [groq] api_key / set WHISRS_GROQ_API_KEY."
+                .to_string(),
+        )
+    })?;
+
+    Ok(Box::new(groq::GroqTts::new(
+        api_key,
+        config.model.clone(),
+        config.voice.clone(),
+        config.response_format.clone(),
+    )))
+}

--- a/src/tts/mod.rs
+++ b/src/tts/mod.rs
@@ -28,6 +28,17 @@ const DEFAULT_SIDECAR_URL: &str = "http://127.0.0.1:8880/v1/audio/speech";
 /// OpenAI's text-to-speech endpoint.
 const OPENAI_SPEECH_URL: &str = "https://api.openai.com/v1/audio/speech";
 
+// Per-backend default model/voice, applied when `[tts] model`/`voice` are unset
+// so a user can switch `backend` without also overriding the model. The Groq
+// default (orpheus) is meaningless to OpenAI/Deepgram, which is why the default
+// is resolved here per backend rather than baked into the config.
+const GROQ_DEFAULT_MODEL: &str = "canopylabs/orpheus-v1-english";
+const GROQ_DEFAULT_VOICE: &str = "autumn";
+const OPENAI_DEFAULT_MODEL: &str = "gpt-4o-mini-tts";
+const OPENAI_DEFAULT_VOICE: &str = "alloy";
+const SIDECAR_DEFAULT_MODEL: &str = "kokoro";
+const SIDECAR_DEFAULT_VOICE: &str = "af_heart";
+
 /// Trait for text-to-speech backends.
 ///
 /// Each backend takes input text and returns synthesized speech as WAV bytes,
@@ -61,19 +72,40 @@ pub fn create_backend(
         })
     };
 
+    // Resolve the effective model/voice: the configured value when present and
+    // non-blank, otherwise the selected backend's default.
+    let model_or = |default: &str| -> String {
+        config
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(default)
+            .to_string()
+    };
+    let voice_or = |default: &str| -> String {
+        config
+            .voice
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(default)
+            .to_string()
+    };
+
     match config.backend.as_str() {
         "groq" => Ok(Box::new(openai_compat::OpenAiCompatTts::new(
             groq::GROQ_SPEECH_URL.to_string(),
             Some(require_key(api_key)?),
-            config.model.clone(),
-            config.voice.clone(),
+            model_or(GROQ_DEFAULT_MODEL),
+            voice_or(GROQ_DEFAULT_VOICE),
             config.response_format.clone(),
         ))),
         "openai" => Ok(Box::new(openai_compat::OpenAiCompatTts::new(
             OPENAI_SPEECH_URL.to_string(),
             Some(require_key(api_key)?),
-            config.model.clone(),
-            config.voice.clone(),
+            model_or(OPENAI_DEFAULT_MODEL),
+            voice_or(OPENAI_DEFAULT_VOICE),
             config.response_format.clone(),
         ))),
         "tts-sidecar" | "openai-compat" => {
@@ -87,14 +119,14 @@ pub fn create_backend(
             Ok(Box::new(openai_compat::OpenAiCompatTts::new(
                 base_url,
                 api_key, // optional — sidecars usually need none
-                config.model.clone(),
-                config.voice.clone(),
+                model_or(SIDECAR_DEFAULT_MODEL),
+                voice_or(SIDECAR_DEFAULT_VOICE),
                 config.response_format.clone(),
             )))
         }
         "deepgram" => Ok(Box::new(deepgram_aura::DeepgramAuraTts::new(
             require_key(api_key)?,
-            config.model.clone(),
+            model_or(deepgram_aura::DEFAULT_MODEL),
         ))),
         other => Err(WhisrsError::Config(format!(
             "Unknown TTS backend '{other}'. Valid options: groq, openai, tts-sidecar, deepgram"

--- a/src/tts/mod.rs
+++ b/src/tts/mod.rs
@@ -124,6 +124,9 @@ pub fn create_backend(
                 config.response_format.clone(),
             )))
         }
+        // `[tts] voice` is intentionally not passed here: Aura encodes the
+        // voice in the model id (e.g. `aura-2-thalia-en`), so the model alone
+        // selects the voice.
         "deepgram" => Ok(Box::new(deepgram_aura::DeepgramAuraTts::new(
             require_key(api_key)?,
             model_or(deepgram_aura::DEFAULT_MODEL),

--- a/src/tts/mod.rs
+++ b/src/tts/mod.rs
@@ -1,15 +1,32 @@
 //! Text-to-speech backends: trait definition and implementations.
 //!
 //! The synthesis stage of the "read selection aloud" feature lives behind a
-//! small [`TtsBackend`] trait (mirroring [`crate::transcription::TranscriptionBackend`])
-//! so a local backend (piper/espeak) can be added later. v1 ships the Groq
-//! backend only.
+//! small [`TtsBackend`] trait (mirroring [`crate::transcription::TranscriptionBackend`]).
+//!
+//! Cloud and local-server backends are covered today:
+//! - `groq` / `openai` / `tts-sidecar` share the OpenAI `/v1/audio/speech`
+//!   request shape via [`openai_compat::OpenAiCompatTts`]. The `tts-sidecar`
+//!   backend points at any local OpenAI-compatible server (Kokoro, Supertonic,
+//!   etc.) and needs no API key.
+//! - `deepgram` uses Deepgram Aura-2 via [`deepgram_aura::DeepgramAuraTts`].
+//!
+//! Roadmap: native in-process local backends (Supertonic via ONNX/`ort`,
+//! Piper, Kokoro) are future work. Until then, those models are reachable
+//! today through a local server behind the `tts-sidecar` backend.
 
+pub mod deepgram_aura;
 pub mod groq;
+pub mod openai_compat;
 
 use async_trait::async_trait;
 
 use crate::{TtsConfig, WhisrsError};
+
+/// Default endpoint for a local OpenAI-compatible TTS sidecar (e.g. Kokoro-FastAPI).
+const DEFAULT_SIDECAR_URL: &str = "http://127.0.0.1:8880/v1/audio/speech";
+
+/// OpenAI's text-to-speech endpoint.
+const OPENAI_SPEECH_URL: &str = "https://api.openai.com/v1/audio/speech";
 
 /// Trait for text-to-speech backends.
 ///
@@ -23,25 +40,111 @@ pub trait TtsBackend: Send + Sync {
 
 /// Build the configured TTS backend.
 ///
-/// `api_key` should already be resolved (TTS-specific key, falling back to the
-/// Groq key / `WHISRS_GROQ_API_KEY`). Returns an error when no key is available.
-/// v1 always builds the Groq backend.
+/// `api_key` should already be resolved for the configured backend (see the
+/// daemon's `resolve_tts_api_key`). Cloud backends (`groq`, `openai`,
+/// `deepgram`) require a key; the `tts-sidecar` backend treats it as optional.
 pub fn create_backend(
     config: &TtsConfig,
     api_key: Option<String>,
 ) -> Result<Box<dyn TtsBackend>, WhisrsError> {
-    let api_key = api_key.filter(|k| !k.is_empty()).ok_or_else(|| {
-        WhisrsError::Config(
-            "TTS is enabled but no API key is configured.\n\
-             Add an api_key to [tts], or configure [groq] api_key / set WHISRS_GROQ_API_KEY."
-                .to_string(),
-        )
-    })?;
+    let api_key = api_key.filter(|k| !k.is_empty());
 
-    Ok(Box::new(groq::GroqTts::new(
-        api_key,
-        config.model.clone(),
-        config.voice.clone(),
-        config.response_format.clone(),
-    )))
+    // Require a key for the cloud backends; the sidecar can run keyless.
+    let require_key = |key: Option<String>| -> Result<String, WhisrsError> {
+        key.ok_or_else(|| {
+            WhisrsError::Config(
+                "TTS is enabled but no API key is configured.\n\
+                 Add an api_key to [tts], or configure the backend's key \
+                 (e.g. [groq] api_key / WHISRS_GROQ_API_KEY)."
+                    .to_string(),
+            )
+        })
+    };
+
+    match config.backend.as_str() {
+        "groq" => Ok(Box::new(openai_compat::OpenAiCompatTts::new(
+            groq::GROQ_SPEECH_URL.to_string(),
+            Some(require_key(api_key)?),
+            config.model.clone(),
+            config.voice.clone(),
+            config.response_format.clone(),
+        ))),
+        "openai" => Ok(Box::new(openai_compat::OpenAiCompatTts::new(
+            OPENAI_SPEECH_URL.to_string(),
+            Some(require_key(api_key)?),
+            config.model.clone(),
+            config.voice.clone(),
+            config.response_format.clone(),
+        ))),
+        "tts-sidecar" | "openai-compat" => {
+            let base_url = config
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(DEFAULT_SIDECAR_URL)
+                .to_string();
+            Ok(Box::new(openai_compat::OpenAiCompatTts::new(
+                base_url,
+                api_key, // optional — sidecars usually need none
+                config.model.clone(),
+                config.voice.clone(),
+                config.response_format.clone(),
+            )))
+        }
+        "deepgram" => Ok(Box::new(deepgram_aura::DeepgramAuraTts::new(
+            require_key(api_key)?,
+            config.model.clone(),
+        ))),
+        other => Err(WhisrsError::Config(format!(
+            "Unknown TTS backend '{other}'. Valid options: groq, openai, tts-sidecar, deepgram"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(backend: &str) -> TtsConfig {
+        TtsConfig {
+            enabled: true,
+            backend: backend.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn create_groq_backend_requires_key() {
+        assert!(create_backend(&cfg("groq"), Some("k".to_string())).is_ok());
+        assert!(create_backend(&cfg("groq"), None).is_err());
+    }
+
+    #[test]
+    fn create_openai_backend_requires_key() {
+        assert!(create_backend(&cfg("openai"), Some("k".to_string())).is_ok());
+        assert!(create_backend(&cfg("openai"), None).is_err());
+    }
+
+    #[test]
+    fn create_deepgram_backend_requires_key() {
+        assert!(create_backend(&cfg("deepgram"), Some("k".to_string())).is_ok());
+        assert!(create_backend(&cfg("deepgram"), None).is_err());
+    }
+
+    #[test]
+    fn create_sidecar_backend_allows_no_key() {
+        // Sidecar must build with no key; alias must also work.
+        assert!(create_backend(&cfg("tts-sidecar"), None).is_ok());
+        assert!(create_backend(&cfg("openai-compat"), None).is_ok());
+    }
+
+    #[test]
+    fn create_unknown_backend_errors() {
+        // `Box<dyn TtsBackend>` isn't Debug, so match instead of unwrap_err().
+        match create_backend(&cfg("bogus"), Some("k".to_string())) {
+            Err(e) => assert!(e.to_string().contains("Unknown TTS backend")),
+            Ok(_) => panic!("expected an error for an unknown backend"),
+        }
+    }
 }

--- a/src/tts/openai_compat.rs
+++ b/src/tts/openai_compat.rs
@@ -1,0 +1,167 @@
+//! OpenAI-compatible text-to-speech backend.
+//!
+//! Speaks the OpenAI `/v1/audio/speech` request shape (`{model, voice, input,
+//! response_format}`) and returns WAV-encoded audio bytes. Groq, OpenAI, and
+//! local servers (Kokoro, Supertonic, etc.) all expose this interface, so a
+//! single backend covers them by varying the base URL and whether an API key
+//! is sent.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use tracing::debug;
+
+use crate::WhisrsError;
+
+use super::TtsBackend;
+
+/// OpenAI-compatible text-to-speech backend.
+pub struct OpenAiCompatTts {
+    client: reqwest::Client,
+    /// Full speech endpoint URL (e.g. `https://api.openai.com/v1/audio/speech`).
+    base_url: String,
+    /// Optional API key. When `None`, no `Authorization` header is sent —
+    /// local sidecars usually need no auth.
+    api_key: Option<String>,
+    model: String,
+    voice: String,
+    response_format: String,
+}
+
+impl OpenAiCompatTts {
+    /// Create a new OpenAI-compatible TTS backend.
+    pub fn new(
+        base_url: String,
+        api_key: Option<String>,
+        model: String,
+        voice: String,
+        response_format: String,
+    ) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url,
+            api_key: api_key.filter(|k| !k.is_empty()),
+            model,
+            voice,
+            response_format,
+        }
+    }
+
+    /// Build the JSON request body for the given input text.
+    ///
+    /// Exposed for unit testing the wire format without hitting the network.
+    fn request_body<'a>(&'a self, text: &'a str) -> SpeechRequest<'a> {
+        SpeechRequest {
+            model: &self.model,
+            voice: &self.voice,
+            input: text,
+            response_format: &self.response_format,
+        }
+    }
+}
+
+/// Request body for the OpenAI-compatible `/v1/audio/speech` endpoint.
+#[derive(Debug, Serialize)]
+struct SpeechRequest<'a> {
+    model: &'a str,
+    voice: &'a str,
+    input: &'a str,
+    response_format: &'a str,
+}
+
+#[async_trait]
+impl TtsBackend for OpenAiCompatTts {
+    async fn synthesize(&self, text: &str) -> Result<Vec<u8>, WhisrsError> {
+        if text.trim().is_empty() {
+            return Err(WhisrsError::Transcription(
+                "cannot synthesize empty text".to_string(),
+            ));
+        }
+
+        debug!(
+            "sending {} chars to TTS at {} (model={}, voice={}, format={})",
+            text.len(),
+            self.base_url,
+            self.model,
+            self.voice,
+            self.response_format
+        );
+
+        let mut request = self
+            .client
+            .post(&self.base_url)
+            .json(&self.request_body(text));
+        if let Some(key) = &self.api_key {
+            request = request.header("Authorization", format!("Bearer {key}"));
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| WhisrsError::Transcription(format!("TTS request failed: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(WhisrsError::Transcription(format!(
+                "TTS error ({}): {}",
+                status.as_u16(),
+                body
+            )));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| WhisrsError::Transcription(format!("TTS read body failed: {e}")))?;
+
+        Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_body_serializes_expected_shape() {
+        let backend = OpenAiCompatTts::new(
+            "https://api.openai.com/v1/audio/speech".to_string(),
+            Some("test-key".to_string()),
+            "tts-1".to_string(),
+            "alloy".to_string(),
+            "wav".to_string(),
+        );
+        let json = serde_json::to_value(backend.request_body("hello world")).unwrap();
+        assert_eq!(json["model"], "tts-1");
+        assert_eq!(json["voice"], "alloy");
+        assert_eq!(json["input"], "hello world");
+        assert_eq!(json["response_format"], "wav");
+    }
+
+    #[test]
+    fn empty_api_key_is_normalized_to_none() {
+        // Sidecars are configured without a key; an empty string must not
+        // become a bogus "Authorization: Bearer " header.
+        let backend = OpenAiCompatTts::new(
+            "http://127.0.0.1:8880/v1/audio/speech".to_string(),
+            Some(String::new()),
+            "kokoro".to_string(),
+            "af_heart".to_string(),
+            "wav".to_string(),
+        );
+        assert!(backend.api_key.is_none());
+    }
+
+    #[tokio::test]
+    async fn synthesize_rejects_empty_text() {
+        let backend = OpenAiCompatTts::new(
+            "https://api.groq.com/openai/v1/audio/speech".to_string(),
+            Some("test-key".to_string()),
+            "canopylabs/orpheus-v1-english".to_string(),
+            "autumn".to_string(),
+            "wav".to_string(),
+        );
+        let err = backend.synthesize("   ").await.unwrap_err();
+        assert!(err.to_string().contains("empty text"));
+    }
+}


### PR DESCRIPTION
Closes #42.

Adds "read selection aloud": select text, press a hotkey, the daemon synthesizes the selection via a TTS backend and plays it on the default output device. Playback is interruptible (a repeat press or `whisrs cancel` stops it).

## Backends (behind a `TtsBackend` trait)
- `groq` (default) and `openai` (`gpt-4o-mini-tts`) over the OpenAI `/v1/audio/speech` shape.
- `deepgram` (Aura-2, REST, native WAV).
- `tts-sidecar`: any local OpenAI-compatible server (Kokoro, Supertonic, etc.), no API key required.

`[tts] model`/`voice` are optional and resolve to a sensible per-backend default, so switching `backend` works without hand-editing the model. Key resolution is backend-aware (falls back to the matching provider key / env var).

## Read-aloud is now modeled in the state machine
Previously read-aloud ran out-of-band via a single `AtomicBool`, with no FSM representation. That made the stop-toggle timing-dependent (a press could be silently swallowed) and left nothing for the overlay/tray to render. Now there are `State::Synthesizing` and `State::Speaking`:
- The stop decision is authoritative on FSM state, not a flag race.
- Read-aloud while recording/transcribing returns a clear "busy" error instead of corrupting state.
- The daemon mutex is never held across the synth or playback await.

## Overlay + tray
- Overlay: a sweep while synthesizing, then distinct-colored, audio-reactive bars while speaking (fed by playback amplitude), with the same appear/despawn animation as recording.
- Tray: distinct icon, title, and tooltip for synthesizing and speaking.

## Other fixes
- Selection capture trusts a non-empty primary selection directly, and only falls back to a simulated copy (with a short settle delay for a still-held hotkey) when there is no primary selection. Fixes the intermittent "read-aloud does nothing after dictating" caused by the held Alt+Shift colliding with the simulated Ctrl+C, plus a false-negative when the selection equalled the clipboard. Capture failures now notify instead of failing silently.
- Manual-stop dictation on a streaming backend no longer returns a spurious InvalidTransition (the streaming pipeline and the toggle handler both finalized the FSM).

## Tests / CI
- Unit tests for each backend's request shape (URL, auth, body) with no network, the new FSM transitions, config round-trips, and playback level. `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build` all pass.

## Follow-ups (not in this PR)
- Native local TTS via ONNX (`ort`): Supertonic looks like the best fit (99M params, fast on CPU, multilingual, emits WAV). Reachable today through `tts-sidecar`.
- The GNOME overlay extension (separate repo) needs an update to render the new TTS states. Native Wayland and X11 already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
