### PR TITLE
Add per-session language override to `toggle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ For the full reference (overlay, `[input]`, `[openai-compatible-realtime]`, `[as
 ```
 whisrs setup     # Interactive onboarding
 whisrs config    # Interactive editor for ~/.config/whisrs/config.toml
-whisrs toggle    # Start/stop recording
+whisrs toggle    # Start/stop recording (uses general.language)
+whisrs toggle -l en  # Start/stop recording, overriding the language for this session
 whisrs cancel    # Cancel recording, discard audio
 whisrs status    # Query daemon state
 whisrs restart   # Restart the daemon (uses the systemd user service when present)
@@ -205,6 +206,24 @@ whisrs log       # Show recent transcription history
 whisrs log -n 5  # Show last 5 entries
 whisrs log --clear  # Clear all history
 ```
+
+### Per-language keys
+
+`toggle` accepts an optional `--language`/`-l <CODE>` (ISO 639-1, or `auto`) that
+overrides `general.language` for that one session only -- no config edit or daemon
+restart. Bind a separate key per language so you can dictate in each without
+switching settings. Hyprland:
+```
+bind = , F1, exec, whisrs toggle -l en
+bind = , F2, exec, whisrs toggle -l pl
+```
+Sway:
+```
+bindsym F1 exec whisrs toggle -l en
+bindsym F2 exec whisrs toggle -l pl
+```
+Without `-l`, `whisrs toggle` keeps using `general.language`, so an existing
+plain-toggle key is unaffected.
 
 ---
 

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -34,6 +34,28 @@ this does not touch udev rules, the systemd unit, or compositor keybindings.
 Start or stop recording. If idle, begins audio capture. If recording,
 stops capture and sends audio for transcription. Text is typed at the
 cursor in the previously focused window.
+.RS
+.TP
+\fB\-l\fR, \fB\-\-language\fR \fICODE\fR
+Override the transcription language for this session only \(em no config
+edit or daemon restart.
+.I CODE
+is an ISO 639\-1 code (e.g.
+.BR en ,
+.BR pl ),
+optionally with a region (e.g.
+.BR en\-US ),
+or
+.B auto
+for automatic detection. Applies to the
+.B toggle
+that starts recording; the override ends with the session. A plain
+.B toggle
+keeps using the configured
+.IR general.language ,
+so an existing hotkey is unaffected. Bind a separate key per language to
+dictate in each without switching settings.
+.RE
 .TP
 .B cancel
 Cancel the current recording and discard captured audio. Returns the
@@ -115,6 +137,12 @@ Start dictation (bind this to a hotkey):
 .PP
 .RS
 .B whisrs toggle
+.RE
+.PP
+Start dictation in Polish for this session only:
+.PP
+.RS
+.B whisrs toggle \-l pl
 .RE
 .PP
 Cancel recording:

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -49,7 +49,11 @@ enum SubCmd {
     /// Edit any part of ~/.config/whisrs/config.toml; restarts the daemon on save
     Config,
     /// Toggle recording on/off (start dictation or stop and transcribe)
-    Toggle,
+    Toggle {
+        /// Override the transcription language for this session (e.g. `en`, `pl`)
+        #[arg(short, long)]
+        language: Option<String>,
+    },
     /// Cancel the current recording and discard audio
     Cancel,
     /// Query the daemon state (idle, recording, transcribing)
@@ -118,8 +122,8 @@ async fn main() -> anyhow::Result<()> {
                 process::exit(1);
             }
         }
-        SubCmd::Toggle => {
-            send_command(Command::Toggle).await?;
+        SubCmd::Toggle { language } => {
+            send_command(Command::Toggle { language }).await?;
         }
         SubCmd::Cancel => {
             send_command(Command::Cancel).await?;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -50,8 +50,9 @@ enum SubCmd {
     Config,
     /// Toggle recording on/off (start dictation or stop and transcribe)
     Toggle {
-        /// Override the transcription language for this session (e.g. `en`, `pl`)
-        #[arg(short, long)]
+        /// Override the transcription language for this session: an ISO 639-1
+        /// code (e.g. `en`, `pl`), optionally with a region (`en-US`), or `auto`
+        #[arg(short, long, value_parser = whisrs::validate_language_override)]
         language: Option<String>,
     },
     /// Cancel the current recording and discard audio

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -28,8 +28,8 @@ use whisrs::transcription::openai_rest::OpenAIRestBackend;
 use whisrs::transcription::{TranscriptionBackend, TranscriptionConfig};
 use whisrs::window::{self, WindowTracker};
 use whisrs::{
-    encode_message, read_message, socket_path, Command, Config, InjectorBackend,
-    LocalWhisperConfig, Response, State,
+    encode_message, read_message, socket_path, validate_language_override, Command, Config,
+    InjectorBackend, LocalWhisperConfig, Response, State,
 };
 
 static KEYBOARD: OnceLock<StdMutex<Option<Box<dyn xkb_type::KeyInjector>>>> = OnceLock::new();
@@ -884,6 +884,14 @@ async fn handle_toggle(
 
     match current_state {
         State::Idle => {
+            // Fail fast on a bad `-l` override before any capture or state
+            // transition — otherwise the user records a whole session and
+            // only finds out when the backend rejects the language.
+            let language = match validate_toggle_language(language) {
+                Ok(lang) => lang,
+                Err(response) => return response,
+            };
+
             // Resolve the session language once: per-toggle override, else
             // config default. Persisted in `DaemonState` below so the
             // stop-toggle can apply it to the batch path and history too.
@@ -1838,6 +1846,26 @@ fn resolve_language(override_lang: Option<String>, default_lang: &str) -> String
     override_lang.unwrap_or_else(|| default_lang.to_string())
 }
 
+/// Validate a per-toggle language override before recording starts.
+///
+/// Returns the normalized override on success, or the error `Response` to
+/// send back to the CLI. Called on the start-press before any capture or
+/// state transition so a bad `-l` value (e.g. `english`) is rejected up
+/// front instead of failing a whole session at transcription time. The
+/// config default (`general.language`) is deliberately not validated.
+fn validate_toggle_language(language: Option<String>) -> Result<Option<String>, Response> {
+    match language {
+        None => Ok(None),
+        Some(lang) => match validate_language_override(&lang) {
+            Ok(normalized) => Ok(Some(normalized)),
+            Err(message) => {
+                warn!("rejected language override: {message}");
+                Err(Response::Error { message })
+            }
+        },
+    }
+}
+
 fn build_transcription_config(config: &Config, language: &str) -> TranscriptionConfig {
     TranscriptionConfig {
         language: language.to_string(),
@@ -2781,6 +2809,32 @@ mod tests {
     #[test]
     fn resolve_language_falls_back_to_default() {
         assert_eq!(resolve_language(None, "en"), "en");
+    }
+
+    /// Mirrors handle_toggle's start-press: validation runs first and its
+    /// error response is returned before the Idle→Recording transition, so
+    /// a bad `-l` override never starts a recording.
+    #[test]
+    fn start_press_rejects_invalid_language_override_before_recording() {
+        let ds = DaemonState::new();
+
+        let response = validate_toggle_language(Some("english".to_string())).unwrap_err();
+        assert!(matches!(response, Response::Error { .. }));
+
+        // handle_toggle returns that response without touching the state
+        // machine — the daemon stays idle and no capture is started.
+        assert_eq!(ds.state_machine.state(), State::Idle);
+    }
+
+    /// Valid overrides are normalized (whisper.cpp needs lowercase codes);
+    /// a plain toggle passes through untouched.
+    #[test]
+    fn start_press_normalizes_valid_language_override() {
+        assert_eq!(
+            validate_toggle_language(Some("PL".to_string())).unwrap(),
+            Some("pl".to_string())
+        );
+        assert_eq!(validate_toggle_language(None).unwrap(), None);
     }
 
     /// Minimal config with a batch (non-streaming) backend and an `en` default

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -829,7 +829,7 @@ async fn handle_command(
     context: Arc<DaemonContext>,
 ) -> Response {
     match cmd {
-        Command::Toggle => handle_toggle(daemon_state, context).await,
+        Command::Toggle { language } => handle_toggle(daemon_state, context, language).await,
         Command::Cancel => handle_cancel(daemon_state, context).await,
         Command::Status => {
             let ds = daemon_state.lock().await;
@@ -862,9 +862,13 @@ async fn handle_command(
 async fn handle_toggle(
     daemon_state: Arc<Mutex<DaemonState>>,
     context: Arc<DaemonContext>,
+    language: Option<String>,
 ) -> Response {
     let mut ds = daemon_state.lock().await;
     let current_state = ds.state_machine.state();
+    // Resolve the session language once: per-toggle override, else config default.
+    // Only consulted on the Idle->Recording start branch below.
+    let language = resolve_language(language, &context.config.general.language);
 
     match current_state {
         State::Idle => {
@@ -908,7 +912,7 @@ async fn handle_toggle(
                     }
                 };
 
-                let config = build_transcription_config(&context.config);
+                let config = build_transcription_config(&context.config, &language);
 
                 let backend = Arc::clone(&context.transcription_backend);
                 let wid = window_id.clone();
@@ -930,7 +934,7 @@ async fn handle_toggle(
                 let pipeline_audio_volume = context.config.general.audio_feedback_volume;
 
                 let pipeline_backend_name = context.config.general.backend.clone();
-                let pipeline_language = context.config.general.language.clone();
+                let pipeline_language = language.clone();
                 let pipeline_state_tx = context.state_tx.clone();
                 let pipeline_key_delay =
                     std::time::Duration::from_millis(context.config.input.key_delay_ms);
@@ -1499,7 +1503,7 @@ async fn process_recording_batch(
     let wav_data = encode_wav(&samples)?;
     info!("encoded WAV: {} bytes", wav_data.len());
 
-    let config = build_transcription_config(&context.config);
+    let config = build_transcription_config(&context.config, &context.config.general.language);
 
     let text = match context
         .transcription_backend
@@ -1772,9 +1776,15 @@ fn new_keyboard(
     }
 }
 
-fn build_transcription_config(config: &Config) -> TranscriptionConfig {
+/// Resolve the effective session language: the per-toggle `override_lang` when
+/// present, otherwise the configured default.
+fn resolve_language(override_lang: Option<String>, default_lang: &str) -> String {
+    override_lang.unwrap_or_else(|| default_lang.to_string())
+}
+
+fn build_transcription_config(config: &Config, language: &str) -> TranscriptionConfig {
     TranscriptionConfig {
-        language: config.general.language.clone(),
+        language: language.to_string(),
         model: get_model_for_backend(config),
         prompt: transcription_prompt(config.general.prompt.as_deref(), &config.general.vocabulary),
     }
@@ -2705,6 +2715,16 @@ async fn handle_cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_language_prefers_override() {
+        assert_eq!(resolve_language(Some("pl".to_string()), "en"), "pl");
+    }
+
+    #[test]
+    fn resolve_language_falls_back_to_default() {
+        assert_eq!(resolve_language(None, "en"), "en");
+    }
 
     #[test]
     fn truncate_ascii_short() {

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -63,6 +63,11 @@ struct DaemonState {
     streaming_cancel: Option<Arc<AtomicBool>>,
     /// When recording started (for duration tracking).
     recording_started_at: Option<std::time::Instant>,
+    /// The language for the active dictation session, resolved at the
+    /// Idle→Recording transition (per-toggle override or config default).
+    /// Consumed when the session ends so an override never leaks into a
+    /// later recording.
+    session_language: Option<String>,
     /// Active command mode context (set when command mode is recording).
     command_mode: Option<CommandModeContext>,
     /// Stop flag for in-progress TTS playback (read-selection-aloud).
@@ -83,9 +88,19 @@ impl DaemonState {
             streaming_task: None,
             streaming_cancel: None,
             recording_started_at: None,
+            session_language: None,
             command_mode: None,
             tts_stop: None,
         }
+    }
+
+    /// Consume the active session's language, falling back to the config
+    /// default. Taking (not reading) the value is what ends the language
+    /// session — a per-toggle override applies to exactly one recording.
+    fn take_session_language(&mut self, default_lang: &str) -> String {
+        self.session_language
+            .take()
+            .unwrap_or_else(|| default_lang.to_string())
     }
 }
 
@@ -866,12 +881,14 @@ async fn handle_toggle(
 ) -> Response {
     let mut ds = daemon_state.lock().await;
     let current_state = ds.state_machine.state();
-    // Resolve the session language once: per-toggle override, else config default.
-    // Only consulted on the Idle->Recording start branch below.
-    let language = resolve_language(language, &context.config.general.language);
 
     match current_state {
         State::Idle => {
+            // Resolve the session language once: per-toggle override, else
+            // config default. Persisted in `DaemonState` below so the
+            // stop-toggle can apply it to the batch path and history too.
+            let session_language = resolve_language(language, &context.config.general.language);
+
             // Capture focused window before recording.
             let window_id = match context.window_tracker.get_focused_window() {
                 Ok(id) => {
@@ -912,7 +929,7 @@ async fn handle_toggle(
                     }
                 };
 
-                let config = build_transcription_config(&context.config, &language);
+                let config = build_transcription_config(&context.config, &session_language);
 
                 let backend = Arc::clone(&context.transcription_backend);
                 let wid = window_id.clone();
@@ -934,7 +951,7 @@ async fn handle_toggle(
                 let pipeline_audio_volume = context.config.general.audio_feedback_volume;
 
                 let pipeline_backend_name = context.config.general.backend.clone();
-                let pipeline_language = language.clone();
+                let pipeline_language = session_language.clone();
                 let pipeline_state_tx = context.state_tx.clone();
                 let pipeline_key_delay =
                     std::time::Duration::from_millis(context.config.input.key_delay_ms);
@@ -985,6 +1002,7 @@ async fn handle_toggle(
             ds.audio_capture = Some(capture);
             ds.recording_window_id = window_id;
             ds.recording_started_at = Some(std::time::Instant::now());
+            ds.session_language = Some(session_language);
 
             match ds.state_machine.transition(Action::Toggle) {
                 Ok(new_state) => {
@@ -1004,6 +1022,7 @@ async fn handle_toggle(
                     ds.recording_window_id = None;
                     ds.streaming_task = None;
                     ds.streaming_cancel = None;
+                    ds.session_language = None;
                     Response::Error {
                         message: e.to_string(),
                     }
@@ -1034,6 +1053,22 @@ async fn handle_toggle(
                     // pipeline drains and types the remaining text.
                     ds.streaming_cancel = None;
                     let recording_started_at = ds.recording_started_at.take();
+                    // The language this session was started with. Consuming it
+                    // here ends the language session.
+                    let session_language =
+                        ds.take_session_language(&context.config.general.language);
+
+                    // A `-l` on the stop-press comes too late to change the
+                    // session — tell the user instead of silently dropping it.
+                    if let Some(requested) = &language {
+                        if *requested != session_language {
+                            warn!(
+                                "language override '{requested}' ignored — this session was \
+                                 started with '{session_language}'; pass -l on the toggle that \
+                                 starts recording"
+                            );
+                        }
+                    }
 
                     // Release lock before slow operations.
                     drop(ds);
@@ -1051,8 +1086,15 @@ async fn handle_toggle(
                             Err(e) => Err(anyhow::anyhow!("streaming task panicked: {e}")),
                         }
                     } else {
-                        // Batch path: collect all audio, then transcribe.
-                        process_recording_batch(capture, window_id.as_deref(), &context).await
+                        // Batch path: collect all audio, then transcribe with
+                        // the session language (not the config default).
+                        process_recording_batch(
+                            capture,
+                            window_id.as_deref(),
+                            &context,
+                            &session_language,
+                        )
+                        .await
                     };
 
                     // Transition back to Idle.
@@ -1074,7 +1116,7 @@ async fn handle_toggle(
                                         save_history_entry(
                                             &text,
                                             &context.config.general.backend,
-                                            &context.config.general.language,
+                                            &session_language,
                                             duration_secs,
                                         );
                                     }
@@ -1133,9 +1175,17 @@ async fn handle_toggle(
                 },
             }
         }
-        State::Transcribing => Response::Error {
-            message: "cannot toggle while transcribing".to_string(),
-        },
+        State::Transcribing => {
+            if let Some(requested) = &language {
+                warn!(
+                    "language override '{requested}' ignored — daemon is still transcribing \
+                     the previous session"
+                );
+            }
+            Response::Error {
+                message: "cannot toggle while transcribing".to_string(),
+            }
+        }
         // Recording is refused while read-aloud is active.
         State::Synthesizing | State::Speaking => Response::Error {
             message: "cannot toggle while reading aloud — cancel read-aloud first".to_string(),
@@ -1355,6 +1405,9 @@ async fn run_streaming_pipeline(
     if ds.state_machine.state() == State::Transcribing {
         debug!("streaming pipeline transitioning daemon state back to idle");
         ds.state_machine.transition(Action::TranscriptionDone).ok();
+        // Auto-stop ends the session without a stop-toggle — clear the
+        // session language so it can't leak into the next recording.
+        ds.session_language = None;
         let _ = state_tx.send(ds.state_machine.state());
         if audio_feedback {
             feedback::play_done(audio_feedback_volume);
@@ -1458,10 +1511,13 @@ where
 }
 
 /// Batch mode: collect all audio, transcribe in one shot, type result.
+/// `language` is the resolved session language (per-toggle override or
+/// config default) captured when recording started.
 async fn process_recording_batch(
     capture: Option<AudioCaptureHandle>,
     window_id: Option<&str>,
     context: &DaemonContext,
+    language: &str,
 ) -> Result<String> {
     use whisrs::audio::capture::encode_wav;
 
@@ -1503,7 +1559,7 @@ async fn process_recording_batch(
     let wav_data = encode_wav(&samples)?;
     info!("encoded WAV: {} bytes", wav_data.len());
 
-    let config = build_transcription_config(&context.config, &context.config.general.language);
+    let config = build_transcription_config(&context.config, language);
 
     let text = match context
         .transcription_backend
@@ -2691,6 +2747,7 @@ async fn handle_cancel(
                 task.abort();
             }
             ds.recording_window_id = None;
+            ds.session_language = None;
             if let Some(level_tx) = &context.overlay_level_tx {
                 let _ = level_tx.send(0.0);
             }
@@ -2724,6 +2781,74 @@ mod tests {
     #[test]
     fn resolve_language_falls_back_to_default() {
         assert_eq!(resolve_language(None, "en"), "en");
+    }
+
+    /// Minimal config with a batch (non-streaming) backend and an `en` default
+    /// language, mirroring the setup where issue reviews caught the batch path
+    /// ignoring `-l`.
+    fn batch_config() -> Config {
+        toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+            language = "en"
+            "#,
+        )
+        .unwrap()
+    }
+
+    /// The batch path must transcribe with the language the session was
+    /// started with (`toggle -l pl`), not the config default. Mirrors the
+    /// handle_toggle flow: the start-press persists the resolved language in
+    /// `DaemonState`; the stop-press consumes it and builds the batch
+    /// `TranscriptionConfig` from it.
+    #[test]
+    fn batch_stop_uses_session_language_override() {
+        let config = batch_config();
+        let mut ds = DaemonState::new();
+
+        // Start press with `-l pl`: resolve and persist the session language.
+        ds.state_machine.transition(Action::Toggle).unwrap();
+        ds.session_language = Some(resolve_language(
+            Some("pl".to_string()),
+            &config.general.language,
+        ));
+
+        // Stop press: the batch path consumes the stored session language.
+        ds.state_machine.transition(Action::Toggle).unwrap();
+        let session_language = ds.take_session_language(&config.general.language);
+        assert_eq!(session_language, "pl");
+
+        // This is the config `process_recording_batch` sends to the backend
+        // (and the language `save_history_entry` records).
+        let tc = build_transcription_config(&config, &session_language);
+        assert_eq!(tc.language, "pl");
+    }
+
+    /// Consuming the session language ends the language session: the next
+    /// recording must fall back to the config default, not inherit `pl`.
+    #[test]
+    fn session_language_does_not_leak_into_next_session() {
+        let config = batch_config();
+        let mut ds = DaemonState::new();
+
+        ds.session_language = Some("pl".to_string());
+        assert_eq!(ds.take_session_language(&config.general.language), "pl");
+
+        // Session over — a plain toggle now uses the default again.
+        assert_eq!(ds.take_session_language(&config.general.language), "en");
+    }
+
+    /// Without an override the batch path keeps using the config default.
+    #[test]
+    fn batch_stop_defaults_to_config_language() {
+        let config = batch_config();
+        let mut ds = DaemonState::new();
+
+        ds.session_language = Some(resolve_language(None, &config.general.language));
+        let session_language = ds.take_session_language(&config.general.language);
+        let tc = build_transcription_config(&config, &session_language);
+        assert_eq!(tc.language, "en");
     }
 
     #[test]

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -43,7 +43,7 @@ pub async fn start_hotkey_listener(config: &HotkeyConfig, cmd_tx: mpsc::Sender<C
                 info!("hotkey: toggle = {s}");
                 actions.push(HotkeyAction {
                     binding,
-                    command: Command::Toggle,
+                    command: Command::Toggle { language: None },
                 });
             }
             Err(e) => warn!("invalid toggle hotkey '{s}': {e}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,6 +633,62 @@ pub fn config_path() -> PathBuf {
 }
 
 // ---------------------------------------------------------------------------
+// Language override validation
+// ---------------------------------------------------------------------------
+
+/// Validate and normalize a per-session language override (`toggle -l`).
+///
+/// Accepts, case-insensitively:
+/// - `auto` — let the backend detect the language
+/// - `multi` — Deepgram's multilingual mode (what `auto` maps to there)
+/// - BCP-47-style tags whose primary subtag is a 2–3 letter ISO 639 code,
+///   with optional region/script subtags: `en`, `en-US`, `pt-BR`, `zh-Hans`
+///
+/// The rule is deliberately structural rather than a whitelist: backends
+/// accept different sets (Deepgram takes region tags and `multi`;
+/// whisper.cpp takes ISO 639-1 plus a few three-letter codes like `yue`),
+/// so only clearly-invalid input (empty, `english`, `123`) is rejected and
+/// the backend interprets the rest. This validates the `-l` override only
+/// — `general.language` from the config file is not validated here.
+///
+/// Returns the normalized tag: primary subtag lowercased (whisper.cpp
+/// requires lowercase codes), two-letter region subtags uppercased,
+/// `_` separators replaced with `-`.
+pub fn validate_language_override(lang: &str) -> Result<String, String> {
+    let trimmed = lang.trim();
+    let invalid = || {
+        format!(
+            "invalid language '{trimmed}': use an ISO 639 code like 'en', \
+             optionally with a region ('en-US'), or 'auto'"
+        )
+    };
+
+    if trimmed.eq_ignore_ascii_case("auto") || trimmed.eq_ignore_ascii_case("multi") {
+        return Ok(trimmed.to_ascii_lowercase());
+    }
+
+    let mut subtags = trimmed.split(['-', '_']);
+    let primary = subtags.next().unwrap_or("");
+    if !(2..=3).contains(&primary.len()) || !primary.bytes().all(|b| b.is_ascii_alphabetic()) {
+        return Err(invalid());
+    }
+
+    let mut normalized = primary.to_ascii_lowercase();
+    for subtag in subtags {
+        if !(2..=8).contains(&subtag.len()) || !subtag.bytes().all(|b| b.is_ascii_alphanumeric()) {
+            return Err(invalid());
+        }
+        normalized.push('-');
+        if subtag.len() == 2 {
+            normalized.push_str(&subtag.to_ascii_uppercase());
+        } else {
+            normalized.push_str(subtag);
+        }
+    }
+    Ok(normalized)
+}
+
+// ---------------------------------------------------------------------------
 // Config validation
 // ---------------------------------------------------------------------------
 
@@ -975,6 +1031,38 @@ mod tests {
         assert_eq!(json, r#"{"cmd":"toggle","language":"pl"}"#);
         let parsed: Command = serde_json::from_str(&json).unwrap();
         assert!(matches!(parsed, Command::Toggle { language: Some(l) } if l == "pl"));
+    }
+
+    #[test]
+    fn language_override_accepts_iso_codes() {
+        assert_eq!(validate_language_override("en").unwrap(), "en");
+        assert_eq!(validate_language_override("PL").unwrap(), "pl");
+        assert_eq!(validate_language_override("auto").unwrap(), "auto");
+    }
+
+    #[test]
+    fn language_override_accepts_region_tags() {
+        assert_eq!(validate_language_override("en-US").unwrap(), "en-US");
+        assert_eq!(validate_language_override("pt-br").unwrap(), "pt-BR");
+        assert_eq!(validate_language_override("en_US").unwrap(), "en-US");
+    }
+
+    #[test]
+    fn language_override_accepts_backend_specific_codes() {
+        // Deepgram's multilingual mode, whisper.cpp's three-letter codes,
+        // and script subtags pass through structurally.
+        assert_eq!(validate_language_override("multi").unwrap(), "multi");
+        assert_eq!(validate_language_override("yue").unwrap(), "yue");
+        assert_eq!(validate_language_override("zh-Hans").unwrap(), "zh-Hans");
+    }
+
+    #[test]
+    fn language_override_rejects_clearly_invalid() {
+        assert!(validate_language_override("").is_err());
+        assert!(validate_language_override("english").is_err());
+        assert!(validate_language_override("123").is_err());
+        assert!(validate_language_override("e").is_err());
+        assert!(validate_language_override("en-").is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,12 @@ use crate::transcription::openai_realtime_protocol::{OpenAiRealtimeProfile, Turn
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "cmd", rename_all = "lowercase")]
 pub enum Command {
-    Toggle,
+    /// Toggle recording. `language` overrides `general.language` for this
+    /// session only; `None` uses the configured default.
+    Toggle {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        language: Option<String>,
+    },
     Cancel,
     Status,
     /// Retrieve recent transcription history.
@@ -955,10 +960,21 @@ mod tests {
 
     #[test]
     fn command_serialization_roundtrip() {
-        let cmd = Command::Toggle;
+        let cmd = Command::Toggle { language: None };
         let json = serde_json::to_string(&cmd).unwrap();
         let parsed: Command = serde_json::from_str(&json).unwrap();
-        assert!(matches!(parsed, Command::Toggle));
+        assert!(matches!(parsed, Command::Toggle { language: None }));
+    }
+
+    #[test]
+    fn toggle_language_serialization_roundtrip() {
+        let cmd = Command::Toggle {
+            language: Some("pl".to_string()),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(json, r#"{"cmd":"toggle","language":"pl"}"#);
+        let parsed: Command = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, Command::Toggle { language: Some(l) } if l == "pl"));
     }
 
     #[test]
@@ -978,7 +994,7 @@ mod tests {
 
     #[test]
     fn command_json_format() {
-        let cmd = Command::Toggle;
+        let cmd = Command::Toggle { language: None };
         let json = serde_json::to_string(&cmd).unwrap();
         assert_eq!(json, r#"{"cmd":"toggle"}"#);
     }
@@ -1199,7 +1215,7 @@ mod tests {
             let (mut reader, mut writer) = stream.into_split();
 
             let cmd: Command = read_message(&mut reader).await.unwrap();
-            assert!(matches!(cmd, Command::Toggle));
+            assert!(matches!(cmd, Command::Toggle { language: None }));
 
             let response = Response::Ok {
                 state: State::Recording,
@@ -1213,7 +1229,7 @@ mod tests {
         let stream = UnixStream::connect(&sock_path).await.unwrap();
         let (mut reader, mut writer) = stream.into_split();
 
-        let cmd = Command::Toggle;
+        let cmd = Command::Toggle { language: None };
         let encoded = encode_message(&cmd).unwrap();
         writer.write_all(&encoded).await.unwrap();
         writer.shutdown().await.unwrap();


### PR DESCRIPTION
## What

Adds an optional `--language <CODE>` (`-l`) flag to `whisrs toggle`, letting a
single dictation session override `general.language` without editing config or
restarting the daemon.

```
whisrs toggle          # uses general.language
whisrs toggle -l pl    # this session only, in Polish
```

The motivating use case is binding one key per language, e.g. in a compositor:

```
F1 -> whisrs toggle -l en
F2 -> whisrs toggle -l pl
```

## How

- **IPC** (`Command::Toggle`): gains `language: Option<String>`. The internally
  tagged enum plus `#[serde(default, skip_serializing_if = "Option::is_none")]`
  keeps the wire format byte-identical for the no-language case
  (`{"cmd":"toggle"}`), so old/new CLI and daemon stay compatible.
- **CLI**: `toggle` subcommand gains `-l/--language`, forwarded over IPC.
- **Daemon**: `handle_toggle` resolves the effective language once via a new
  `resolve_language()` helper (override else config default) and threads that
  single value into both the backend `TranscriptionConfig` and the
  post-processing `pipeline_language`, removing a duplicated global read. The
  override is consulted only on the Idle->Recording start; a toggle that stops
  recording is unaffected. The batch (non-streaming) path keeps the config
  default. The internal hotkey binding constructs `Toggle { language: None }`.

## Tests

- `resolve_language` override/default.
- JSON round-trip for both `None` (stable `{"cmd":"toggle"}`) and
  `Some("pl")` -> `{"cmd":"toggle","language":"pl"}`.

`cargo test`, `cargo fmt --check`, and `cargo clippy` all pass.

## Docs

README documents `toggle -l/--language` with a per-language key-binding example
for Hyprland and Sway.
