### PR TITLE
fix(local-whisper): silence-delimited phrase segmentation to eliminate repetition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/fixtures/
 crates/*/target/
 crates/*/Cargo.lock
 /docs/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,5 @@ optional = true
 
 [dev-dependencies]
 tempfile = "3"
+# start_paused tests need tokio's paused clock ("test-util" is not in "full").
+tokio = { version = "1", features = ["test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ path = "src/cli/main.rs"
 name = "whisrsd"
 path = "src/daemon/main.rs"
 
+[[example]]
+name = "issue55_stream_check"
+required-features = ["local-whisper"]
+
 [features]
 default = ["local-whisper", "tray", "overlay"]
 local-whisper = ["dep:whisper-rs"]

--- a/README.md
+++ b/README.md
@@ -157,10 +157,12 @@ bindsym $mod+w exec whisrs toggle
 | **OpenAI Realtime** | Cloud (WebSocket) | True streaming | Paid | Best UX, text as you speak |
 | **OpenAI REST** | Cloud | Batch | Paid | Simple fallback |
 | **OpenAI-compatible Realtime** | External WebSocket | Completed-utterance realtime | Free / self-hosted | Lemonade and similar OpenAI-style ASR servers |
-| **Local whisper.cpp** | Local (CPU/GPU) | Sliding window | Free | Privacy, offline use |
+| **Local whisper.cpp** | Local (CPU/GPU) | Silence-split phrases | Free | Privacy, offline use |
 | **ASR sidecar** | Local sidecar | Batch | Free | Bring-your-own local ASR (Moonshine, Parakeet, VibeVoice-ASR, …) |
 
 Groq is the default. For fully offline use, run `whisrs setup` and select **Local > whisper.cpp** — `base.en` (142 MB, ~388 MB RAM) is recommended; `tiny.en` (75 MB) for low-end hardware, `small.en` (466 MB) for higher accuracy.
+
+Local whisper.cpp streams by splitting dictation into phrases at natural pauses and decoding each phrase exactly once (the `[local-whisper]` defaults `segmentation = "silence"`, `phrase_silence_ms = 400`); set `segmentation = "window"` for the legacy overlapping sliding window. See [docs/configuration.md](docs/configuration.md).
 
 For local ASR models without a Rust runtime (Moonshine, NVIDIA Parakeet, Microsoft VibeVoice-ASR), use the generic ASR sidecar backend — it talks to a small local HTTP service that hosts the model. See [`contrib/asr-sidecars/`](contrib/asr-sidecars/) for ready-to-run sidecars.
 

--- a/crates/asr-dedup/src/lib.rs
+++ b/crates/asr-dedup/src/lib.rs
@@ -617,4 +617,155 @@ mod tests {
         // Index past the end clamps to len.
         assert_eq!(floor_char_boundary(s, 100), s.len());
     }
+
+    // ─── Issue #55 reproductions ─────────────────────────────────────────
+    //
+    // These tests DOCUMENT CURRENT BUGGY BEHAVIOR of the sliding-window
+    // text dedup (https://github.com/y0sif/whisrs/issues/55: local whisper
+    // repeats phrases / types invented text). Each assertion pins what the
+    // code does *today* so the suite stays green; the comment above each
+    // assertion states the desired behavior. When the dedup fix lands,
+    // FLIP these assertions to the desired outputs.
+    //
+    // Root causes exercised here:
+    //   1. Anchors are only suffixes of the previous window's FINAL words
+    //      (remove_overlap builds every anchor ending at prev's last word),
+    //      so when whisper re-words the tail of the previous window, no
+    //      anchor matches and dedup fails OPEN — the entire new window is
+    //      emitted, duplicating everything already typed.
+    //   2. The anchor is only searched in the first 75% of the new text
+    //      (`search_limit`), so a long verbatim overlap is never found.
+    //   3. Nothing tracks what was already EMITTED beyond the previous
+    //      window's tail, so a hallucinated echo of an earlier phrase
+    //      sails through.
+    //   4. `recent_text` persists across pauses, so a coincidental phrase
+    //      reuse in a brand-new utterance is treated as overlap and the
+    //      novel words before it are silently DELETED.
+    mod issue_55_repro {
+        use super::*;
+
+        #[test]
+        fn issue_55_repro_rephrased_tail_fails_open() {
+            // Window N's audio cut off mid-phrase, so whisper guessed a tail
+            // ("if this is...") that window N+1 — hearing more audio — re-words
+            // as "if this might be actually enough". Every anchor is a suffix
+            // ending at prev's final word "is...", which never appears in the
+            // new text, so all anchor lengths (8..=3) fail. The strict
+            // prefix-alignment fallback also fails (the two windows share a
+            // *prefix*, not a prev-suffix == new-prefix alignment). Dedup
+            // fails open and returns the ENTIRE new window.
+            //
+            // This reproduces the duplicated sentence from issue #55:
+            //   "Well, let me try to figure out if this is... Well, let me
+            //    try to figure out if this might be actually enough. ..."
+            let mut tracker = TextDedup::new();
+            tracker.filter_text("Well, let me try to figure out if this is...");
+            let result = tracker.filter_text(
+                "Well, let me try to figure out if this might be actually enough. \
+                 So anyways, I typed my code in the description.",
+            );
+            // BUG (current behavior): the full window is emitted, so the user
+            // sees "Well, let me try to figure out ..." typed twice.
+            // DESIRED after fix: only the novel continuation, e.g.
+            // "might be actually enough. So anyways, I typed my code in the
+            // description." — the repeated stem must not be re-emitted.
+            assert_eq!(
+                result,
+                "Well, let me try to figure out if this might be actually enough. \
+                 So anyways, I typed my code in the description."
+            );
+        }
+
+        #[test]
+        fn issue_55_surviving_tail_anchor_still_matches() {
+            // Contrast case (asserts CORRECT behavior — keep green after the
+            // fix): when prev's final words survive verbatim in the new
+            // window, the anchor search works. Here the 4-word anchor
+            // ["might","be","actually","enough."] is found at position 9,
+            // within search_limit (16 of 22 words), even though the longer
+            // anchors (8..=5, which straddle the dropped "is...") all fail.
+            // The rephrased-tail bug above only strikes when the rephrase
+            // reaches prev's LAST words.
+            let mut tracker = TextDedup::new();
+            tracker.filter_text(
+                "Well, let me try to figure out if this is... might be actually enough.",
+            );
+            let result = tracker.filter_text(
+                "Well, let me try to figure out if this might be actually enough. \
+                 So anyways, I typed my code in the description.",
+            );
+            assert_eq!(result, "So anyways, I typed my code in the description.");
+        }
+
+        #[test]
+        fn issue_55_repro_long_overlap_beyond_search_limit_fails_open() {
+            // The new window repeats 39 words of the previous window VERBATIM,
+            // then adds two new words. The anchor (prev's last 3..=8 words)
+            // sits at positions 31..=36 of the 41-word new text, but the
+            // search stops at search_limit = 41 * 3/4 = 30 — so the anchor is
+            // never found despite being textually identical. The strict
+            // prefix fallback dies on the first word ("Okay" vs "Look,", a
+            // typical whisper re-hearing of a window that now starts
+            // mid-word). Dedup fails open: all 39 already-typed words are
+            // emitted again.
+            let prev = "Okay so today I want to walk through the entire deployment \
+                        pipeline because several people asked how the staging \
+                        environment gets promoted into production and honestly the \
+                        documentation we have right now does not explain any of it \
+                        clearly";
+            let new = "Look, so today I want to walk through the entire deployment \
+                       pipeline because several people asked how the staging \
+                       environment gets promoted into production and honestly the \
+                       documentation we have right now does not explain any of it \
+                       clearly which hurts.";
+            let mut tracker = TextDedup::new();
+            tracker.filter_text(prev);
+            let result = tracker.filter_text(new);
+            // BUG (current behavior): the entire new window comes back.
+            // DESIRED after fix: only the novel suffix "which hurts.".
+            assert_eq!(result, new);
+        }
+
+        #[test]
+        fn issue_55_repro_resurrected_earlier_phrase_passes_dedup() {
+            // Prompt-echo / invented text: the previous window ended normally,
+            // and the new window ends with a hallucinated resurrection of a
+            // phrase emitted TWO windows ago ("Might be actually enough." —
+            // the trailing invented line from the issue #55 transcript).
+            // Anchors only cover prev's last 3..=8 words, so once prev's tail
+            // is correctly stripped (7-word anchor matches at position 0),
+            // everything after it is emitted — including the echo of older
+            // text that dedup has no memory of.
+            let mut tracker = TextDedup::new();
+            tracker.filter_text("So anyways, I typed my code in the description.");
+            let result = tracker
+                .filter_text("I typed my code in the description. Might be actually enough.");
+            // BUG (current behavior): the resurrected phrase is typed again.
+            // DESIRED after fix: text repeating anything already emitted
+            // (not just prev's tail) should be suppressed → "".
+            assert_eq!(result, "Might be actually enough.");
+        }
+
+        #[test]
+        fn issue_55_repro_stale_anchor_after_pause_deletes_novel_words() {
+            // Stale state across a pause: the tracker still holds the last
+            // window of the PREVIOUS utterance. The user then starts a
+            // brand-new sentence that happens to reuse the phrase "check the
+            // reports". The 4-word anchor ["to","check","the","reports"]
+            // coincidentally matches at position 4 of the new text, so
+            // everything up to and including it is treated as overlap and
+            // silently DELETED — eight legitimate words are never typed.
+            let mut tracker = TextDedup::new();
+            tracker.filter_text("Please remember to check the reports");
+            // ... user pauses; a new utterance begins ...
+            let result = tracker
+                .filter_text("Yesterday I asked him to check the reports again before the meeting");
+            // BUG (current behavior): "Yesterday I asked him to check the
+            // reports" is swallowed; only the trailing words survive.
+            // DESIRED after fix: the full new sentence is emitted (fresh
+            // utterance — state should reset on pause, and a mid-text match
+            // must not discard the novel words before it).
+            assert_eq!(result, "again before the meeting");
+        }
+    }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,15 @@ turn_detection = "server-vad"  # recommended; see notes below
 
 [local-whisper]
 model_path = "~/.local/share/whisrs/models/ggml-base.en.bin"
+# segmentation: how streaming audio is split before decoding.
+# - "silence" (default): split into phrases at natural pauses and decode each
+#   phrase exactly once. No overlap, no dedup — prevents repeated/invented
+#   text. Continuous speech is force-split at 20 s so it still emits.
+# - "window": legacy 8s/2s overlapping sliding window with text-based dedup.
+# segmentation = "silence"
+# phrase_silence_ms: continuous silence (ms) that ends a phrase in "silence"
+# mode. Lower = snappier output, higher = fewer mid-sentence splits.
+# phrase_silence_ms = 400
 
 # Generic local ASR sidecar — talks to a small HTTP service that hosts the
 # model (Moonshine, NVIDIA Parakeet, Microsoft VibeVoice-ASR, …). Keeps

--- a/examples/issue55_stream_check.rs
+++ b/examples/issue55_stream_check.rs
@@ -15,8 +15,16 @@
 //!   MODEL_PATH  ~/.local/share/whisrs/models/ggml-base.en.bin ($WHISRS_ISSUE55_MODEL)
 //!   TRUTH_PATH  fixtures/issue55.txt if present             ($WHISRS_ISSUE55_TRUTH)
 //!
-//! Exit code: 0 if the transcript is clean, 1 if repetition was detected —
-//! so once the bug is fixed this doubles as a regression check.
+//! Extra env knobs:
+//!   WHISRS_ISSUE55_SEGMENTATION       "silence" (default) | "window"
+//!   WHISRS_ISSUE55_PHRASE_SILENCE_MS  phrase split threshold (default 400)
+//!   WHISRS_ISSUE55_MIN_COVERAGE       if set (e.g. "0.8"), fail when less
+//!                                     than that fraction of ground-truth
+//!                                     words appears in the transcript
+//!
+//! Exit code: 0 if the transcript is clean (and coverage passes when
+//! required), 1 otherwise — so once the bug is fixed this doubles as a
+//! regression check.
 
 use std::collections::HashMap;
 use std::process::ExitCode;
@@ -136,6 +144,28 @@ fn inserted_words(transcript: &[String], truth: &[String]) -> Vec<(String, usize
     out
 }
 
+/// Fraction of ground-truth words present in the transcript (multiset:
+/// each transcript word can satisfy at most one truth occurrence).
+fn truth_coverage(transcript: &[String], truth: &[String]) -> f64 {
+    if truth.is_empty() {
+        return 1.0;
+    }
+    let mut available: HashMap<&str, usize> = HashMap::new();
+    for w in transcript {
+        *available.entry(w.as_str()).or_default() += 1;
+    }
+    let mut matched = 0usize;
+    for w in truth {
+        if let Some(c) = available.get_mut(w.as_str()) {
+            if *c > 0 {
+                *c -= 1;
+                matched += 1;
+            }
+        }
+    }
+    matched as f64 / truth.len() as f64
+}
+
 fn read_wav_samples(path: &str) -> anyhow::Result<Vec<i16>> {
     let reader = hound::WavReader::open(path)
         .map_err(|e| anyhow::anyhow!("failed to open WAV {path}: {e}"))?;
@@ -183,16 +213,28 @@ async fn main() -> anyhow::Result<ExitCode> {
                 .then(|| default.to_string())
         });
 
+    let segmentation =
+        std::env::var("WHISRS_ISSUE55_SEGMENTATION").unwrap_or_else(|_| "silence".to_string());
+    let phrase_silence_ms: u64 = std::env::var("WHISRS_ISSUE55_PHRASE_SILENCE_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(400);
+    let min_coverage: Option<f64> = std::env::var("WHISRS_ISSUE55_MIN_COVERAGE")
+        .ok()
+        .and_then(|v| v.parse().ok());
+
     let samples = read_wav_samples(&wav_path)?;
     println!(
         "== issue #55 stream check ==\n\
          wav:   {wav_path} ({:.1}s, {} samples)\n\
-         model: {model_path}",
+         model: {model_path}\n\
+         mode:  {segmentation} (phrase_silence_ms={phrase_silence_ms})",
         samples.len() as f64 / 16_000.0,
         samples.len(),
     );
 
-    let backend = LocalWhisperBackend::new(model_path);
+    let backend =
+        LocalWhisperBackend::new(model_path).with_segmentation(&segmentation, phrase_silence_ms);
     let config = TranscriptionConfig {
         language: "en".to_string(),
         model: "base.en".to_string(),
@@ -222,7 +264,7 @@ async fn main() -> anyhow::Result<ExitCode> {
     backend_task.await??;
     let chunks = collector.await?;
 
-    println!("\n-- per-window emissions ({}) --", chunks.len());
+    println!("\n-- emitted batches ({}) --", chunks.len());
     for (i, c) in chunks.iter().enumerate() {
         println!("[{i:>2}] {c:?}");
     }
@@ -262,8 +304,32 @@ async fn main() -> anyhow::Result<ExitCode> {
         }
     }
 
+    let mut coverage_failed = false;
+    if let Some(truth_words) = &truth_words {
+        let coverage = truth_coverage(&words, truth_words);
+        println!("\n-- ground-truth coverage --");
+        println!(
+            "{:.1}% of {} truth words present in transcript",
+            coverage * 100.0,
+            truth_words.len()
+        );
+        if let Some(min) = min_coverage {
+            if coverage < min {
+                println!(
+                    "COVERAGE FAIL: {:.1}% < required {:.1}%",
+                    coverage * 100.0,
+                    min * 100.0
+                );
+                coverage_failed = true;
+            }
+        }
+    }
+
     if repetition_found {
         println!("\nRESULT: FAIL — repetition detected (issue #55 reproduced)");
+        Ok(ExitCode::from(1))
+    } else if coverage_failed {
+        println!("\nRESULT: FAIL — transcript does not cover the full utterance");
         Ok(ExitCode::from(1))
     } else {
         println!("\nRESULT: OK — transcript is repetition-free");

--- a/examples/issue55_stream_check.rs
+++ b/examples/issue55_stream_check.rs
@@ -1,0 +1,272 @@
+//! Scripted repro harness for issue #55: local whisper streaming produces
+//! repeated/invented text, worse when the speaker pauses.
+//!
+//! Feeds a WAV file through `LocalWhisperBackend::transcribe_stream` exactly
+//! the way the daemon does (i16 16 kHz mono chunks over an mpsc channel),
+//! joins the emitted text with the daemon's spacing rule, then runs a
+//! repetition detector over the final transcript.
+//!
+//! Usage:
+//!   cargo run --release --example issue55_stream_check --features local-whisper -- \
+//!       [WAV_PATH] [MODEL_PATH] [TRUTH_PATH]
+//!
+//! Defaults (overridable via env):
+//!   WAV_PATH    fixtures/issue55.wav                        ($WHISRS_ISSUE55_WAV)
+//!   MODEL_PATH  ~/.local/share/whisrs/models/ggml-base.en.bin ($WHISRS_ISSUE55_MODEL)
+//!   TRUTH_PATH  fixtures/issue55.txt if present             ($WHISRS_ISSUE55_TRUTH)
+//!
+//! Exit code: 0 if the transcript is clean, 1 if repetition was detected —
+//! so once the bug is fixed this doubles as a regression check.
+
+use std::collections::HashMap;
+use std::process::ExitCode;
+
+use tokio::sync::mpsc;
+use whisrs::transcription::{
+    local_whisper::LocalWhisperBackend, TranscriptionBackend, TranscriptionConfig,
+};
+
+/// 100 ms of 16 kHz mono audio — the granularity the daemon's capture layer
+/// delivers. The streaming loop is buffer-length driven, so no real-time
+/// pacing is needed: all windows still fire in order.
+const CHUNK_SAMPLES: usize = 1600;
+
+/// N-gram sizes checked by the repetition detector.
+const NGRAM_RANGE: std::ops::RangeInclusive<usize> = 3..=6;
+
+fn default_model_path() -> String {
+    dirs::data_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("whisrs/models/ggml-base.en.bin")
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Mirror of the daemon's `leads_with_punct` (src/daemon/main.rs): batches
+/// that lead with punctuation don't get a space inserted before them.
+fn leads_with_punct(text: &str) -> bool {
+    text.starts_with([
+        '.', ',', '!', '?', ';', ':', ')', ']', '}', '。', '，', '！', '？', '；', '：', '）',
+        '】', '｝', '…', '\u{2019}', '\u{201D}',
+    ])
+}
+
+/// Join emitted chunks the way the daemon's typing task does: each chunk is
+/// one batch; a space is inserted between batches unless the boundary already
+/// has one or the batch leads with punctuation.
+fn join_daemon_style(chunks: &[String]) -> String {
+    let mut full = String::new();
+    for batch in chunks {
+        if batch.is_empty() {
+            continue;
+        }
+        if full.is_empty()
+            || batch.starts_with(' ')
+            || full.ends_with(' ')
+            || leads_with_punct(batch)
+        {
+            full.push_str(batch);
+        } else {
+            full.push(' ');
+            full.push_str(batch);
+        }
+    }
+    full
+}
+
+/// Case- and punctuation-insensitive word list (apostrophes kept).
+fn normalize_words(text: &str) -> Vec<String> {
+    text.to_lowercase()
+        .split_whitespace()
+        .map(|w| {
+            w.chars()
+                .filter(|c| c.is_alphanumeric() || *c == '\'')
+                .collect::<String>()
+        })
+        .filter(|w| !w.is_empty())
+        .collect()
+}
+
+fn ngram_counts(words: &[String], n: usize) -> HashMap<String, usize> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for win in words.windows(n) {
+        *counts.entry(win.join(" ")).or_default() += 1;
+    }
+    counts
+}
+
+/// N-grams that occur more often in the transcript than in the ground truth
+/// (or more than once when no ground truth is available).
+fn repeated_ngrams(
+    transcript: &[String],
+    truth: Option<&[String]>,
+    n: usize,
+) -> Vec<(String, usize, usize)> {
+    let counts = ngram_counts(transcript, n);
+    let truth_counts = truth.map(|t| ngram_counts(t, n));
+    let mut out: Vec<(String, usize, usize)> = counts
+        .into_iter()
+        .filter_map(|(gram, count)| {
+            let allowed = truth_counts
+                .as_ref()
+                .map_or(1, |tc| tc.get(&gram).copied().unwrap_or(0).max(1));
+            (count > allowed).then_some((gram, count, allowed))
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Multiset difference: words in the transcript that exceed their ground-truth
+/// occurrence count (invented/inserted words).
+fn inserted_words(transcript: &[String], truth: &[String]) -> Vec<(String, usize)> {
+    let mut budget: HashMap<&str, usize> = HashMap::new();
+    for w in truth {
+        *budget.entry(w.as_str()).or_default() += 1;
+    }
+    let mut extra: HashMap<String, usize> = HashMap::new();
+    for w in transcript {
+        match budget.get_mut(w.as_str()) {
+            Some(c) if *c > 0 => *c -= 1,
+            _ => *extra.entry(w.clone()).or_default() += 1,
+        }
+    }
+    let mut out: Vec<(String, usize)> = extra.into_iter().collect();
+    out.sort();
+    out
+}
+
+fn read_wav_samples(path: &str) -> anyhow::Result<Vec<i16>> {
+    let reader = hound::WavReader::open(path)
+        .map_err(|e| anyhow::anyhow!("failed to open WAV {path}: {e}"))?;
+    let spec = reader.spec();
+    anyhow::ensure!(
+        spec.channels == 1
+            && spec.sample_rate == 16_000
+            && spec.bits_per_sample == 16
+            && spec.sample_format == hound::SampleFormat::Int,
+        "expected 16 kHz mono s16 WAV, got {} Hz {} ch {} bit {:?} — \
+         regenerate with scripts/gen-issue55-fixture.sh",
+        spec.sample_rate,
+        spec.channels,
+        spec.bits_per_sample,
+        spec.sample_format,
+    );
+    Ok(reader.into_samples::<i16>().collect::<Result<_, _>>()?)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<ExitCode> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let mut args = std::env::args().skip(1);
+    let wav_path = args
+        .next()
+        .or_else(|| std::env::var("WHISRS_ISSUE55_WAV").ok())
+        .unwrap_or_else(|| "fixtures/issue55.wav".to_string());
+    let model_path = args
+        .next()
+        .or_else(|| std::env::var("WHISRS_ISSUE55_MODEL").ok())
+        .unwrap_or_else(default_model_path);
+    let truth_path = args
+        .next()
+        .or_else(|| std::env::var("WHISRS_ISSUE55_TRUTH").ok())
+        .or_else(|| {
+            let default = "fixtures/issue55.txt";
+            std::path::Path::new(default)
+                .exists()
+                .then(|| default.to_string())
+        });
+
+    let samples = read_wav_samples(&wav_path)?;
+    println!(
+        "== issue #55 stream check ==\n\
+         wav:   {wav_path} ({:.1}s, {} samples)\n\
+         model: {model_path}",
+        samples.len() as f64 / 16_000.0,
+        samples.len(),
+    );
+
+    let backend = LocalWhisperBackend::new(model_path);
+    let config = TranscriptionConfig {
+        language: "en".to_string(),
+        model: "base.en".to_string(),
+        prompt: None,
+    };
+
+    let (audio_tx, audio_rx) = mpsc::channel::<Vec<i16>>(256);
+    let (text_tx, mut text_rx) = mpsc::channel::<String>(64);
+
+    let backend_task =
+        tokio::spawn(async move { backend.transcribe_stream(audio_rx, text_tx, &config).await });
+    let collector = tokio::spawn(async move {
+        let mut chunks: Vec<String> = Vec::new();
+        while let Some(t) = text_rx.recv().await {
+            chunks.push(t);
+        }
+        chunks
+    });
+
+    for chunk in samples.chunks(CHUNK_SAMPLES) {
+        if audio_tx.send(chunk.to_vec()).await.is_err() {
+            break; // backend hung up (e.g. model failed to load)
+        }
+    }
+    drop(audio_tx);
+
+    backend_task.await??;
+    let chunks = collector.await?;
+
+    println!("\n-- per-window emissions ({}) --", chunks.len());
+    for (i, c) in chunks.iter().enumerate() {
+        println!("[{i:>2}] {c:?}");
+    }
+
+    let transcript = join_daemon_style(&chunks);
+    println!("\n-- final joined transcript --\n{transcript}");
+
+    let truth_text = match &truth_path {
+        Some(p) => Some(std::fs::read_to_string(p)?),
+        None => None,
+    };
+    let words = normalize_words(&transcript);
+    let truth_words = truth_text.as_deref().map(normalize_words);
+
+    println!("\n-- repetition detector (n-grams, case/punct-insensitive) --");
+    let mut repetition_found = false;
+    for n in NGRAM_RANGE {
+        let reps = repeated_ngrams(&words, truth_words.as_deref(), n);
+        for (gram, count, allowed) in &reps {
+            println!("REPEATED {n}-gram x{count} (expected <= {allowed}): {gram:?}");
+            repetition_found = true;
+        }
+    }
+    if !repetition_found {
+        println!("no repeated n-grams detected");
+    }
+
+    if let Some(truth_words) = &truth_words {
+        println!("\n-- inserted words vs ground truth ({:?}) --", truth_path);
+        let inserted = inserted_words(&words, truth_words);
+        if inserted.is_empty() {
+            println!("no inserted words");
+        } else {
+            for (w, count) in &inserted {
+                println!("INSERTED x{count}: {w:?}");
+            }
+        }
+    }
+
+    if repetition_found {
+        println!("\nRESULT: FAIL — repetition detected (issue #55 reproduced)");
+        Ok(ExitCode::from(1))
+    } else {
+        println!("\nRESULT: OK — transcript is repetition-free");
+        Ok(ExitCode::SUCCESS)
+    }
+}

--- a/scripts/check-issue55.sh
+++ b/scripts/check-issue55.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # whisrs check-issue55 — scripted sanity check for issue #55.
 #
-# Generates the synthetic dictation fixture (if missing) and streams it
-# through LocalWhisperBackend the same way the daemon does, then scans the
-# transcript for repeated n-grams and invented words. No microphone or
-# manual dictation needed.
+# Generates the synthetic dictation fixtures (if missing) and streams them
+# through LocalWhisperBackend the same way the daemon does:
 #
-# Exit code: 0 = transcript clean, 1 = repetition detected (bug reproduced).
+#   1. issue55.wav          pause-heavy dictation — must transcribe with no
+#                           repeated n-grams (the original issue #55 repro).
+#   2. issue55_nopause.wav  ~28 s of continuous pause-free speech — must be
+#                           transcribed in full (>= 80% ground-truth word
+#                           coverage), proving the 20 s max-segment cap emits
+#                           instead of stalling.
+#
+# Exit code: 0 = both checks pass, 1 = at least one failed.
 #
 # Usage:
 #   ./scripts/check-issue55.sh                 # uses ~/.local/share/whisrs/models/ggml-base.en.bin
@@ -17,9 +22,11 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WAV="$REPO_ROOT/fixtures/issue55.wav"
 TRUTH="$REPO_ROOT/fixtures/issue55.txt"
+NP_WAV="$REPO_ROOT/fixtures/issue55_nopause.wav"
+NP_TRUTH="$REPO_ROOT/fixtures/issue55_nopause.txt"
 MODEL="${WHISRS_ISSUE55_MODEL:-$HOME/.local/share/whisrs/models/ggml-base.en.bin}"
 
-if [ ! -f "$WAV" ]; then
+if [ ! -f "$WAV" ] || [ ! -f "$NP_WAV" ]; then
     "$REPO_ROOT/scripts/gen-issue55-fixture.sh"
 fi
 
@@ -30,5 +37,34 @@ if [ ! -f "$MODEL" ]; then
 fi
 
 cd "$REPO_ROOT"
-exec cargo run --release --example issue55_stream_check --features local-whisper -- \
-    "$WAV" "$MODEL" "$TRUTH"
+cargo build --release --example issue55_stream_check --features local-whisper
+BIN="$REPO_ROOT/target/release/examples/issue55_stream_check"
+
+echo
+echo "=== 1/2 pause fixture (repetition gate) ==="
+pause_status=0
+"$BIN" "$WAV" "$MODEL" "$TRUTH" || pause_status=$?
+
+echo
+echo "=== 2/2 no-pause fixture (coverage gate, 20s cap) ==="
+nopause_status=0
+WHISRS_ISSUE55_MIN_COVERAGE=0.8 "$BIN" "$NP_WAV" "$MODEL" "$NP_TRUTH" \
+    || nopause_status=$?
+
+echo
+echo "=== summary ==="
+if [ "$pause_status" -eq 0 ]; then
+    echo "pause fixture:    OK"
+else
+    echo "pause fixture:    FAIL (exit $pause_status)"
+fi
+if [ "$nopause_status" -eq 0 ]; then
+    echo "no-pause fixture: OK"
+else
+    echo "no-pause fixture: FAIL (exit $nopause_status)"
+fi
+
+if [ "$pause_status" -ne 0 ] || [ "$nopause_status" -ne 0 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/check-issue55.sh
+++ b/scripts/check-issue55.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# whisrs check-issue55 — scripted sanity check for issue #55.
+#
+# Generates the synthetic dictation fixture (if missing) and streams it
+# through LocalWhisperBackend the same way the daemon does, then scans the
+# transcript for repeated n-grams and invented words. No microphone or
+# manual dictation needed.
+#
+# Exit code: 0 = transcript clean, 1 = repetition detected (bug reproduced).
+#
+# Usage:
+#   ./scripts/check-issue55.sh                 # uses ~/.local/share/whisrs/models/ggml-base.en.bin
+#   WHISRS_ISSUE55_MODEL=/path/to/model.bin ./scripts/check-issue55.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WAV="$REPO_ROOT/fixtures/issue55.wav"
+TRUTH="$REPO_ROOT/fixtures/issue55.txt"
+MODEL="${WHISRS_ISSUE55_MODEL:-$HOME/.local/share/whisrs/models/ggml-base.en.bin}"
+
+if [ ! -f "$WAV" ]; then
+    "$REPO_ROOT/scripts/gen-issue55-fixture.sh"
+fi
+
+if [ ! -f "$MODEL" ]; then
+    echo "Model not found: $MODEL" >&2
+    echo "Run 'whisrs setup' to download one, or set WHISRS_ISSUE55_MODEL." >&2
+    exit 2
+fi
+
+cd "$REPO_ROOT"
+exec cargo run --release --example issue55_stream_check --features local-whisper -- \
+    "$WAV" "$MODEL" "$TRUTH"

--- a/scripts/check-issue55.sh
+++ b/scripts/check-issue55.sh
@@ -5,7 +5,9 @@
 # through LocalWhisperBackend the same way the daemon does:
 #
 #   1. issue55.wav          pause-heavy dictation — must transcribe with no
-#                           repeated n-grams (the original issue #55 repro).
+#                           repeated n-grams (the original issue #55 repro)
+#                           and >= 80% ground-truth word coverage, so silently
+#                           dropped words fail too.
 #   2. issue55_nopause.wav  ~28 s of continuous pause-free speech — must be
 #                           transcribed in full (>= 80% ground-truth word
 #                           coverage), proving the 20 s max-segment cap emits
@@ -41,9 +43,10 @@ cargo build --release --example issue55_stream_check --features local-whisper
 BIN="$REPO_ROOT/target/release/examples/issue55_stream_check"
 
 echo
-echo "=== 1/2 pause fixture (repetition gate) ==="
+echo "=== 1/2 pause fixture (repetition + coverage gate) ==="
 pause_status=0
-"$BIN" "$WAV" "$MODEL" "$TRUTH" || pause_status=$?
+WHISRS_ISSUE55_MIN_COVERAGE=0.8 "$BIN" "$WAV" "$MODEL" "$TRUTH" \
+    || pause_status=$?
 
 echo
 echo "=== 2/2 no-pause fixture (coverage gate, 20s cap) ==="

--- a/scripts/gen-issue55-fixture.sh
+++ b/scripts/gen-issue55-fixture.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# whisrs gen-issue55-fixture — synthesize the audio fixture for issue #55.
+#
+# Builds a 16 kHz mono s16 WAV that mimics the dictation pattern from
+# https://github.com/y0sif/whisrs/issues/55: several slow-paced sentences
+# separated by 2-6 s silence gaps, including a trailing incomplete phrase
+# right before a pause (the golden repro for the repetition bug).
+#
+# Output (gitignored, never commit the WAV):
+#   fixtures/issue55.wav   16 kHz mono s16 test audio (~45 s)
+#   fixtures/issue55.txt   ground-truth transcript (one line)
+#
+# Requires: espeak-ng, ffmpeg
+#
+# Usage:
+#   ./scripts/gen-issue55-fixture.sh          # writes fixtures/issue55.wav
+#   ./scripts/gen-issue55-fixture.sh --force  # regenerate even if present
+
+set -euo pipefail
+
+GREEN='\033[32m'
+RED='\033[31m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()  { echo -e "  ${GREEN}${BOLD}$1${RESET} $2"; }
+error() { echo -e "  ${RED}$1${RESET}"; }
+
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        -h|--help)
+            sed -n '2,17p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            error "Unknown flag: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+for tool in espeak-ng ffmpeg; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        error "Missing required tool: $tool"
+        exit 1
+    fi
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE_DIR="$REPO_ROOT/fixtures"
+OUT_WAV="$FIXTURE_DIR/issue55.wav"
+OUT_TXT="$FIXTURE_DIR/issue55.txt"
+
+if [ -f "$OUT_WAV" ] && [ "$FORCE" -eq 0 ]; then
+    info "Exists:" "$OUT_WAV (use --force to regenerate)"
+    exit 0
+fi
+
+mkdir -p "$FIXTURE_DIR"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Spoken segments and the silence gap (seconds) inserted AFTER each one.
+# Segments 1 and 5 deliberately stop mid-sentence before a long pause —
+# the exact condition issue #55 reports as the worst offender.
+SEGMENTS=(
+    "Well, let me try to figure out if this is"
+    "might be actually enough to reproduce the problem."
+    "The quick brown fox jumps over the lazy dog."
+    "Today I am testing the local whisper streaming backend."
+    "Sometimes I pause in the middle of a"
+    "sentence and then continue talking after a while."
+    "This is the final sentence of the recording."
+)
+PAUSES=(4 3 5 2.5 4 3 0.8)
+
+# Slow-ish pacing (default espeak-ng speed is 175 wpm).
+ESPEAK_VOICE="en-us"
+ESPEAK_SPEED=130
+
+silence() { # silence <seconds> <outfile>
+    ffmpeg -loglevel error -y \
+        -f lavfi -i anullsrc=channel_layout=mono:sample_rate=16000 \
+        -t "$1" -c:a pcm_s16le "$2"
+}
+
+CONCAT_LIST="$WORK_DIR/concat.txt"
+: > "$CONCAT_LIST"
+
+# Short lead-in silence so speech doesn't start at sample zero.
+silence 0.3 "$WORK_DIR/lead.wav"
+echo "file '$WORK_DIR/lead.wav'" >> "$CONCAT_LIST"
+
+for i in "${!SEGMENTS[@]}"; do
+    raw="$WORK_DIR/raw_$i.wav"
+    seg="$WORK_DIR/seg_$i.wav"
+    gap="$WORK_DIR/gap_$i.wav"
+
+    espeak-ng -v "$ESPEAK_VOICE" -s "$ESPEAK_SPEED" -w "$raw" "${SEGMENTS[$i]}"
+    # Resample espeak-ng output (22.05 kHz) to the pipeline's 16 kHz mono s16.
+    ffmpeg -loglevel error -y -i "$raw" -ar 16000 -ac 1 -c:a pcm_s16le "$seg"
+    echo "file '$seg'" >> "$CONCAT_LIST"
+
+    silence "${PAUSES[$i]}" "$gap"
+    echo "file '$gap'" >> "$CONCAT_LIST"
+done
+
+ffmpeg -loglevel error -y -f concat -safe 0 -i "$CONCAT_LIST" -c copy "$OUT_WAV"
+
+# Ground truth: the segments joined with single spaces, one line.
+printf '%s\n' "$(IFS=' '; echo "${SEGMENTS[*]}")" > "$OUT_TXT"
+
+DURATION="$(ffprobe -loglevel error -show_entries format=duration \
+    -of default=noprint_wrappers=1:nokey=1 "$OUT_WAV")"
+
+info "Wrote:" "$OUT_WAV (${DURATION%.*}s, 16 kHz mono s16)"
+info "Wrote:" "$OUT_TXT (ground truth)"

--- a/scripts/gen-issue55-fixture.sh
+++ b/scripts/gen-issue55-fixture.sh
@@ -6,14 +6,19 @@
 # separated by 2-6 s silence gaps, including a trailing incomplete phrase
 # right before a pause (the golden repro for the repetition bug).
 #
-# Output (gitignored, never commit the WAV):
-#   fixtures/issue55.wav   16 kHz mono s16 test audio (~45 s)
-#   fixtures/issue55.txt   ground-truth transcript (one line)
+# Also builds a continuous no-pause fixture (~28 s of speech with no gaps)
+# used to prove that pause-free dictation still emits (20 s max-segment cap).
+#
+# Output (gitignored, never commit the WAVs):
+#   fixtures/issue55.wav           16 kHz mono s16 test audio (~45 s, pauses)
+#   fixtures/issue55.txt           ground-truth transcript (one line)
+#   fixtures/issue55_nopause.wav   16 kHz mono s16 test audio (~28 s, no gaps)
+#   fixtures/issue55_nopause.txt   ground-truth transcript (one line)
 #
 # Requires: espeak-ng, ffmpeg
 #
 # Usage:
-#   ./scripts/gen-issue55-fixture.sh          # writes fixtures/issue55.wav
+#   ./scripts/gen-issue55-fixture.sh          # writes the fixtures
 #   ./scripts/gen-issue55-fixture.sh --force  # regenerate even if present
 
 set -euo pipefail
@@ -52,9 +57,11 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FIXTURE_DIR="$REPO_ROOT/fixtures"
 OUT_WAV="$FIXTURE_DIR/issue55.wav"
 OUT_TXT="$FIXTURE_DIR/issue55.txt"
+OUT_NP_WAV="$FIXTURE_DIR/issue55_nopause.wav"
+OUT_NP_TXT="$FIXTURE_DIR/issue55_nopause.txt"
 
-if [ -f "$OUT_WAV" ] && [ "$FORCE" -eq 0 ]; then
-    info "Exists:" "$OUT_WAV (use --force to regenerate)"
+if [ -f "$OUT_WAV" ] && [ -f "$OUT_NP_WAV" ] && [ "$FORCE" -eq 0 ]; then
+    info "Exists:" "$OUT_WAV + $OUT_NP_WAV (use --force to regenerate)"
     exit 0
 fi
 
@@ -117,3 +124,40 @@ DURATION="$(ffprobe -loglevel error -show_entries format=duration \
 
 info "Wrote:" "$OUT_WAV (${DURATION%.*}s, 16 kHz mono s16)"
 info "Wrote:" "$OUT_TXT (ground truth)"
+
+# ---------------------------------------------------------------------------
+# Continuous no-pause fixture: one long run-on utterance with no punctuation
+# (espeak-ng inserts pauses at clause boundaries, so the text avoids them).
+# Exercises the streaming max-segment cap: continuous speech past 20 s must
+# still be emitted in full.
+# ---------------------------------------------------------------------------
+NOPAUSE_TEXT="this recording keeps going without any pauses so the streaming \
+backend must split the audio on its own the quick brown fox jumps over the \
+lazy dog while the developer keeps talking about testing the local whisper \
+backend and the words continue to flow one after another until the very end \
+of the recording where the final words prove the whole utterance was \
+transcribed"
+
+NP_RAW="$WORK_DIR/nopause_raw.wav"
+NP_SEG="$WORK_DIR/nopause_seg.wav"
+NP_LIST="$WORK_DIR/nopause_concat.txt"
+
+espeak-ng -v "$ESPEAK_VOICE" -s "$ESPEAK_SPEED" -w "$NP_RAW" "$NOPAUSE_TEXT"
+ffmpeg -loglevel error -y -i "$NP_RAW" -ar 16000 -ac 1 -c:a pcm_s16le "$NP_SEG"
+
+silence 0.3 "$WORK_DIR/np_lead.wav"
+silence 0.5 "$WORK_DIR/np_tail.wav"
+{
+    echo "file '$WORK_DIR/np_lead.wav'"
+    echo "file '$NP_SEG'"
+    echo "file '$WORK_DIR/np_tail.wav'"
+} > "$NP_LIST"
+
+ffmpeg -loglevel error -y -f concat -safe 0 -i "$NP_LIST" -c copy "$OUT_NP_WAV"
+printf '%s\n' "$NOPAUSE_TEXT" > "$OUT_NP_TXT"
+
+NP_DURATION="$(ffprobe -loglevel error -show_entries format=duration \
+    -of default=noprint_wrappers=1:nokey=1 "$OUT_NP_WAV")"
+
+info "Wrote:" "$OUT_NP_WAV (${NP_DURATION%.*}s, 16 kHz mono s16, no pauses)"
+info "Wrote:" "$OUT_NP_TXT (ground truth)"

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -482,7 +482,7 @@ pub(crate) fn configure_backend(
 
             let model_path = dest.to_string_lossy().to_string();
             Ok(BackendConfigSelection {
-                local_whisper: Some(LocalWhisperConfig { model_path }),
+                local_whisper: Some(LocalWhisperConfig::new(model_path)),
                 ..BackendConfigSelection::default()
             })
         }

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -27,7 +27,8 @@ use whisrs::transcription::openai_rest::OpenAIRestBackend;
 use whisrs::transcription::{TranscriptionBackend, TranscriptionConfig};
 use whisrs::window::{self, WindowTracker};
 use whisrs::{
-    encode_message, read_message, socket_path, Command, Config, InjectorBackend, Response, State,
+    encode_message, read_message, socket_path, Command, Config, InjectorBackend,
+    LocalWhisperConfig, Response, State,
 };
 
 static KEYBOARD: OnceLock<StdMutex<Option<Box<dyn xkb_type::KeyInjector>>>> = OnceLock::new();
@@ -482,29 +483,28 @@ fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
             Arc::new(OpenAIRestBackend::new(api_key))
         }
         "local-whisper" | "local" => {
-            let local_whisper = config.local_whisper.as_ref();
-            let model_path = local_whisper
-                .map(|l| l.model_path.clone())
-                .unwrap_or_else(|| {
+            // Serde defaults only apply when the [local-whisper] section
+            // exists; `LocalWhisperConfig::new` supplies the same defaults
+            // for a fully absent section.
+            let local_whisper = config.local_whisper.clone().unwrap_or_else(|| {
+                LocalWhisperConfig::new(
                     dirs::data_dir()
                         .unwrap_or_else(|| std::path::PathBuf::from("~/.local/share"))
                         .join("whisrs/models/ggml-base.en.bin")
                         .to_string_lossy()
-                        .to_string()
-                });
-            // Serde defaults only apply when the [local-whisper] section
-            // exists; mirror them here for a fully absent section.
-            let segmentation = local_whisper
-                .map(|l| l.segmentation.clone())
-                .unwrap_or_else(|| "silence".to_string());
-            let phrase_silence_ms = local_whisper.map(|l| l.phrase_silence_ms).unwrap_or(400);
+                        .to_string(),
+                )
+            });
             info!(
                 "using local whisper transcription backend \
-                 (model: {model_path}, segmentation: {segmentation})"
+                 (model: {}, segmentation: {})",
+                local_whisper.model_path, local_whisper.segmentation
             );
             Arc::new(
-                LocalWhisperBackend::new(model_path)
-                    .with_segmentation(&segmentation, phrase_silence_ms),
+                LocalWhisperBackend::new(local_whisper.model_path).with_segmentation(
+                    &local_whisper.segmentation,
+                    local_whisper.phrase_silence_ms,
+                ),
             )
         }
         "local-vosk" => {

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::Duration;
 
@@ -51,6 +52,15 @@ struct DaemonState {
     recording_window_id: Option<String>,
     /// Handle to the background streaming pipeline (if active).
     streaming_task: Option<tokio::task::JoinHandle<Result<String>>>,
+    /// Cancel flag for the active streaming pipeline.
+    ///
+    /// Aborting `streaming_task` only drops the outer pipeline future — the
+    /// spawned backend and typing tasks are detached JoinHandles that keep
+    /// running, and the backend treats the dropped audio channel as a normal
+    /// end-of-stream (it flushes and the typing task types the trailing
+    /// phrase). Setting this flag makes the typing loop discard everything
+    /// instead, so `cancel` never types text. Created per recording.
+    streaming_cancel: Option<Arc<AtomicBool>>,
     /// When recording started (for duration tracking).
     recording_started_at: Option<std::time::Instant>,
     /// Active command mode context (set when command mode is recording).
@@ -71,6 +81,7 @@ impl DaemonState {
             audio_capture: None,
             recording_window_id: None,
             streaming_task: None,
+            streaming_cancel: None,
             recording_started_at: None,
             command_mode: None,
             tts_stop: None,
@@ -925,6 +936,12 @@ async fn handle_toggle(
                     std::time::Duration::from_millis(context.config.input.key_delay_ms);
                 let pipeline_injector_backend = context.config.input.backend;
 
+                // Per-recording cancel flag: lets `handle_cancel` stop the
+                // typing loop, which keeps running detached when the outer
+                // pipeline future is aborted.
+                let cancel_flag = Arc::new(AtomicBool::new(false));
+                let pipeline_cancel = Arc::clone(&cancel_flag);
+
                 let task = tokio::spawn(async move {
                     run_streaming_pipeline(
                         audio_rx,
@@ -945,11 +962,13 @@ async fn handle_toggle(
                         pipeline_state_tx,
                         pipeline_key_delay,
                         pipeline_injector_backend,
+                        pipeline_cancel,
                     )
                     .await
                 });
 
                 ds.streaming_task = Some(task);
+                ds.streaming_cancel = Some(cancel_flag);
 
                 // Focus the window now (so text goes to the right place from the start).
                 if let Some(wid) = &wid_for_focus {
@@ -980,6 +999,7 @@ async fn handle_toggle(
                     ds.audio_capture = None;
                     ds.recording_window_id = None;
                     ds.streaming_task = None;
+                    ds.streaming_cancel = None;
                     Response::Error {
                         message: e.to_string(),
                     }
@@ -1006,6 +1026,9 @@ async fn handle_toggle(
                     let capture = ds.audio_capture.take();
                     let window_id = ds.recording_window_id.take();
                     let streaming_task = ds.streaming_task.take();
+                    // Normal stop: drop the cancel flag untriggered so the
+                    // pipeline drains and types the remaining text.
+                    ds.streaming_cancel = None;
                     let recording_started_at = ds.recording_started_at.take();
 
                     // Release lock before slow operations.
@@ -1138,13 +1161,14 @@ async fn run_streaming_pipeline(
     state_tx: tokio::sync::watch::Sender<State>,
     key_delay: std::time::Duration,
     injector_backend: InjectorBackend,
+    cancel_flag: Arc<AtomicBool>,
 ) -> Result<String> {
     // State-progress toasts are noise when the overlay is on.
     let notify_state = notify && !overlay_enabled;
     let notify_error = notify;
     let pipeline_start = std::time::Instant::now();
     let (audio_tx, backend_rx) = tokio::sync::mpsc::channel::<Vec<i16>>(256);
-    let (text_tx, mut text_rx) = tokio::sync::mpsc::channel::<String>(64);
+    let (text_tx, text_rx) = tokio::sync::mpsc::channel::<String>(64);
 
     // Build the filler filter once for the lifetime of this pipeline so the
     // batch loop below isn't recompiling regexes on every typed delta.
@@ -1169,81 +1193,41 @@ async fn run_streaming_pipeline(
     // We collect deltas for a short window to avoid creating a new virtual
     // keyboard for every single word delta from the streaming API.
     let wid = window_id.clone();
+    let typing_cancel = Arc::clone(&cancel_flag);
     let typing_task = tokio::spawn(async move {
-        let mut full_text = String::new();
-        let mut focused = false;
-        let batch_delay = std::time::Duration::from_millis(150);
-
-        // The daemon text channel is intentionally append-only. For OpenAI
-        // realtime this still feels token-by-token because the backend emits
-        // stable append deltas. For Lemonade-compatible profiles, the protocol
-        // layer only forwards completed utterances, so this loop naturally
-        // types phrase-sized chunks without needing any replacement semantics.
-        loop {
-            // Wait for the first delta (blocking).
-            let first = text_rx.recv().await;
-            let Some(first) = first else { break };
-
-            // Collect this delta and any others that arrive within the batch window.
-            let mut batch = first;
-            while let Ok(Some(more)) = tokio::time::timeout(batch_delay, text_rx.recv()).await {
-                batch.push_str(&more);
-            }
-
-            if batch.is_empty() {
-                continue;
-            }
-
-            // Apply filler word removal if enabled.
-            if let Some(filter) = filler_filter.as_ref() {
-                batch = filter.apply(&batch);
-                if batch.is_empty() {
-                    continue;
-                }
-            }
-
-            // Focus the original window (only once, or re-focus if needed).
-            if !focused {
-                if let Some(wid) = &wid {
-                    let wid_clone = wid.clone();
-                    let tracker = Arc::clone(&window_tracker);
-                    if let Err(e) = tracker.focus_window(&wid_clone) {
-                        warn!("failed to refocus window {wid_clone} before typing: {e}");
-                    } else {
-                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Focus the original window before the first batch (only once).
+        // Sequenced by the batcher awaiting each sink call, so a plain
+        // atomic is enough to carry the flag into the 'static sink futures.
+        let focused = Arc::new(AtomicBool::new(false));
+        run_typing_batcher(text_rx, typing_cancel, filler_filter, move |text_to_type| {
+            let wid = wid.clone();
+            let tracker = Arc::clone(&window_tracker);
+            let focused = Arc::clone(&focused);
+            async move {
+                // Focus the original window (only once, or re-focus if needed).
+                if !focused.swap(true, Ordering::SeqCst) {
+                    if let Some(wid) = &wid {
+                        if let Err(e) = tracker.focus_window(wid) {
+                            warn!("failed to refocus window {wid} before typing: {e}");
+                        } else {
+                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        }
                     }
                 }
-                focused = true;
+
+                info!("typing: {:?}", text_to_type);
+                match tokio::task::spawn_blocking(move || {
+                    type_text_at_cursor(&text_to_type, key_delay, injector_backend)
+                })
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => warn!("failed to type text: {e:#}"),
+                    Err(e) => warn!("failed to join typing task: {e}"),
+                }
             }
-
-            // Add space separator between turns if needed.
-            // Don't insert a space before punctuation streaming deltas,
-            // as they arrive as bare tokens.
-            let text_to_type = if full_text.is_empty()
-                || batch.starts_with(' ')
-                || full_text.ends_with(' ')
-                || leads_with_punct(&batch)
-            {
-                batch.clone()
-            } else {
-                format!(" {batch}")
-            };
-
-            full_text.push_str(&text_to_type);
-
-            info!("typing: {:?}", text_to_type);
-            match tokio::task::spawn_blocking(move || {
-                type_text_at_cursor(&text_to_type, key_delay, injector_backend)
-            })
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => warn!("failed to type text: {e:#}",),
-                Err(e) => warn!("failed to join typing task: {e}"),
-            }
-        }
-
-        full_text
+        })
+        .await
     });
 
     // Forward audio from capture to backend, with auto-stop detection.
@@ -1380,6 +1364,93 @@ async fn run_streaming_pipeline(
     }
 
     Ok(full_text)
+}
+
+/// Batches streaming text deltas and hands them to `sink` (the key injector
+/// in production). This is the single choke point through which all streamed
+/// text reaches the cursor.
+///
+/// Deltas arriving within 150ms of each other are coalesced into one batch so
+/// we don't create a new virtual keyboard per word delta. Returns the full
+/// accumulated (typed) text. Exits when the text channel closes or `cancel`
+/// is set.
+///
+/// The cancel flag is checked when a delta arrives and again right before a
+/// batch reaches the sink, so a cancelled recording never types the text the
+/// backend flushes on shutdown (a batch already inside the sink still
+/// finishes). Exiting drops `text_rx`, which makes subsequent backend sends
+/// fail fast and winds the detached backend task down.
+///
+/// The daemon text channel is intentionally append-only. For OpenAI realtime
+/// this still feels token-by-token because the backend emits stable append
+/// deltas. For Lemonade-compatible profiles, the protocol layer only forwards
+/// completed utterances, so this loop naturally types phrase-sized chunks
+/// without needing any replacement semantics.
+async fn run_typing_batcher<F, Fut>(
+    mut text_rx: tokio::sync::mpsc::Receiver<String>,
+    cancel: Arc<AtomicBool>,
+    filler_filter: Option<FillerFilter>,
+    mut sink: F,
+) -> String
+where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let mut full_text = String::new();
+    let batch_delay = std::time::Duration::from_millis(150);
+
+    loop {
+        // Wait for the first delta (blocking).
+        let first = text_rx.recv().await;
+        let Some(first) = first else { break };
+
+        // Cancelled while we were waiting: discard everything from here on.
+        if cancel.load(Ordering::SeqCst) {
+            break;
+        }
+
+        // Collect this delta and any others that arrive within the batch window.
+        let mut batch = first;
+        while let Ok(Some(more)) = tokio::time::timeout(batch_delay, text_rx.recv()).await {
+            batch.push_str(&more);
+        }
+
+        if batch.is_empty() {
+            continue;
+        }
+
+        // Apply filler word removal if enabled.
+        if let Some(filter) = filler_filter.as_ref() {
+            batch = filter.apply(&batch);
+            if batch.is_empty() {
+                continue;
+            }
+        }
+
+        // Add space separator between turns if needed.
+        // Don't insert a space before punctuation streaming deltas,
+        // as they arrive as bare tokens.
+        let text_to_type = if full_text.is_empty()
+            || batch.starts_with(' ')
+            || full_text.ends_with(' ')
+            || leads_with_punct(&batch)
+        {
+            batch
+        } else {
+            format!(" {batch}")
+        };
+
+        // Last gate before the sink: cancel may have arrived while this
+        // batch was being collected.
+        if cancel.load(Ordering::SeqCst) {
+            break;
+        }
+
+        full_text.push_str(&text_to_type);
+        sink(text_to_type).await;
+    }
+
+    full_text
 }
 
 /// Batch mode: collect all audio, transcribe in one shot, type result.
@@ -2598,6 +2669,14 @@ async fn handle_cancel(
                 capture.stop();
                 tokio::task::spawn_blocking(move || drop(capture));
             }
+            // Stop the typing loop BEFORE aborting the pipeline. Aborting
+            // only drops the outer pipeline future; the detached backend and
+            // typing tasks keep running, the backend treats the dropped audio
+            // channel as a normal end-of-stream and flushes the trailing
+            // phrase — without this flag the typing task would type it.
+            if let Some(cancel) = ds.streaming_cancel.take() {
+                cancel.store(true, Ordering::SeqCst);
+            }
             if let Some(task) = ds.streaming_task.take() {
                 task.abort();
             }
@@ -2885,5 +2964,81 @@ mod tests {
             format_api_error(&err),
             "Realtime transcription timed out waiting for the server to finish after stop"
         );
+    }
+
+    /// Spawn `run_typing_batcher` with a recording sink; returns the text
+    /// channel sender, the cancel flag, the sink log, and the join handle.
+    #[allow(clippy::type_complexity)]
+    fn spawn_test_batcher() -> (
+        tokio::sync::mpsc::Sender<String>,
+        Arc<AtomicBool>,
+        Arc<StdMutex<Vec<String>>>,
+        tokio::task::JoinHandle<String>,
+    ) {
+        let (text_tx, text_rx) = tokio::sync::mpsc::channel::<String>(64);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let typed = Arc::new(StdMutex::new(Vec::<String>::new()));
+
+        let sink_log = Arc::clone(&typed);
+        let batcher = tokio::spawn(run_typing_batcher(
+            text_rx,
+            Arc::clone(&cancel),
+            None,
+            move |text| {
+                let sink_log = Arc::clone(&sink_log);
+                async move {
+                    sink_log.lock().unwrap().push(text);
+                }
+            },
+        ));
+
+        (text_tx, cancel, typed, batcher)
+    }
+
+    /// Issue: `whisrs cancel` during a streaming recording still typed the
+    /// phrase the backend flushed on shutdown. Once the cancel flag is set,
+    /// nothing further may reach the sink and the loop must exit.
+    #[tokio::test(start_paused = true)]
+    async fn typing_batcher_discards_text_after_cancel() {
+        let (text_tx, cancel, typed, batcher) = spawn_test_batcher();
+
+        // A delta before cancel is batched and typed.
+        text_tx.send("hello".to_string()).await.unwrap();
+        // Paused clock: sleeping past the 150ms batch window deterministically
+        // lets the batcher flush the batch to the sink.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(*typed.lock().unwrap(), vec!["hello".to_string()]);
+
+        // Cancel, then simulate the backend flushing a trailing phrase.
+        cancel.store(true, Ordering::SeqCst);
+        text_tx
+            .send(" flushed trailing phrase".to_string())
+            .await
+            .unwrap();
+
+        // The sink never fires again and the loop exits, returning only the
+        // text typed before cancel.
+        let full_text = batcher.await.unwrap();
+        assert_eq!(full_text, "hello");
+        assert_eq!(*typed.lock().unwrap(), vec!["hello".to_string()]);
+
+        // Exiting dropped text_rx, so backend sends now fail fast.
+        assert!(text_tx.send("more".to_string()).await.is_err());
+    }
+
+    /// Cancel arriving while a batch is still being coalesced (inside the
+    /// 150ms window) must drop that batch before it reaches the sink.
+    #[tokio::test(start_paused = true)]
+    async fn typing_batcher_drops_batch_cancelled_during_window() {
+        let (text_tx, cancel, typed, batcher) = spawn_test_batcher();
+
+        text_tx.send("hello".to_string()).await.unwrap();
+        // Cancel mid-window, before the batch flushes at 150ms.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        cancel.store(true, Ordering::SeqCst);
+
+        let full_text = batcher.await.unwrap();
+        assert_eq!(full_text, "");
+        assert!(typed.lock().unwrap().is_empty());
     }
 }

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -482,9 +482,8 @@ fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
             Arc::new(OpenAIRestBackend::new(api_key))
         }
         "local-whisper" | "local" => {
-            let model_path = config
-                .local_whisper
-                .as_ref()
+            let local_whisper = config.local_whisper.as_ref();
+            let model_path = local_whisper
                 .map(|l| l.model_path.clone())
                 .unwrap_or_else(|| {
                     dirs::data_dir()
@@ -493,8 +492,20 @@ fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
                         .to_string_lossy()
                         .to_string()
                 });
-            info!("using local whisper transcription backend (model: {model_path})");
-            Arc::new(LocalWhisperBackend::new(model_path))
+            // Serde defaults only apply when the [local-whisper] section
+            // exists; mirror them here for a fully absent section.
+            let segmentation = local_whisper
+                .map(|l| l.segmentation.clone())
+                .unwrap_or_else(|| "silence".to_string());
+            let phrase_silence_ms = local_whisper.map(|l| l.phrase_silence_ms).unwrap_or(400);
+            info!(
+                "using local whisper transcription backend \
+                 (model: {model_path}, segmentation: {segmentation})"
+            );
+            Arc::new(
+                LocalWhisperBackend::new(model_path)
+                    .with_segmentation(&segmentation, phrase_silence_ms),
+            )
         }
         "local-vosk" => {
             let model_path = config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,6 +431,26 @@ impl Default for TtsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalWhisperConfig {
     pub model_path: String,
+    /// Streaming segmentation strategy: `"silence"` (default) splits audio
+    /// into phrases at natural pauses and decodes each exactly once;
+    /// `"window"` is the legacy overlapping sliding window with text dedup.
+    #[serde(default = "default_local_whisper_segmentation")]
+    pub segmentation: String,
+    /// Milliseconds of continuous silence that ends a phrase in `"silence"`
+    /// segmentation mode.
+    #[serde(default = "default_phrase_silence_ms")]
+    pub phrase_silence_ms: u64,
+}
+
+impl LocalWhisperConfig {
+    /// Config for `model_path` with default segmentation settings.
+    pub fn new(model_path: String) -> Self {
+        Self {
+            model_path,
+            segmentation: default_local_whisper_segmentation(),
+            phrase_silence_ms: default_phrase_silence_ms(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -499,6 +519,12 @@ fn default_tts_backend() -> String {
 }
 fn default_tts_response_format() -> String {
     "wav".to_string()
+}
+fn default_local_whisper_segmentation() -> String {
+    "silence".to_string()
+}
+fn default_phrase_silence_ms() -> u64 {
+    400
 }
 fn default_asr_sidecar_url() -> String {
     "http://127.0.0.1:8765/transcribe".to_string()

--- a/src/transcription/local_whisper.rs
+++ b/src/transcription/local_whisper.rs
@@ -1,12 +1,17 @@
 //! Local whisper.cpp transcription backend via `whisper-rs`.
 //!
-//! Uses whisper-rs with a sliding window approach for pseudo-streaming.
+//! Streaming uses silence-delimited phrase segmentation by default
+//! (`segmentation = "silence"`): incoming audio is split into phrases at
+//! natural pauses (>= `phrase_silence_ms` of silence) and each phrase is
+//! decoded exactly once — no overlapping windows, no deduplication, and no
+//! feedback of prior output. Feeding each window's transcription back as
+//! `initial_prompt` was the root cause of the repetition/invented-text loops
+//! in issue #55, so the only prompt ever passed to the decoder is the static
+//! vocabulary prompt from the user's config.
 //!
-//! Deduplication strategy: each window is transcribed with `set_initial_prompt()`
-//! set to the previous output for consistency. Text-based n-gram overlap removal
-//! (from `dedup.rs`) strips the repeated prefix. Timestamp filtering is not used
-//! because whisper often produces a single segment with `start_timestamp=0`,
-//! making timestamp-based approaches unreliable.
+//! The legacy sliding-window mode (`segmentation = "window"`) keeps the
+//! 8s/2s overlapping windows with text-based n-gram overlap removal
+//! (`asr_dedup::TextDedup`) for lower-latency partial output.
 
 use std::sync::Arc;
 
@@ -15,10 +20,11 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
+use super::phrase_split::PhraseSplitter;
 use super::{TranscriptionBackend, TranscriptionConfig};
 use crate::audio::AudioChunk;
 
-/// Sliding window parameters for pseudo-streaming.
+/// Sliding window parameters for the legacy "window" streaming mode.
 const WINDOW_SECS: usize = 8;
 const STEP_SECS: usize = 2;
 const SAMPLE_RATE: usize = 16_000;
@@ -29,18 +35,53 @@ const INITIAL_WINDOW_SECS: usize = 4;
 const INITIAL_WINDOW_SAMPLES: usize = INITIAL_WINDOW_SECS * SAMPLE_RATE;
 
 /// Silence threshold — must match or be below the daemon's auto-stop threshold
-/// (0.003) so we never skip windows that auto-stop considers speech.
+/// (0.003) so we never skip audio that auto-stop considers speech.
 const SILENCE_THRESHOLD: f64 = 0.003;
+
+/// Default silence duration (ms) that ends a phrase in "silence" mode.
+pub const DEFAULT_PHRASE_SILENCE_MS: u64 = 400;
+
+/// whisper.cpp produces no output for buffers shorter than ~1 s of audio;
+/// short phrases are zero-padded up to this length before decoding.
+const MIN_DECODE_SAMPLES: usize = SAMPLE_RATE + SAMPLE_RATE / 10; // 1.1 s
+
+/// How streaming audio is segmented before decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SegmentationMode {
+    /// Split at natural pauses; decode each phrase exactly once (default).
+    #[default]
+    Silence,
+    /// Legacy overlapping sliding window with text-based dedup.
+    Window,
+}
+
+impl SegmentationMode {
+    /// Parse a config string; unknown values warn and fall back to `Silence`.
+    pub fn parse(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "silence" => Self::Silence,
+            "window" => Self::Window,
+            other => {
+                warn!("unknown local-whisper segmentation {other:?}, using \"silence\"");
+                Self::Silence
+            }
+        }
+    }
+}
 
 /// Local whisper.cpp transcription backend.
 pub struct LocalWhisperBackend {
     ctx: Option<Arc<whisper_rs::WhisperContext>>,
-    #[allow(dead_code)]
     model_path: String,
+    segmentation: SegmentationMode,
+    phrase_silence_ms: u64,
 }
 
 impl LocalWhisperBackend {
     /// Create a new local whisper backend, eagerly loading the model.
+    ///
+    /// Defaults to silence-delimited phrase segmentation; see
+    /// [`Self::with_segmentation`].
     pub fn new(model_path: String) -> Self {
         let ctx = match Self::load_model(&model_path) {
             Ok(ctx) => {
@@ -52,7 +93,22 @@ impl LocalWhisperBackend {
                 None
             }
         };
-        Self { ctx, model_path }
+        Self {
+            ctx,
+            model_path,
+            segmentation: SegmentationMode::default(),
+            phrase_silence_ms: DEFAULT_PHRASE_SILENCE_MS,
+        }
+    }
+
+    /// Configure the streaming segmentation strategy.
+    ///
+    /// `mode` is `"silence"` (default) or `"window"`; `phrase_silence_ms` is
+    /// how much continuous silence ends a phrase in silence mode.
+    pub fn with_segmentation(mut self, mode: &str, phrase_silence_ms: u64) -> Self {
+        self.segmentation = SegmentationMode::parse(mode);
+        self.phrase_silence_ms = phrase_silence_ms.max(1);
+        self
     }
 
     fn load_model(path: &str) -> anyhow::Result<whisper_rs::WhisperContext> {
@@ -65,6 +121,133 @@ impl LocalWhisperBackend {
         whisper_rs::WhisperContext::new_with_params(path, params)
             .map_err(|e| anyhow::anyhow!("failed to initialize whisper context: {e}"))
     }
+
+    /// Silence-delimited streaming: split audio into phrases at pauses and
+    /// decode each phrase exactly once, in FIFO order.
+    async fn stream_phrases(
+        &self,
+        ctx: &Arc<whisper_rs::WhisperContext>,
+        mut audio_rx: mpsc::Receiver<AudioChunk>,
+        text_tx: mpsc::Sender<String>,
+        config: &TranscriptionConfig,
+    ) -> anyhow::Result<()> {
+        let mut splitter =
+            PhraseSplitter::new(SAMPLE_RATE, SILENCE_THRESHOLD, self.phrase_silence_ms);
+
+        while let Some(chunk) = audio_rx.recv().await {
+            for phrase in splitter.feed(&chunk) {
+                decode_phrase(ctx, phrase, config, &text_tx).await;
+            }
+        }
+
+        // End of stream: flush the trailing in-progress phrase (if any),
+        // exactly once. No rewind, no overlap re-send.
+        if let Some(phrase) = splitter.flush() {
+            decode_phrase(ctx, phrase, config, &text_tx).await;
+        }
+
+        Ok(())
+    }
+
+    /// Legacy sliding-window streaming with text-based overlap removal.
+    async fn stream_windows(
+        &self,
+        ctx: &Arc<whisper_rs::WhisperContext>,
+        mut audio_rx: mpsc::Receiver<AudioChunk>,
+        text_tx: mpsc::Sender<String>,
+        config: &TranscriptionConfig,
+    ) -> anyhow::Result<()> {
+        let mut buffer: Vec<i16> = Vec::new();
+        let mut dedup = TextDedup::new();
+        let mut next_process_at = INITIAL_WINDOW_SAMPLES;
+        let mut last_processed_end: usize = 0;
+        // Static vocabulary prompt only — never prior transcription output.
+        let prompt = config.prompt.clone().filter(|p| !p.is_empty());
+
+        while let Some(chunk) = audio_rx.recv().await {
+            buffer.extend_from_slice(&chunk);
+
+            while buffer.len() >= next_process_at {
+                let window_size = if last_processed_end == 0 {
+                    INITIAL_WINDOW_SAMPLES.min(buffer.len())
+                } else {
+                    WINDOW_SAMPLES.min(buffer.len())
+                };
+
+                let window_end = next_process_at;
+                let window_start = window_end.saturating_sub(window_size);
+                let window = buffer[window_start..window_end].to_vec();
+
+                // Skip silent windows.
+                if !audio_silence_gate::is_silent(&window, SILENCE_THRESHOLD) {
+                    let samples_f32 = i16_to_f32(&window);
+                    let ctx_clone = Arc::clone(ctx);
+                    let lang = config.language.clone();
+                    let prompt = prompt.clone();
+
+                    match tokio::task::spawn_blocking(move || {
+                        run_whisper_inference(&ctx_clone, &samples_f32, &lang, prompt.as_deref())
+                    })
+                    .await
+                    {
+                        Ok(Ok(full_text)) => {
+                            // Use text-based dedup to extract only the new portion.
+                            let new_text = dedup.filter_text(&full_text);
+                            if !new_text.trim().is_empty() {
+                                debug!("streaming window produced: {:?}", new_text);
+                                text_tx.send(new_text).await.ok();
+                            }
+                        }
+                        Ok(Err(e)) => warn!("whisper window inference failed: {e}"),
+                        Err(e) => warn!("whisper task panicked: {e}"),
+                    }
+                } else {
+                    debug!(
+                        "skipping silent window at samples {}..{}",
+                        window_start, window_end
+                    );
+                }
+
+                last_processed_end = window_end;
+                next_process_at += STEP_SAMPLES;
+            }
+        }
+
+        // Process remaining audio not covered by the last window.
+        if buffer.len() > last_processed_end {
+            let remaining_start = if buffer.len() - last_processed_end < SAMPLE_RATE {
+                last_processed_end.saturating_sub(WINDOW_SAMPLES / 4)
+            } else {
+                last_processed_end
+            };
+            let remaining = &buffer[remaining_start..];
+
+            if !remaining.is_empty() && !audio_silence_gate::is_silent(remaining, SILENCE_THRESHOLD)
+            {
+                let samples_f32 = i16_to_f32(remaining);
+                let ctx_clone = Arc::clone(ctx);
+                let lang = config.language.clone();
+                let prompt = prompt.clone();
+
+                match tokio::task::spawn_blocking(move || {
+                    run_whisper_inference(&ctx_clone, &samples_f32, &lang, prompt.as_deref())
+                })
+                .await
+                {
+                    Ok(Ok(full_text)) => {
+                        let new_text = dedup.filter_text(&full_text);
+                        if !new_text.trim().is_empty() {
+                            text_tx.send(new_text).await.ok();
+                        }
+                    }
+                    Ok(Err(e)) => warn!("whisper final inference failed: {e}"),
+                    Err(e) => warn!("whisper final task panicked: {e}"),
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 /// Convert i16 PCM samples to f32 in the range [-1.0, 1.0].
@@ -76,10 +259,51 @@ fn i16_to_f32(samples: &[i16]) -> Vec<f32> {
         .collect()
 }
 
-/// Run whisper inference on an audio window.
+/// Decode a single phrase and send its trimmed text over `text_tx`.
 ///
-/// - `prompt`: previous transcription to condition this window for consistency.
-///   Whisper uses it to maintain context across overlapping windows.
+/// Each phrase is decoded exactly once with only the static config prompt.
+async fn decode_phrase(
+    ctx: &Arc<whisper_rs::WhisperContext>,
+    mut phrase: Vec<i16>,
+    config: &TranscriptionConfig,
+    text_tx: &mpsc::Sender<String>,
+) {
+    debug!(
+        "decoding phrase of {:.2}s",
+        phrase.len() as f64 / SAMPLE_RATE as f64
+    );
+    // whisper.cpp silently produces nothing for <1 s buffers; pad with silence.
+    if phrase.len() < MIN_DECODE_SAMPLES {
+        phrase.resize(MIN_DECODE_SAMPLES, 0);
+    }
+
+    let samples_f32 = i16_to_f32(&phrase);
+    let ctx = Arc::clone(ctx);
+    let lang = config.language.clone();
+    let prompt = config.prompt.clone().filter(|p| !p.is_empty());
+
+    match tokio::task::spawn_blocking(move || {
+        run_whisper_inference(&ctx, &samples_f32, &lang, prompt.as_deref())
+    })
+    .await
+    {
+        Ok(Ok(text)) => {
+            let text = text.trim();
+            if !text.is_empty() {
+                debug!("phrase produced: {:?}", text);
+                text_tx.send(text.to_string()).await.ok();
+            }
+        }
+        Ok(Err(e)) => warn!("whisper phrase inference failed: {e}"),
+        Err(e) => warn!("whisper phrase task panicked: {e}"),
+    }
+}
+
+/// Run whisper inference on an audio buffer.
+///
+/// - `prompt`: the static vocabulary/context hint from the user's config.
+///   Never prior transcription output — feeding decoded text back as the
+///   prompt caused the repetition loops of issue #55.
 fn run_whisper_inference(
     ctx: &whisper_rs::WhisperContext,
     audio: &[f32],
@@ -98,15 +322,21 @@ fn run_whisper_inference(
         params.set_language(Some(language));
     }
 
-    // Feed previous transcription as prompt so whisper produces consistent
-    // output across overlapping windows.
+    // Static vocabulary/context hint (config `prompt` + `vocabulary`).
     if let Some(prompt) = prompt {
         if !prompt.is_empty() {
             params.set_initial_prompt(prompt);
         }
     }
-    // Allow whisper to use the prompt as context.
-    params.set_no_context(false);
+    // Decode every buffer independently: carrying decoder context across
+    // buffers amplified repetition/invented text (issue #55). The static
+    // initial_prompt above is still applied.
+    params.set_no_context(true);
+    // Fall back to a higher temperature sooner when the decoder gets stuck in
+    // low-entropy (repetitive) output. whisper.cpp default is 2.4.
+    params.set_entropy_thold(2.6);
+    // Suppress non-speech tokens (e.g. "(silence)", "♪") on pause-heavy audio.
+    params.set_suppress_nst(true);
 
     params.set_print_special(false);
     params.set_print_progress(false);
@@ -165,7 +395,7 @@ impl TranscriptionBackend for LocalWhisperBackend {
 
     async fn transcribe_stream(
         &self,
-        mut audio_rx: mpsc::Receiver<AudioChunk>,
+        audio_rx: mpsc::Receiver<AudioChunk>,
         text_tx: mpsc::Sender<String>,
         config: &TranscriptionConfig,
     ) -> anyhow::Result<()> {
@@ -174,114 +404,10 @@ impl TranscriptionBackend for LocalWhisperBackend {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("whisper model not loaded from {}", self.model_path))?;
 
-        let mut buffer: Vec<i16> = Vec::new();
-        let mut dedup = TextDedup::new();
-        let mut next_process_at = INITIAL_WINDOW_SAMPLES;
-        let mut last_processed_end: usize = 0;
-        // Previous full transcription fed as prompt to the next window.
-        // Seed with vocabulary prompt if available.
-        let mut prompt = config.prompt.clone().unwrap_or_default();
-
-        while let Some(chunk) = audio_rx.recv().await {
-            buffer.extend_from_slice(&chunk);
-
-            while buffer.len() >= next_process_at {
-                let window_size = if last_processed_end == 0 {
-                    INITIAL_WINDOW_SAMPLES.min(buffer.len())
-                } else {
-                    WINDOW_SAMPLES.min(buffer.len())
-                };
-
-                let window_end = next_process_at;
-                let window_start = window_end.saturating_sub(window_size);
-                let window = buffer[window_start..window_end].to_vec();
-
-                // Skip silent windows.
-                if !audio_silence_gate::is_silent(&window, SILENCE_THRESHOLD) {
-                    let samples_f32 = i16_to_f32(&window);
-                    let ctx_clone = Arc::clone(ctx);
-                    let lang = config.language.clone();
-                    let prev_prompt = if prompt.is_empty() {
-                        None
-                    } else {
-                        Some(prompt.clone())
-                    };
-
-                    match tokio::task::spawn_blocking(move || {
-                        run_whisper_inference(
-                            &ctx_clone,
-                            &samples_f32,
-                            &lang,
-                            prev_prompt.as_deref(),
-                        )
-                    })
-                    .await
-                    {
-                        Ok(Ok(full_text)) => {
-                            // Update prompt with this window's full transcription.
-                            if !full_text.is_empty() {
-                                prompt.clone_from(&full_text);
-                            }
-                            // Use text-based dedup to extract only the new portion.
-                            let new_text = dedup.filter_text(&full_text);
-                            if !new_text.trim().is_empty() {
-                                debug!("streaming window produced: {:?}", new_text);
-                                text_tx.send(new_text).await.ok();
-                            }
-                        }
-                        Ok(Err(e)) => warn!("whisper window inference failed: {e}"),
-                        Err(e) => warn!("whisper task panicked: {e}"),
-                    }
-                } else {
-                    debug!(
-                        "skipping silent window at samples {}..{}",
-                        window_start, window_end
-                    );
-                }
-
-                last_processed_end = window_end;
-                next_process_at += STEP_SAMPLES;
-            }
+        match self.segmentation {
+            SegmentationMode::Silence => self.stream_phrases(ctx, audio_rx, text_tx, config).await,
+            SegmentationMode::Window => self.stream_windows(ctx, audio_rx, text_tx, config).await,
         }
-
-        // Process remaining audio not covered by the last window.
-        if buffer.len() > last_processed_end {
-            let remaining_start = if buffer.len() - last_processed_end < SAMPLE_RATE {
-                last_processed_end.saturating_sub(WINDOW_SAMPLES / 4)
-            } else {
-                last_processed_end
-            };
-            let remaining = &buffer[remaining_start..];
-
-            if !remaining.is_empty() && !audio_silence_gate::is_silent(remaining, SILENCE_THRESHOLD)
-            {
-                let samples_f32 = i16_to_f32(remaining);
-                let ctx_clone = Arc::clone(ctx);
-                let lang = config.language.clone();
-                let prev_prompt = if prompt.is_empty() {
-                    None
-                } else {
-                    Some(prompt.clone())
-                };
-
-                match tokio::task::spawn_blocking(move || {
-                    run_whisper_inference(&ctx_clone, &samples_f32, &lang, prev_prompt.as_deref())
-                })
-                .await
-                {
-                    Ok(Ok(full_text)) => {
-                        let new_text = dedup.filter_text(&full_text);
-                        if !new_text.trim().is_empty() {
-                            text_tx.send(new_text).await.ok();
-                        }
-                    }
-                    Ok(Err(e)) => warn!("whisper final inference failed: {e}"),
-                    Err(e) => warn!("whisper final task panicked: {e}"),
-                }
-            }
-        }
-
-        Ok(())
     }
 
     fn supports_streaming(&self) -> bool {
@@ -318,5 +444,21 @@ mod tests {
         assert_eq!(f32_samples[0], 0.0);
         assert!((f32_samples[1] - 1.0).abs() < 0.001);
         assert!((f32_samples[2] + 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn segmentation_mode_parsing() {
+        assert_eq!(
+            SegmentationMode::parse("silence"),
+            SegmentationMode::Silence
+        );
+        assert_eq!(SegmentationMode::parse("Window"), SegmentationMode::Window);
+        assert_eq!(
+            SegmentationMode::parse(" window "),
+            SegmentationMode::Window
+        );
+        // Unknown values fall back to the default.
+        assert_eq!(SegmentationMode::parse("bogus"), SegmentationMode::Silence);
+        assert_eq!(SegmentationMode::default(), SegmentationMode::Silence);
     }
 }

--- a/src/transcription/local_whisper.rs
+++ b/src/transcription/local_whisper.rs
@@ -38,9 +38,6 @@ const INITIAL_WINDOW_SAMPLES: usize = INITIAL_WINDOW_SECS * SAMPLE_RATE;
 /// (0.003) so we never skip audio that auto-stop considers speech.
 const SILENCE_THRESHOLD: f64 = 0.003;
 
-/// Default silence duration (ms) that ends a phrase in "silence" mode.
-pub const DEFAULT_PHRASE_SILENCE_MS: u64 = 400;
-
 /// whisper.cpp produces no output for buffers shorter than ~1 s of audio;
 /// short phrases are zero-padded up to this length before decoding.
 const MIN_DECODE_SAMPLES: usize = SAMPLE_RATE + SAMPLE_RATE / 10; // 1.1 s
@@ -97,7 +94,9 @@ impl LocalWhisperBackend {
             ctx,
             model_path,
             segmentation: SegmentationMode::default(),
-            phrase_silence_ms: DEFAULT_PHRASE_SILENCE_MS,
+            // Same default as `crate::LocalWhisperConfig` — lib.rs is the
+            // single source of truth for segmentation defaults.
+            phrase_silence_ms: crate::default_phrase_silence_ms(),
         }
     }
 

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -15,6 +15,9 @@ pub mod local_whisper {
         pub fn new(_model_path: String) -> Self {
             Self
         }
+        pub fn with_segmentation(self, _mode: &str, _phrase_silence_ms: u64) -> Self {
+            self
+        }
     }
     #[async_trait::async_trait]
     impl super::TranscriptionBackend for LocalWhisperBackend {
@@ -31,6 +34,7 @@ pub mod openai_compatible_realtime;
 pub mod openai_realtime;
 pub mod openai_realtime_protocol;
 pub mod openai_rest;
+pub mod phrase_split;
 
 use async_trait::async_trait;
 use tokio::sync::mpsc;

--- a/src/transcription/phrase_split.rs
+++ b/src/transcription/phrase_split.rs
@@ -1,0 +1,438 @@
+//! Silence-delimited phrase segmentation for local streaming ASR.
+//!
+//! [`PhraseSplitter`] is a pure, incremental splitter: feed it i16 PCM samples
+//! and it yields complete phrases — runs of speech delimited by a configurable
+//! stretch of silence. Each returned phrase is a contiguous slice of the input
+//! audio (plus a little silence padding on both sides), so a decoder can
+//! transcribe each phrase exactly once with no overlap and no deduplication.
+//!
+//! Rules:
+//! - RMS energy is tracked per fixed-size frame (100 ms in production).
+//! - A phrase ends once `split_silence_frames` consecutive silent frames
+//!   follow speech.
+//! - Phrases with fewer than `min_speech_frames` frames containing speech are
+//!   discarded as noise.
+//! - Emitted phrases include up to `pad_frames` of surrounding silence.
+//! - A phrase that reaches `max_phrase_frames` without a silence split is
+//!   force-split at the quietest recent frame boundary, so continuous
+//!   pause-free speech still emits. No padding is added at a forced boundary
+//!   (the audio is contiguous, and padding would duplicate samples).
+//! - [`PhraseSplitter::flush`] emits the trailing in-progress phrase at end of
+//!   stream (if it carries enough speech) exactly once.
+
+use audio_silence_gate::rms_energy;
+
+/// Analysis frame length in milliseconds.
+const FRAME_MS: usize = 100;
+/// Silence padding kept around each phrase, in milliseconds.
+const PAD_MS: usize = 100;
+/// Minimum speech (frames containing speech, ~ms) required to keep a phrase.
+const MIN_PHRASE_SPEECH_MS: usize = 250;
+/// Hard cap on phrase length before a forced split.
+const MAX_PHRASE_SECS: usize = 20;
+/// How far back to look for the quietest frame when force-splitting.
+const QUIET_SEARCH_MS: usize = 2000;
+
+/// Incremental silence-delimited phrase splitter over i16 PCM samples.
+pub struct PhraseSplitter {
+    // Configuration (all in frames unless noted).
+    frame_len: usize,
+    threshold: f64,
+    split_silence_frames: usize,
+    min_speech_frames: usize,
+    max_phrase_frames: usize,
+    pad_frames: usize,
+    quiet_search_frames: usize,
+
+    // Rolling state. `buffer` holds samples not yet consumed by an emitted or
+    // discarded phrase; `energies[i]` is the RMS of frame `i` of `buffer`.
+    buffer: Vec<i16>,
+    energies: Vec<f64>,
+    in_phrase: bool,
+    /// First frame of the emitted slice (speech onset minus padding).
+    emit_start_frame: usize,
+    /// First frame that contained speech in the current phrase.
+    phrase_start_frame: usize,
+    /// Frames containing speech in the current phrase.
+    speech_frames: usize,
+    /// Consecutive silent frames at the current analysis position.
+    trailing_silence: usize,
+}
+
+impl PhraseSplitter {
+    /// Create a splitter with production defaults for the given sample rate.
+    ///
+    /// `threshold` is a normalized RMS silence threshold (0.0–1.0);
+    /// `phrase_silence_ms` is how much continuous silence ends a phrase.
+    pub fn new(sample_rate: usize, threshold: f64, phrase_silence_ms: u64) -> Self {
+        let frame_len = (sample_rate * FRAME_MS / 1000).max(1);
+        Self::with_params(
+            frame_len,
+            threshold,
+            (phrase_silence_ms as usize).div_ceil(FRAME_MS).max(1),
+            MIN_PHRASE_SPEECH_MS.div_ceil(FRAME_MS).max(1),
+            (MAX_PHRASE_SECS * 1000 / FRAME_MS).max(2),
+            PAD_MS / FRAME_MS,
+            (QUIET_SEARCH_MS / FRAME_MS).max(1),
+        )
+    }
+
+    /// Create a splitter with explicit frame-level parameters (used by tests).
+    pub fn with_params(
+        frame_len: usize,
+        threshold: f64,
+        split_silence_frames: usize,
+        min_speech_frames: usize,
+        max_phrase_frames: usize,
+        pad_frames: usize,
+        quiet_search_frames: usize,
+    ) -> Self {
+        Self {
+            frame_len: frame_len.max(1),
+            threshold,
+            split_silence_frames: split_silence_frames.max(1),
+            min_speech_frames: min_speech_frames.max(1),
+            max_phrase_frames: max_phrase_frames.max(2),
+            pad_frames,
+            quiet_search_frames: quiet_search_frames.max(1),
+            buffer: Vec::new(),
+            energies: Vec::new(),
+            in_phrase: false,
+            emit_start_frame: 0,
+            phrase_start_frame: 0,
+            speech_frames: 0,
+            trailing_silence: 0,
+        }
+    }
+
+    /// Feed samples; returns zero or more completed phrases in FIFO order.
+    pub fn feed(&mut self, samples: &[i16]) -> Vec<Vec<i16>> {
+        self.buffer.extend_from_slice(samples);
+        let mut out = Vec::new();
+        // Analyze every complete frame not yet analyzed. `process_frame` may
+        // drop consumed frames from the front, so recompute the index each
+        // iteration.
+        while (self.energies.len() + 1) * self.frame_len <= self.buffer.len() {
+            let i = self.energies.len();
+            let energy = rms_energy(&self.buffer[i * self.frame_len..(i + 1) * self.frame_len]);
+            self.energies.push(energy);
+            self.process_frame(i, energy, &mut out);
+        }
+        out
+    }
+
+    /// End of stream: emit the trailing in-progress phrase, if it carries
+    /// enough speech. Resets the splitter; subsequent calls return `None`.
+    pub fn flush(&mut self) -> Option<Vec<i16>> {
+        // A partial (<1 frame) unanalyzed tail without an open phrase can hold
+        // at most one frame of speech — below any sensible minimum. Discard.
+        if !self.in_phrase || self.speech_frames < self.min_speech_frames {
+            self.clear();
+            return None;
+        }
+
+        // Trim excess trailing silence down to the padding; keep the partial
+        // unanalyzed tail when speech may still be running into it.
+        let end_sample = if self.trailing_silence > self.pad_frames {
+            let speech_end = self.energies.len() - self.trailing_silence;
+            (speech_end + self.pad_frames) * self.frame_len
+        } else {
+            self.buffer.len()
+        };
+        let phrase = self.buffer[self.emit_start_frame * self.frame_len..end_sample].to_vec();
+        self.clear();
+        Some(phrase)
+    }
+
+    /// Process the just-analyzed frame `i` (index into `energies`).
+    fn process_frame(&mut self, i: usize, energy: f64, out: &mut Vec<Vec<i16>>) {
+        let silent = energy < self.threshold;
+
+        if !self.in_phrase {
+            if silent {
+                // Keep only `pad_frames` of leading silence so long pauses
+                // don't grow the buffer.
+                if self.energies.len() > self.pad_frames {
+                    let drop = self.energies.len() - self.pad_frames;
+                    self.drop_frames(drop);
+                }
+            } else {
+                self.in_phrase = true;
+                self.phrase_start_frame = i;
+                self.emit_start_frame = i.saturating_sub(self.pad_frames);
+                self.speech_frames = 1;
+                self.trailing_silence = 0;
+            }
+            return;
+        }
+
+        if silent {
+            self.trailing_silence += 1;
+            if self.trailing_silence >= self.split_silence_frames {
+                self.end_phrase(i, out);
+                return;
+            }
+        } else {
+            self.speech_frames += 1;
+            self.trailing_silence = 0;
+        }
+
+        // Forced split: phrase reached the hard cap without a silence gap.
+        if i + 1 - self.phrase_start_frame >= self.max_phrase_frames {
+            self.force_split(i, out);
+        }
+    }
+
+    /// Natural end of phrase: enough consecutive silence after speech.
+    fn end_phrase(&mut self, i: usize, out: &mut Vec<Vec<i16>>) {
+        // One past the last frame that contained speech.
+        let speech_end = i + 1 - self.trailing_silence;
+        let end_frame = (speech_end + self.pad_frames).min(self.energies.len());
+
+        if self.speech_frames >= self.min_speech_frames {
+            out.push(
+                self.buffer[self.emit_start_frame * self.frame_len..end_frame * self.frame_len]
+                    .to_vec(),
+            );
+        }
+
+        self.in_phrase = false;
+        self.speech_frames = 0;
+        self.trailing_silence = 0;
+        // Keep up to `pad_frames` of the gap as leading padding for the next
+        // phrase; everything earlier is consumed.
+        let keep_from = self
+            .energies
+            .len()
+            .saturating_sub(self.pad_frames)
+            .max(speech_end);
+        self.drop_frames(keep_from);
+    }
+
+    /// Forced split at the cap: cut at the quietest recent frame boundary so
+    /// we are least likely to cut mid-word. The quietest frame starts the
+    /// next phrase; no padding is duplicated across the boundary.
+    fn force_split(&mut self, i: usize, out: &mut Vec<Vec<i16>>) {
+        let search_start = (i + 1)
+            .saturating_sub(self.quiet_search_frames)
+            .max(self.phrase_start_frame + 1);
+        let mut split_frame = search_start;
+        let mut min_energy = f64::INFINITY;
+        for j in search_start..=i {
+            if self.energies[j] < min_energy {
+                min_energy = self.energies[j];
+                split_frame = j;
+            }
+        }
+
+        out.push(
+            self.buffer[self.emit_start_frame * self.frame_len..split_frame * self.frame_len]
+                .to_vec(),
+        );
+
+        // The remainder continues as an open phrase starting at the split.
+        self.drop_frames(split_frame);
+        self.phrase_start_frame = 0;
+        self.emit_start_frame = 0;
+        self.speech_frames = self
+            .energies
+            .iter()
+            .filter(|&&e| e >= self.threshold)
+            .count();
+        self.trailing_silence = self
+            .energies
+            .iter()
+            .rev()
+            .take_while(|&&e| e < self.threshold)
+            .count();
+    }
+
+    /// Drop the first `n` analyzed frames (and their samples) from the front.
+    fn drop_frames(&mut self, n: usize) {
+        if n == 0 {
+            return;
+        }
+        self.buffer.drain(..n * self.frame_len);
+        self.energies.drain(..n);
+    }
+
+    fn clear(&mut self) {
+        self.buffer.clear();
+        self.energies.clear();
+        self.in_phrase = false;
+        self.emit_start_frame = 0;
+        self.phrase_start_frame = 0;
+        self.speech_frames = 0;
+        self.trailing_silence = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FRAME: usize = 10;
+    const SPEECH: i16 = 1000; // normalized RMS ~0.031, above the 0.01 threshold
+    const QUIET_SPEECH: i16 = 500; // ~0.015 — voiced but the quietest around
+
+    /// frame_len=10, threshold=0.01, split after 3 silent frames, min 2 speech
+    /// frames, cap at 100 frames, 1 pad frame, search 5 frames for the
+    /// quietest split point.
+    fn splitter() -> PhraseSplitter {
+        PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 100, 1, 5)
+    }
+
+    fn frames(pattern: &[(i16, usize)]) -> Vec<i16> {
+        let mut out = Vec::new();
+        for &(value, count) in pattern {
+            out.extend(std::iter::repeat_n(value, count * FRAME));
+        }
+        out
+    }
+
+    #[test]
+    fn basic_split_two_phrases() {
+        let mut s = splitter();
+        // 2 silence, 5 speech, 4 silence, 3 speech, 4 silence (frames).
+        let audio = frames(&[(0, 2), (SPEECH, 5), (0, 4), (SPEECH, 3), (0, 4)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert_eq!(phrases.len(), 2);
+        // Phrase 1: 1 pad + 5 speech + 1 pad frames.
+        assert_eq!(phrases[0].len(), 7 * FRAME);
+        // Phrase 2: 1 pad + 3 speech + 1 pad frames.
+        assert_eq!(phrases[1].len(), 5 * FRAME);
+    }
+
+    #[test]
+    fn padding_included_around_speech() {
+        let mut s = splitter();
+        let audio = frames(&[(0, 3), (SPEECH, 4), (0, 4)]);
+        let phrases = s.feed(&audio);
+
+        assert_eq!(phrases.len(), 1);
+        let p = &phrases[0];
+        assert_eq!(p.len(), 6 * FRAME);
+        // Leading pad frame is silence, then speech, then trailing pad frame.
+        assert!(p[..FRAME].iter().all(|&x| x == 0));
+        assert!(p[FRAME..5 * FRAME].iter().all(|&x| x == SPEECH));
+        assert!(p[5 * FRAME..].iter().all(|&x| x == 0));
+    }
+
+    #[test]
+    fn no_leading_pad_when_speech_starts_at_zero() {
+        let mut s = splitter();
+        let audio = frames(&[(SPEECH, 4), (0, 4)]);
+        let phrases = s.feed(&audio);
+
+        assert_eq!(phrases.len(), 1);
+        // No silence exists before the speech: 4 speech + 1 trailing pad.
+        assert_eq!(phrases[0].len(), 5 * FRAME);
+        assert_eq!(phrases[0][0], SPEECH);
+    }
+
+    #[test]
+    fn short_blip_discarded_as_noise() {
+        let mut s = splitter();
+        // 1 speech frame < min_speech_frames (2).
+        let audio = frames(&[(0, 2), (SPEECH, 1), (0, 4)]);
+        let phrases = s.feed(&audio);
+        assert!(phrases.is_empty());
+        assert!(s.flush().is_none());
+    }
+
+    #[test]
+    fn incremental_feeding_matches_single_feed() {
+        let audio = frames(&[(0, 2), (SPEECH, 5), (0, 4), (SPEECH, 3), (0, 4)]);
+
+        let mut whole = splitter();
+        let mut expected = whole.feed(&audio);
+        expected.extend(whole.flush());
+
+        let mut incremental = splitter();
+        let mut got = Vec::new();
+        for chunk in audio.chunks(7) {
+            got.extend(incremental.feed(chunk));
+        }
+        got.extend(incremental.flush());
+
+        assert_eq!(expected, got);
+    }
+
+    #[test]
+    fn cap_force_splits_at_quietest_frame() {
+        // Cap at 6 frames; quiet-but-voiced frame at index 4 should become
+        // the split point (start of the next phrase).
+        let mut s = PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 6, 1, 3);
+        let audio = frames(&[(SPEECH, 4), (QUIET_SPEECH, 1), (SPEECH, 3)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert_eq!(phrases.len(), 2);
+        // First phrase: frames 0..4 (split before the quiet frame).
+        assert_eq!(phrases[0].len(), 4 * FRAME);
+        assert!(phrases[0].iter().all(|&x| x == SPEECH));
+        // Continuation: quiet frame + remaining speech, flushed at end.
+        assert_eq!(phrases[1].len(), 4 * FRAME);
+        assert_eq!(phrases[1][0], QUIET_SPEECH);
+    }
+
+    #[test]
+    fn continuous_speech_is_emitted_without_loss_or_duplication() {
+        // 25 frames of pause-free speech with a cap of 6: every sample must be
+        // emitted exactly once across forced splits + final flush.
+        let mut s = PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 6, 1, 3);
+        let audio = frames(&[(SPEECH, 25)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert!(
+            phrases.len() >= 4,
+            "expected multiple forced splits, got {}",
+            phrases.len()
+        );
+        let rejoined: Vec<i16> = phrases.into_iter().flatten().collect();
+        assert_eq!(rejoined, audio);
+    }
+
+    #[test]
+    fn flush_emits_trailing_phrase_once() {
+        let mut s = splitter();
+        // Speech that never sees enough trailing silence to split.
+        let audio = frames(&[(0, 1), (SPEECH, 4), (0, 1)]);
+        assert!(s.feed(&audio).is_empty());
+
+        let phrase = s.flush().expect("trailing phrase should flush");
+        // 1 pad + 4 speech + 1 trailing silence frame (<= pad, kept).
+        assert_eq!(phrase.len(), 6 * FRAME);
+        assert!(s.flush().is_none(), "flush must emit exactly once");
+    }
+
+    #[test]
+    fn flush_trims_excess_trailing_silence() {
+        let mut s = splitter();
+        // 2 trailing silent frames (< split threshold of 3, > pad of 1).
+        let audio = frames(&[(0, 1), (SPEECH, 4), (0, 2)]);
+        assert!(s.feed(&audio).is_empty());
+
+        let phrase = s.flush().expect("trailing phrase should flush");
+        // Trimmed to 1 pad + 4 speech + 1 pad.
+        assert_eq!(phrase.len(), 6 * FRAME);
+    }
+
+    #[test]
+    fn pure_silence_yields_nothing() {
+        let mut s = splitter();
+        assert!(s.feed(&frames(&[(0, 50)])).is_empty());
+        assert!(s.flush().is_none());
+    }
+
+    #[test]
+    fn long_leading_silence_does_not_grow_buffer() {
+        let mut s = splitter();
+        s.feed(&frames(&[(0, 1000)]));
+        // Only the pad frame (plus at most a partial tail) may remain.
+        assert!(s.buffer.len() <= 2 * FRAME);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the repeated/invented text reported in #55 by replacing the local Whisper sliding-window streaming with silence-delimited phrase segmentation, plus decoder hardening and a cancel fix the change exposed.

Closes #55

## Root cause

The 8s/2s overlapping sliding window decoded every sample up to 4 times and relied on text dedup to strip the overlap. Two flaws combined into the reported behavior:

- `TextDedup::remove_overlap` anchors on the previous window's final words, exactly the region Whisper re-words across window boundaries at pauses. When no anchor matches it fails open and emits the entire new window, typing whole sentences twice.
- Each window's full output was fed back as `initial_prompt` with `no_context = false`, so a hallucinated guess became a self-reinforcing prompt (the classic Whisper failure loop; whisper.cpp's own stream example disables context in its VAD mode for this reason).

Not a regression: this design shipped with the first local backend release. Slow, pausey dictation is simply its worst case.

## Changes

- **New default segmentation mode `silence`**: audio is split into phrases after `phrase_silence_ms` (default 400ms) of silence, min phrase 250ms, 100ms padding, 20s cap with force-split at the quietest frame. Each phrase is decoded exactly once, FIFO, no text dedup needed. Implemented as a pure, unit-tested `PhraseSplitter` (`src/transcription/phrase_split.rs`).
- **Decoder hardening (both modes)**: `no_context(true)`, `entropy_thold(2.6)`, `suppress_nst(true)`; previous transcription is never fed back as prompt (only the static vocabulary prompt is used).
- **Sliding window kept as opt-in legacy** via `[local-whisper] segmentation = "window"`.
- **Cancel now discards pending streamed text** (all streaming backends): a per-recording cancel flag gates the typing loop. Previously cancel only aborted the outer pipeline task while the detached backend/typing tasks kept running and typed the end-of-stream flush. Pre-existing bug, fully exposed by phrase batching.
- **Scripted repro/regression harness**: `./scripts/check-issue55.sh` generates espeak-ng fixtures (pause-heavy + continuous no-pause), streams them through the real backend with `ggml-base.en.bin`, and gates on repeated n-grams and ground-truth coverage. Repro unit tests in `crates/asr-dedup` pin the fail-open dedup behavior of the legacy path.

## Testing

- `cargo fmt` / `clippy --all-targets -D warnings` / `cargo test` (254) / `cargo build` all green
- `./scripts/check-issue55.sh` exit 0: pause fixture has zero repeated n-grams at 96.7% ground-truth coverage; no-pause fixture proves the 20s cap emits (98.4% coverage). Same harness run in `window` mode still reproduces the old repetition, confirming the detector is a real gate.
- Manual dictation on Hyprland/Wayland with `base.en`: slow speech with mid-sentence pauses, long dictation, short utterances, cancel mid-speech; no duplication, cancel discards.

## Latency notes

- Text now appears ~`phrase_silence_ms` after each pause instead of on a 2s window cadence; short-phrase decode cost drops (no 4x redundant decoding).
- Trade-off: pause-free continuous speech emits nothing until the 20s force-split (vs 4s first window before). Judged acceptable for dictation; tunable later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
