### PR TITLE
fix(build): include tray + overlay in minimal release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         include:
           - name: full (default features)
             features: ""
-          - name: minimal (--no-default-features)
-            features: "--no-default-features"
+          - name: minimal (no local-whisper)
+            features: "--no-default-features --features tray,overlay"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           - name: Linux x86_64 (no local-whisper)
             runner: ubuntu-latest
             artifact: whisrs-linux-x86_64-minimal
-            features: "--no-default-features"
+            features: "--no-default-features --features tray,overlay"
           - name: Linux aarch64
             runner: ubuntu-24.04-arm
             artifact: whisrs-linux-aarch64
@@ -33,7 +33,7 @@ jobs:
           - name: Linux aarch64 (no local-whisper)
             runner: ubuntu-24.04-arm
             artifact: whisrs-linux-aarch64-minimal
-            features: "--no-default-features"
+            features: "--no-default-features --features tray,overlay"
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Each tagged release publishes tarballs on [GitHub Releases](https://github.com/y
 ARCH=x86_64   # or aarch64
 curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-${ARCH}.tar.gz
 
-# Or the minimal build (cloud backends only — no whisper.cpp):
+# Or the minimal build (cloud backends only — no whisper.cpp; keeps tray + overlay):
 # curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/download/whisrs-linux-${ARCH}-minimal.tar.gz
 
 tar xzf whisrs.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,8 @@
 #
 # Environment:
 #   WHISRS_VERSION=v0.1.11   Pin to a specific tag (default: latest)
-#   WHISRS_MINIMAL=1         Use the minimal build (cloud-only, no whisper.cpp)
+#   WHISRS_MINIMAL=1         Use the minimal build (cloud-only, no whisper.cpp;
+#                            still includes the tray icon and overlay)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Fixes #51. The minimal release variant was built with `--no-default-features`, which dropped **all three** default features (`local-whisper`, `tray`, `overlay`) — not just whisper.cpp. Users upgrading to the minimal build silently lost the tray icon and overlay.

This redefines "minimal" as **the full build minus offline whisper.cpp**: build with `--no-default-features --features tray,overlay` so the tray + overlay are retained and only the heavy `whisper-rs` (C++/libclang) dependency is excluded.

## Changes

- `.github/workflows/release.yml` — both minimal matrix entries (x86_64 + aarch64) build with `--no-default-features --features tray,overlay`.
- `.github/workflows/ci.yml` — minimal release-build check uses the same flags (renamed the matrix entry to "minimal (no local-whisper)").
- `install.sh` — clarify the `WHISRS_MINIMAL=1` comment (still ships tray + overlay).
- `README.md` — clarify the minimal-build install note.

No Rust source changes were needed: `tray` and `overlay` are already cleanly `#[cfg(feature = ...)]`-gated, and the full build already compiles them with the same system deps, so the minimal artifact needs no new dependencies.

## Verification (local)

- `cargo clippy --all-targets --no-default-features --features tray,overlay -- -D warnings` — clean (the changed config)
- `cargo build --release --no-default-features --features tray,overlay` — compiles (workflow-faithful)
- `cargo fmt -- --check` — OK
- `cargo clippy --all-targets -- -D warnings` (default) — clean
- `cargo test` — 240 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)