### PR TITLE
Answer whisrsd --version/--help; tidy udev rule comments

### DIFF
--- a/contrib/99-whisrs.rules
+++ b/contrib/99-whisrs.rules
@@ -1,10 +1,15 @@
-# Allow members of the "input" group to access /dev/uinput
-# Install: sudo cp 99-whisrs.rules /etc/udev/rules.d/
-# Reload: sudo udevadm control --reload-rules && sudo udevadm trigger
+# Grant members of the "input" group access to /dev/uinput, which whisrs needs
+# in order to synthesize keystrokes.
 #
-# Note: MODE/GROUP alone are not enough if another udev rule (e.g. brltty)
-# sets an ACL on /dev/uinput, because ACLs override traditional Unix group
-# permissions. The setfacl call below ensures the input group always has
-# read-write access regardless of ACL state.
+# MODE/GROUP alone are not enough if another udev rule (e.g. brltty) sets an
+# ACL on /dev/uinput, because ACLs override traditional Unix group permissions.
+# The setfacl call below ensures the input group always has read-write access
+# regardless of ACL state.
+#
+# Packagers: /usr/bin/setfacl is the FHS location. On distributions that put it
+# elsewhere (NixOS, Guix), rewrite both occurrences below at build time — the
+# TEST== guard makes this rule a silent no-op when the path does not exist.
+#
+# Installation instructions live in README.md and docs/troubleshooting.md.
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", TAG+="uaccess"
 KERNEL=="uinput", SUBSYSTEM=="misc", TEST=="/usr/bin/setfacl", RUN+="/usr/bin/setfacl -m g:input:rw /dev/$name"

--- a/contrib/whisrsd.1
+++ b/contrib/whisrsd.1
@@ -3,6 +3,14 @@
 whisrsd \- whisrs dictation daemon
 .SH SYNOPSIS
 .B whisrsd
+.RI [ OPTIONS ]
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Print a short help message and exit.
+.TP
+.BR \-V ", " \-\-version
+Print version information and exit.
 .SH DESCRIPTION
 .B whisrsd
 is the background daemon for the whisrs dictation system. It manages audio

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixListener;
 use tokio::sync::Mutex;
@@ -684,8 +685,17 @@ fn send_notification(summary: &str, body: &str) {
     });
 }
 
+/// The daemon takes no options of its own, but declaring the interface means
+/// `--version` and `--help` are answered and exit, instead of being ignored and
+/// starting a daemon.
+#[derive(Parser)]
+#[command(name = "whisrsd", about = "whisrs dictation daemon", version)]
+struct Args {}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    Args::parse();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()


### PR DESCRIPTION
## Summary

Two small independent fixes, split into one commit each. Both came out of packaging whisrs for nixpkgs (NixOS/nixpkgs#545837), where they showed up as friction.

1. `whisrsd` did no argument parsing at all, so `whisrsd --version` ignored the flag and started a daemon instead of reporting a version.
2. The udev rule file led with `sudo cp` install instructions that read as stale once a package manager has installed it.

## Changes

**`fix(daemon): answer --version and --help instead of starting up`**

- Declare the daemon's (empty) option set with `clap` — already a dependency, and what the `whisrs` CLI uses — and parse it as the first statement in `main()`.
- `-h/--help` and `-V/--version` are now answered and exit before any daemon state is touched. Unknown arguments are rejected with a usage error rather than silently ignored.
- Documented `-h`/`-V` in `contrib/whisrsd.1`, which previously had no OPTIONS section.

Before, `whisrsd --version` started up and then bailed with `another whisrsd instance is already running`. Distro packagers and service health checks reach for `--version` as a smoke test, so this makes the binary behave the way those tools expect. `whisrsd` is always invoked bare (`contrib/whisrs.service`, `install.sh`, and the CLI's restart path), so the stricter parsing does not affect any existing caller.

**`docs(udev): drop install steps from the rule file, add a packager note`**

- Removed the `sudo cp` / `udevadm control --reload-rules` lines. They are already documented in both `README.md` and `docs/troubleshooting.md`, so nothing is lost.
- Kept the genuinely useful in-file explanation of why `MODE`/`GROUP` alone are not sufficient when another rule sets an ACL.
- Added a note that `/usr/bin/setfacl` is an FHS path which has to be rewritten on distributions that do not have it (NixOS, Guix), where the `TEST==` guard otherwise turns the fallback into a silent no-op.

Both rule lines are unchanged — this commit is comments only, no behavioral change.

## Testing

Run in the repo's own `nix develop` shell on NixOS (x86_64-linux), against `fa88fab`:

- `cargo fmt --check` — passes
- `cargo clippy --all-targets -- -D warnings` — passes
- `cargo test` — passes, 228 + 38 tests, 0 failures

Behavior verified on the built binary:

```
$ whisrsd --version
whisrsd 0.1.20

$ whisrsd --help
whisrs dictation daemon

Usage: whisrsd

Options:
  -h, --help     Print help
  -V, --version  Print version

$ whisrsd --nonsense
error: unexpected argument '--nonsense' found
```

None of these start a daemon or touch the socket. Compositor: not exercised — neither change touches capture, transcription, or injection, and the daemon's normal no-argument startup path is unchanged.

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Tested on at least one compositor — not applicable; see above

---

Disclosure: these changes were prepared with AI assistance (Claude Code, claude-opus-5). I have reviewed and tested them, and take responsibility for the content.
