### PR TITLE
feat(llm-commands): named LLM commands with per-command hotkeys + selection-reprogram

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,11 +128,42 @@ model_path = "~/.local/share/whisrs/models/ggml-base.en.bin"
 url = "http://127.0.0.1:8765/transcribe"
 model = "microsoft/VibeVoice-ASR-HF"
 
-# Command mode: LLM for voice-driven text rewriting
+# Command mode: LLM for voice-driven text rewriting.
+# Also used by [[llm_commands]] (see below). Any OpenAI-compatible
+# /chat/completions endpoint works here, including a local server:
+#   [llm]
+#   api_key = "not-needed"   # local servers don't validate this
+#   model = "<model loaded in LM Studio / Ollama / llama.cpp server>"
+#   api_url = "http://localhost:1234/v1/chat/completions"  # LM Studio default
 [llm]
 api_key = "sk-..."
 model = "gpt-4o-mini"
 api_url = "https://api.openai.com/v1/chat/completions"
+
+# Named custom LLM commands: each gets its own hotkey. Dictate, the LLM
+# applies the instruction to the transcribed text, result is typed at the
+# cursor. A toggle-recording flavor of plain dictation — unlike command mode,
+# there's no text selection involved. Uses the [llm] config above.
+# Optional; can also be triggered via `whisrs llm-command <name>` for
+# compositor keybind integration (same pattern as `whisrs toggle`).
+#
+# set_hotkey (optional): reprogram this command by selection. Highlight the new
+# instruction text anywhere, press set_hotkey, and it becomes the command's
+# instruction — saved back to this file and applied immediately (no restart).
+# Lets you repurpose a command (translate -> summarize -> ...) without editing
+# config. Also available as `whisrs llm-command-set <name>` for compositor
+# binds. Selection-based on purpose: the instruction is exact, no dictation
+# glitches.
+#
+# Tip: write the instruction so it clearly refers to the dictated text (e.g.
+# "the following text") and pins the output ("Return only ..., no explanations,
+# no quotes"). Small local models otherwise sometimes echo the instruction or
+# add commentary.
+[[llm_commands]]
+name = "translate-de"
+hotkey = "Super+Shift+T"           # run: dictate -> LLM -> type
+set_hotkey = "Super+Shift+Alt+T"   # reprogram: select new instruction, press
+instruction = "Translate the following text into German, using the friendly informal 'du' form and a warm, casual tone. Return only the translated text — no explanations, no quotes."
 
 # Text-to-speech: read the current selection aloud (`whisrs speak`).
 # Opt-in. model/voice are optional; each backend has its own default,

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -70,6 +70,22 @@ enum SubCmd {
     },
     /// Command mode: select text, speak an instruction, LLM rewrites it in place
     Command,
+    /// Toggle a named custom LLM command (see [[llm_commands]] in config.toml):
+    /// dictate, the LLM applies the configured instruction, result is typed
+    /// at the cursor. Press again to stop recording, same as `toggle`.
+    #[command(name = "llm-command")]
+    LlmCommand {
+        /// Name of the [[llm_commands]] entry to run.
+        name: String,
+    },
+    /// Reprogram a named LLM command from the current selection: highlight the
+    /// new instruction text, then run this — it's saved to config and applied
+    /// live. Pairs with an entry's `set_hotkey`.
+    #[command(name = "llm-command-set")]
+    LlmCommandSet {
+        /// Name of the [[llm_commands]] entry to reprogram.
+        name: String,
+    },
     /// Read the selected text aloud via TTS (press again to stop playback)
     #[command(alias = "read")]
     Speak,
@@ -141,6 +157,12 @@ async fn main() -> anyhow::Result<()> {
         }
         SubCmd::Command => {
             send_command(Command::CommandMode).await?;
+        }
+        SubCmd::LlmCommand { name } => {
+            send_command(Command::LlmCommand { name }).await?;
+        }
+        SubCmd::LlmCommandSet { name } => {
+            send_command(Command::SetLlmInstruction { name }).await?;
         }
         SubCmd::Speak => {
             send_command(Command::Speak).await?;

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -55,6 +55,7 @@ pub fn run_config_menu() -> Result<()> {
             "Hotkeys",
             "Tray & overlay",
             "Command mode (LLM)",
+            "Custom LLM commands",
             "Show full config (masked)",
             "Open in $EDITOR",
             "─────────",
@@ -80,8 +81,9 @@ pub fn run_config_menu() -> Result<()> {
             7 => edit_hotkeys(&mut config)?,
             8 => edit_tray_overlay(&mut config)?,
             9 => edit_llm(&mut config)?,
-            10 => show_config(&config),
-            11 => {
+            10 => edit_llm_commands(&mut config)?,
+            11 => show_config(&config),
+            12 => {
                 if open_in_editor(&mut config)? {
                     // External edit already wrote the file; reload and skip the
                     // normal save path so we don't clobber formatting/comments
@@ -89,17 +91,17 @@ pub fn run_config_menu() -> Result<()> {
                     println!("  {GREEN}Applied edits from $EDITOR.{RESET}");
                 }
             }
-            12 => {
+            13 => {
                 // separator — no-op
             }
-            13 => {
+            14 => {
                 if save_and_restart(&config, fresh)? {
                     return Ok(());
                 }
                 // Validation failed — fall through to next loop iteration,
                 // preserving the in-memory `config` so the user can fix it.
             }
-            14 => {
+            15 => {
                 println!("\n  {DIM}Discarded changes.{RESET}");
                 return Ok(());
             }
@@ -126,6 +128,7 @@ fn default_config() -> Config {
         tts: None,
         hotkeys: None,
         overlay: None,
+        llm_commands: Vec::new(),
     }
 }
 
@@ -499,6 +502,175 @@ fn edit_llm(config: &mut Config) -> Result<()> {
         _ => {}
     }
     Ok(())
+}
+
+fn edit_llm_commands(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Custom LLM commands{RESET}");
+    println!(
+        "  {DIM}Each entry gets its own hotkey: dictate, the LLM applies a fixed\n   \
+         instruction to what you said, and the result is typed at the cursor —\n   \
+         a toggle-recording flavor of plain dictation, not command mode (no\n   \
+         selection needed). Uses the same [llm] configuration as command mode.{RESET}"
+    );
+
+    loop {
+        if config.llm_commands.is_empty() {
+            println!("  {DIM}(none configured){RESET}");
+        } else {
+            println!();
+            for (i, entry) in config.llm_commands.iter().enumerate() {
+                println!(
+                    "    {}. {BOLD}{}{RESET}  [{}]  {}",
+                    i + 1,
+                    entry.name,
+                    entry.hotkey,
+                    truncate_for_menu(&entry.instruction)
+                );
+            }
+        }
+
+        let mut choices = vec!["Add new".to_string()];
+        if !config.llm_commands.is_empty() {
+            choices.push("Edit an entry".to_string());
+            choices.push("Remove an entry".to_string());
+        }
+        choices.push("Done".to_string());
+        let done_index = choices.len() - 1;
+
+        let selection = Select::new()
+            .with_prompt("Custom LLM commands")
+            .items(&choices)
+            .default(done_index)
+            .interact()
+            .context("failed to read menu selection")?;
+
+        match choices[selection].as_str() {
+            "Add new" => add_llm_command(config)?,
+            "Edit an entry" => edit_one_llm_command(config)?,
+            "Remove an entry" => remove_llm_command(config)?,
+            _ => return Ok(()), // "Done"
+        }
+    }
+}
+
+fn add_llm_command(config: &mut Config) -> Result<()> {
+    let name: String = Input::new()
+        .with_prompt("Name (identifier, e.g. \"translate-de\")")
+        .interact_text()
+        .context("failed to read name")?;
+    if config.llm_commands.iter().any(|e| e.name == name) {
+        println!("  {YELLOW}An entry named '{name}' already exists — edit it instead.{RESET}");
+        return Ok(());
+    }
+    let hotkey: String = Input::new()
+        .with_prompt("Hotkey (e.g. \"Super+Shift+T\")")
+        .interact_text()
+        .context("failed to read hotkey")?;
+    let set_hotkey_raw: String = Input::new()
+        .with_prompt(
+            "Set-hotkey — reprogram this command from selected text (optional, blank to skip)",
+        )
+        .allow_empty(true)
+        .interact_text()
+        .context("failed to read set_hotkey")?;
+    let set_hotkey = Some(set_hotkey_raw.trim().to_string()).filter(|s| !s.is_empty());
+    let instruction: String = Input::new()
+        .with_prompt("Instruction applied to the dictated text")
+        .interact_text()
+        .context("failed to read instruction")?;
+
+    config.llm_commands.push(crate::llm::LlmCommandConfig {
+        name,
+        hotkey,
+        set_hotkey,
+        instruction,
+    });
+    println!("  {GREEN}Added.{RESET}");
+    Ok(())
+}
+
+fn edit_one_llm_command(config: &mut Config) -> Result<()> {
+    let Some(idx) = select_llm_command(config, "Edit which entry?")? else {
+        return Ok(());
+    };
+
+    let entry = config.llm_commands[idx].clone();
+    let name: String = Input::new()
+        .with_prompt("Name")
+        .default(entry.name)
+        .interact_text()
+        .context("failed to read name")?;
+    let hotkey: String = Input::new()
+        .with_prompt("Hotkey")
+        .default(entry.hotkey)
+        .interact_text()
+        .context("failed to read hotkey")?;
+    let set_hotkey_raw: String = Input::new()
+        .with_prompt("Set-hotkey (reprogram from selection; blank for none)")
+        .default(entry.set_hotkey.clone().unwrap_or_default())
+        .allow_empty(true)
+        .interact_text()
+        .context("failed to read set_hotkey")?;
+    let set_hotkey = Some(set_hotkey_raw.trim().to_string()).filter(|s| !s.is_empty());
+    let instruction: String = Input::new()
+        .with_prompt("Instruction")
+        .default(entry.instruction)
+        .interact_text()
+        .context("failed to read instruction")?;
+
+    config.llm_commands[idx] = crate::llm::LlmCommandConfig {
+        name,
+        hotkey,
+        set_hotkey,
+        instruction,
+    };
+    println!("  {GREEN}Updated.{RESET}");
+    Ok(())
+}
+
+fn remove_llm_command(config: &mut Config) -> Result<()> {
+    let Some(idx) = select_llm_command(config, "Remove which entry?")? else {
+        return Ok(());
+    };
+    let removed = config.llm_commands.remove(idx);
+    println!("  {GREEN}Removed '{}'.{RESET}", removed.name);
+    Ok(())
+}
+
+/// Show a picker over current entries plus a trailing "Cancel". Returns
+/// `None` when the user cancels.
+fn select_llm_command(config: &Config, prompt: &str) -> Result<Option<usize>> {
+    let mut items: Vec<String> = config
+        .llm_commands
+        .iter()
+        .map(|e| format!("{} ({})", e.name, e.hotkey))
+        .collect();
+    items.push("Cancel".to_string());
+    let cancel_index = items.len() - 1;
+
+    let selection = Select::new()
+        .with_prompt(prompt)
+        .items(&items)
+        .default(0)
+        .interact()
+        .context("failed to read selection")?;
+
+    Ok(if selection == cancel_index {
+        None
+    } else {
+        Some(selection)
+    })
+}
+
+/// Truncate an instruction string for the summary menu line.
+fn truncate_for_menu(s: &str) -> String {
+    const MAX: usize = 50;
+    if s.chars().count() <= MAX {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(MAX).collect();
+        format!("{truncated}…")
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -171,6 +171,7 @@ pub fn run_setup() -> Result<()> {
         tts: None,
         hotkeys: None,
         overlay: if overlay { overlay_config } else { None },
+        llm_commands: Vec::new(),
     };
 
     let config_path = write_config(&config)?;
@@ -773,7 +774,7 @@ fn test_microphone() {
 }
 
 /// Write the config to `~/.config/whisrs/config.toml` with `chmod 0600`.
-pub(crate) fn write_config(config: &Config) -> Result<PathBuf> {
+pub fn write_config(config: &Config) -> Result<PathBuf> {
     let config_path = crate::config_path();
     let config_dir = config_path
         .parent()

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -2550,7 +2550,10 @@ async fn handle_set_llm_instruction(
     }
 
     let Some(instruction) = acquire_selected_text(&context).await else {
-        if context.notify_state() {
+        // Not gated by `notify_state()`: this path never records, so the
+        // overlay (which would otherwise justify suppressing toasts) never
+        // shows — without a toast there'd be no feedback at all.
+        if context.notify {
             send_notification(
                 "whisrs",
                 &format!("'{name}': select the instruction text first"),
@@ -2573,7 +2576,12 @@ async fn handle_set_llm_instruction(
         "llm-command '{name}': instruction reprogrammed ({} chars)",
         instruction.len()
     );
-    if context.notify_state() {
+    // Audible + toast confirmation. Not gated by `notify_state()` (see above):
+    // the set path shows no overlay, so this is the only feedback the user gets.
+    if context.config.general.audio_feedback {
+        feedback::play_done(context.config.general.audio_feedback_volume);
+    }
+    if context.notify {
         let preview = truncate_preview(&instruction, 77);
         send_notification("whisrs", &format!("'{name}' set to: {preview}"));
     }

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -45,6 +45,17 @@ struct CommandModeContext {
     is_terminal: bool,
 }
 
+/// Context saved when a named LLM command (`[[llm_commands]]`) starts recording.
+///
+/// Simpler than [`CommandModeContext`]: there's no selection or clipboard
+/// involved — this is a toggle-recording flavor of plain dictation where the
+/// transcribed text is run through a fixed instruction before typing.
+struct LlmCommandContext {
+    name: String,
+    instruction: String,
+    llm_config: llm::LlmConfig,
+}
+
 /// Shared daemon state protected by a mutex.
 struct DaemonState {
     state_machine: StateMachine,
@@ -71,6 +82,15 @@ struct DaemonState {
     session_language: Option<String>,
     /// Active command mode context (set when command mode is recording).
     command_mode: Option<CommandModeContext>,
+    /// Active named LLM command context (set when an `[[llm_commands]]`
+    /// hotkey is recording).
+    llm_command: Option<LlmCommandContext>,
+    /// Runtime instruction overrides for `[[llm_commands]]`, keyed by command
+    /// name. Written by the `set_hotkey` path (`SetLlmInstruction`) so a
+    /// reprogrammed instruction takes effect immediately — the loaded
+    /// `Config` is an immutable `Arc`, so this map is the live source of truth
+    /// (and the change is also persisted to disk for the next start).
+    llm_instruction_overrides: std::collections::HashMap<String, String>,
     /// Stop flag for in-progress TTS playback (read-selection-aloud).
     ///
     /// Set when a `Speak` synthesis succeeds and playback begins; cleared when
@@ -91,6 +111,8 @@ impl DaemonState {
             recording_started_at: None,
             session_language: None,
             command_mode: None,
+            llm_command: None,
+            llm_instruction_overrides: std::collections::HashMap::new(),
             tts_stop: None,
         }
     }
@@ -189,6 +211,7 @@ fn load_config() -> (Config, Option<String>) {
                             llm: None,
                             tts: None,
                             hotkeys: None,
+                            llm_commands: Vec::new(),
                             overlay: None,
                         },
                         Some(msg),
@@ -217,6 +240,7 @@ fn load_config() -> (Config, Option<String>) {
                         llm: None,
                         tts: None,
                         hotkeys: None,
+                        llm_commands: Vec::new(),
                         overlay: None,
                     },
                     Some(msg),
@@ -245,6 +269,7 @@ fn load_config() -> (Config, Option<String>) {
             llm: None,
             tts: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
         },
         None,
@@ -798,15 +823,18 @@ async fn main() -> Result<()> {
         std::process::exit(0);
     });
 
-    // Start global hotkey listener if configured.
+    // Start global hotkey listener if configured — either the fixed
+    // [hotkeys] section, or any [[llm_commands]] entry (each carries its own
+    // hotkey independent of [hotkeys]).
     // Spawned as a background task so retries don't block the IPC server.
-    if let Some(ref hk_config) = context.config.hotkeys {
-        let hk_config = hk_config.clone();
+    if context.config.hotkeys.is_some() || !context.config.llm_commands.is_empty() {
+        let hk_config = context.config.hotkeys.clone().unwrap_or_default();
+        let llm_commands = context.config.llm_commands.clone();
         let hk_state = Arc::clone(&daemon_state);
         let hk_ctx = Arc::clone(&context);
         tokio::spawn(async move {
             let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::channel::<Command>(16);
-            whisrs::hotkey::start_hotkey_listener(&hk_config, hotkey_tx).await;
+            whisrs::hotkey::start_hotkey_listener(&hk_config, &llm_commands, hotkey_tx).await;
 
             // Process hotkey commands.
             while let Some(cmd) = hotkey_rx.recv().await {
@@ -885,6 +913,10 @@ async fn handle_command(
             },
         },
         Command::CommandMode => handle_command_mode(daemon_state, context).await,
+        Command::LlmCommand { name } => handle_llm_command(daemon_state, context, name).await,
+        Command::SetLlmInstruction { name } => {
+            handle_set_llm_instruction(daemon_state, context, name).await
+        }
         Command::Speak => handle_speak(daemon_state, context).await,
     }
 }
@@ -2425,6 +2457,479 @@ async fn command_mode_background(
     }
 }
 
+/// Handle a named `[[llm_commands]]` hotkey. A toggle-recording flavor of
+/// plain dictation: first press starts recording, second press stops it and
+/// runs the transcribed text through the command's fixed instruction via the
+/// LLM before typing the result at the cursor. Unlike command mode, there's
+/// no selection or clipboard involved.
+async fn handle_llm_command(
+    daemon_state: Arc<Mutex<DaemonState>>,
+    context: Arc<DaemonContext>,
+    name: String,
+) -> Response {
+    let current_state = {
+        let ds = daemon_state.lock().await;
+        ds.state_machine.state()
+    };
+
+    match current_state {
+        State::Recording => {
+            // Second press: only stop if an llm-command session is active —
+            // mirrors handle_command_mode's own-flag check.
+            let is_llm_command = {
+                let ds = daemon_state.lock().await;
+                ds.llm_command.is_some()
+            };
+            if !is_llm_command {
+                return Response::Error {
+                    message: "recording is active but not for an llm-command — use toggle, \
+                              command, or cancel"
+                        .to_string(),
+                };
+            }
+            let mut ds = daemon_state.lock().await;
+            if let Some(mut capture) = ds.audio_capture.take() {
+                capture.stop();
+                tokio::task::spawn_blocking(move || drop(capture));
+            }
+            info!("llm-command '{name}': manual stop");
+            Response::Ok {
+                state: State::Recording,
+            }
+        }
+        State::Idle => {
+            let entry = context
+                .config
+                .llm_commands
+                .iter()
+                .find(|e| e.name == name)
+                .cloned();
+            match entry {
+                Some(entry) => llm_command_start(daemon_state, context, entry).await,
+                None => Response::Error {
+                    message: format!("no llm_commands entry named '{name}' — check config.toml"),
+                },
+            }
+        }
+        State::Transcribing => Response::Error {
+            message: "cannot start llm-command while transcribing".to_string(),
+        },
+        State::Synthesizing | State::Speaking => Response::Error {
+            message: "cannot start llm-command while reading aloud — cancel read-aloud first"
+                .to_string(),
+        },
+    }
+}
+
+/// Reprogram a named LLM command from the current selection (its `set_hotkey`).
+///
+/// Synchronous: no recording, no LLM, no typing. Captures the highlighted text
+/// and stores it as the command's new instruction — applied live via the
+/// daemon override map and persisted to `config.toml` for the next start.
+async fn handle_set_llm_instruction(
+    daemon_state: Arc<Mutex<DaemonState>>,
+    context: Arc<DaemonContext>,
+    name: String,
+) -> Response {
+    // Only when idle — don't interfere with an active recording / read-aloud.
+    let state = {
+        let ds = daemon_state.lock().await;
+        ds.state_machine.state()
+    };
+    if state != State::Idle {
+        return Response::Error {
+            message: format!("cannot set an instruction while {state:?} — finish or cancel first"),
+        };
+    }
+
+    // The command must exist (its hotkey was registered from config).
+    if !context.config.llm_commands.iter().any(|e| e.name == name) {
+        return Response::Error {
+            message: format!("no llm_commands entry named '{name}' — check config.toml"),
+        };
+    }
+
+    let Some(instruction) = acquire_selected_text(&context).await else {
+        if context.notify_state() {
+            send_notification(
+                "whisrs",
+                &format!("'{name}': select the instruction text first"),
+            );
+        }
+        return Response::Ok { state: State::Idle };
+    };
+
+    {
+        let mut ds = daemon_state.lock().await;
+        ds.llm_instruction_overrides
+            .insert(name.clone(), instruction.clone());
+    }
+
+    if let Err(e) = persist_llm_instruction(&name, &instruction) {
+        warn!("llm-command '{name}': failed to persist new instruction to config: {e:#}");
+    }
+
+    info!(
+        "llm-command '{name}': instruction reprogrammed ({} chars)",
+        instruction.len()
+    );
+    if context.notify_state() {
+        let preview = truncate_preview(&instruction, 77);
+        send_notification("whisrs", &format!("'{name}' set to: {preview}"));
+    }
+
+    Response::Ok { state: State::Idle }
+}
+
+/// Capture the currently selected text: primary selection first, else a
+/// simulated copy (Ctrl+C, or Ctrl+Shift+C in terminals). Restores the
+/// clipboard afterwards (this path never pastes). Returns `None` when nothing
+/// usable is selected. Mirrors command mode's acquisition, minus the recording.
+async fn acquire_selected_text(context: &DaemonContext) -> Option<String> {
+    let clipboard = xkb_type::default_clipboard();
+    let saved = clipboard.get_text().unwrap_or_default();
+
+    let is_terminal = context
+        .window_tracker
+        .get_focused_window_class()
+        .map(|c| is_terminal_class(&c))
+        .unwrap_or(false);
+
+    let mut text = clipboard.get_primary_selection().unwrap_or_default();
+
+    if text.trim().is_empty() || text == saved {
+        let copy_fn = if is_terminal {
+            simulate_terminal_copy
+        } else {
+            simulate_copy
+        };
+        let _ = tokio::task::spawn_blocking(copy_fn).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        text = clipboard.get_text().unwrap_or_default();
+    }
+
+    // Restore the user's clipboard — the set path never pastes.
+    let _ = clipboard.set_text(&saved);
+
+    let text = text.trim().to_string();
+    if text.is_empty() || text == saved.trim() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// Persist a reprogrammed instruction to `config.toml`: re-read the on-disk
+/// config, update the matching entry, write it back. Best-effort — the
+/// in-memory override already applies to the running daemon.
+fn persist_llm_instruction(name: &str, instruction: &str) -> anyhow::Result<()> {
+    let path = whisrs::config_path();
+    let contents = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read config at {}", path.display()))?;
+    let mut config: Config =
+        toml::from_str(&contents).context("failed to parse config for instruction update")?;
+    let entry = config
+        .llm_commands
+        .iter_mut()
+        .find(|e| e.name == name)
+        .ok_or_else(|| anyhow::anyhow!("entry '{name}' not present in config file"))?;
+    entry.instruction = instruction.to_string();
+    whisrs::config::setup::write_config(&config)?;
+    Ok(())
+}
+
+/// Named LLM command, first press: capture the focused window, start
+/// recording, spawn the background processor. Mirrors `handle_toggle`'s Idle
+/// branch (batch path only — this feature doesn't support streaming
+/// backends, same as command mode).
+async fn llm_command_start(
+    daemon_state: Arc<Mutex<DaemonState>>,
+    context: Arc<DaemonContext>,
+    entry: llm::LlmCommandConfig,
+) -> Response {
+    let llm_config = context.config.llm.clone().unwrap_or_default();
+
+    // Capture focused window before recording, like plain dictation — the
+    // result is typed at the cursor, not pasted over a selection.
+    let window_id = match context.window_tracker.get_focused_window() {
+        Ok(id) => Some(id),
+        Err(e) => {
+            warn!("failed to capture focused window: {e}");
+            None
+        }
+    };
+
+    if context.config.general.audio_feedback {
+        feedback::play_start(context.config.general.audio_feedback_volume);
+    }
+
+    let mut capture =
+        match AudioCaptureHandle::start_with_level_tx(context.overlay_level_tx.clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                let msg = format!("{e}");
+                let friendly = if msg.contains("no default audio input device") {
+                    format_no_microphone_error()
+                } else {
+                    format!("Failed to start audio capture: {e}")
+                };
+                error!("{friendly}");
+                return Response::Error { message: friendly };
+            }
+        };
+
+    let audio_rx = capture.take_receiver();
+
+    {
+        let mut ds = daemon_state.lock().await;
+        if let Err(e) = ds.state_machine.transition(Action::Toggle) {
+            return Response::Error {
+                message: format!("state transition failed: {e}"),
+            };
+        }
+        ds.audio_capture = Some(capture);
+        ds.recording_window_id = window_id;
+        ds.recording_started_at = Some(std::time::Instant::now());
+        // Prefer a runtime override set via `set_hotkey`; else the configured
+        // instruction.
+        let instruction = ds
+            .llm_instruction_overrides
+            .get(&entry.name)
+            .cloned()
+            .unwrap_or_else(|| entry.instruction.clone());
+        ds.llm_command = Some(LlmCommandContext {
+            name: entry.name.clone(),
+            instruction,
+            llm_config,
+        });
+    }
+
+    if context.notify_state() {
+        send_notification(
+            "whisrs",
+            &format!("Recording for '{}'... (press again to stop)", entry.name),
+        );
+    }
+
+    let ds_ref = Arc::clone(&daemon_state);
+    let ctx = Arc::clone(&context);
+    tokio::spawn(async move {
+        llm_command_background(audio_rx, ds_ref, ctx).await;
+    });
+
+    Response::Ok {
+        state: State::Recording,
+    }
+}
+
+/// Background task: collects audio until channel closes (manual stop or
+/// auto-stop), transcribes it, applies the command's fixed instruction via
+/// the LLM (reusing the same `llm::rewrite_text` call as command mode, just
+/// with the roles swapped — the dictated text is the "selected text" and the
+/// preset instruction is the "voice instruction"), and types the result at
+/// the cursor.
+async fn llm_command_background(
+    audio_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Vec<i16>>>,
+    daemon_state: Arc<Mutex<DaemonState>>,
+    context: Arc<DaemonContext>,
+) {
+    let silence_timeout = context.config.general.silence_timeout_ms;
+    let mut auto_stop = AutoStopDetector::new(SILENCE_RMS_THRESHOLD, silence_timeout, SAMPLE_RATE);
+    let mut all_samples: Vec<i16> = Vec::new();
+
+    if let Some(mut rx) = audio_rx {
+        while let Some(chunk) = rx.recv().await {
+            all_samples.extend_from_slice(&chunk);
+            if auto_stop.feed(&chunk) {
+                info!("llm-command: silence auto-stop");
+                let mut ds = daemon_state.lock().await;
+                if let Some(mut capture) = ds.audio_capture.take() {
+                    capture.stop();
+                    tokio::task::spawn_blocking(move || drop(capture));
+                }
+                break;
+            }
+        }
+    }
+
+    let (cmd_ctx, window_id, recording_started_at) = {
+        let mut ds = daemon_state.lock().await;
+        ds.audio_capture.take();
+        (
+            ds.llm_command.take(),
+            ds.recording_window_id.take(),
+            ds.recording_started_at.take(),
+        )
+    };
+
+    let Some(cmd_ctx) = cmd_ctx else {
+        warn!("llm-command: context missing, aborting");
+        let mut ds = daemon_state.lock().await;
+        let _ = ds.state_machine.transition(Action::Toggle);
+        let _ = ds.state_machine.transition(Action::TranscriptionDone);
+        return;
+    };
+
+    {
+        let mut ds = daemon_state.lock().await;
+        let _ = ds.state_machine.transition(Action::Toggle);
+    }
+
+    if context.config.general.audio_feedback {
+        feedback::play_stop(context.config.general.audio_feedback_volume);
+    }
+
+    if let Some(reason) = audio_gate_reason(
+        &all_samples,
+        SAMPLE_RATE,
+        AUDIO_GATE_MIN_MS,
+        SILENCE_RMS_THRESHOLD,
+    ) {
+        let label = reason.as_str();
+        info!(
+            "llm-command '{}': skipping (recording was {label}, {} samples)",
+            cmd_ctx.name,
+            all_samples.len()
+        );
+        if context.notify_state() {
+            send_notification("whisrs", &format!("Skipped: recording was {label}"));
+        }
+        let mut ds = daemon_state.lock().await;
+        let _ = ds.state_machine.transition(Action::TranscriptionDone);
+        return;
+    }
+
+    if context.notify_state() {
+        send_notification("whisrs", &format!("Processing '{}'...", cmd_ctx.name));
+    }
+
+    let wav_data = match whisrs::audio::capture::encode_wav(&all_samples) {
+        Ok(d) => d,
+        Err(e) => {
+            error!(
+                "llm-command '{}': failed to encode audio: {e}",
+                cmd_ctx.name
+            );
+            let mut ds = daemon_state.lock().await;
+            let _ = ds.state_machine.transition(Action::TranscriptionDone);
+            return;
+        }
+    };
+
+    let config = build_transcription_config(&context.config, &context.config.general.language);
+
+    let text = match context
+        .transcription_backend
+        .transcribe(&wav_data, &config)
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            let friendly = format_api_error(&e);
+            error!(
+                "llm-command '{}': transcription failed: {friendly}",
+                cmd_ctx.name
+            );
+            if context.notify_error() {
+                send_notification("whisrs", &format!("'{}' failed: {friendly}", cmd_ctx.name));
+            }
+            let mut ds = daemon_state.lock().await;
+            let _ = ds.state_machine.transition(Action::TranscriptionDone);
+            return;
+        }
+    };
+
+    if text.is_empty() {
+        if context.notify_error() {
+            send_notification("whisrs", "Could not understand speech — try again");
+        }
+        let mut ds = daemon_state.lock().await;
+        let _ = ds.state_machine.transition(Action::TranscriptionDone);
+        return;
+    }
+
+    info!(
+        "llm-command '{}': transcribed {} chars",
+        cmd_ctx.name,
+        text.len()
+    );
+
+    let result = match llm::rewrite_text(&cmd_ctx.llm_config, &text, &cmd_ctx.instruction).await {
+        Ok(r) => r,
+        Err(e) => {
+            error!("llm-command '{}': LLM failed: {e}", cmd_ctx.name);
+            if context.notify_error() {
+                send_notification("whisrs", &format!("'{}' failed: {e}", cmd_ctx.name));
+            }
+            let mut ds = daemon_state.lock().await;
+            let _ = ds.state_machine.transition(Action::TranscriptionDone);
+            return;
+        }
+    };
+
+    if result.is_empty() {
+        if context.notify_error() {
+            send_notification(
+                "whisrs",
+                &format!("'{}': LLM returned empty text", cmd_ctx.name),
+            );
+        }
+        let mut ds = daemon_state.lock().await;
+        let _ = ds.state_machine.transition(Action::TranscriptionDone);
+        return;
+    }
+
+    // Restore window focus, then type the result at the cursor.
+    if let Some(wid) = &window_id {
+        if let Err(e) = context.window_tracker.focus_window(wid) {
+            warn!("failed to restore window focus: {e}");
+        } else {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    let result_clone = result.clone();
+    let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
+    let injector_backend = context.config.input.backend;
+    match tokio::task::spawn_blocking(move || {
+        type_text_at_cursor(&result_clone, key_delay, injector_backend)
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!("llm-command '{}': failed to type text: {e:#}", cmd_ctx.name),
+        Err(e) => warn!(
+            "llm-command '{}': failed to join typing task: {e}",
+            cmd_ctx.name
+        ),
+    }
+
+    let duration_secs = recording_started_at
+        .map(|t| t.elapsed().as_secs_f64())
+        .unwrap_or(0.0);
+    save_history_entry(
+        &result,
+        &format!("llm:{}", cmd_ctx.name),
+        &context.config.general.language,
+        duration_secs,
+    );
+
+    if context.config.general.audio_feedback {
+        feedback::play_done(context.config.general.audio_feedback_volume);
+    }
+    if context.notify_state() {
+        let preview = truncate_preview(&result, 77);
+        send_notification("whisrs", &format!("'{}' done: {preview}", cmd_ctx.name));
+    }
+
+    let mut ds = daemon_state.lock().await;
+    let _ = ds.state_machine.transition(Action::TranscriptionDone);
+    let _ = context.state_tx.send(ds.state_machine.state());
+    if let Some(level_tx) = &context.overlay_level_tx {
+        let _ = level_tx.send(0.0);
+    }
+}
+
 /// Simulate a key combo (e.g. Ctrl+C, Ctrl+V) via a temporary uinput device.
 fn simulate_key_combo(modifier: evdev::Key, key: evdev::Key) -> anyhow::Result<()> {
     use evdev::{AttributeSet, EventType, InputEvent, Key};
@@ -3326,6 +3831,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
             tts: None,
         };

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -13,6 +13,7 @@ use evdev::{Device, EventType, InputEventKind, Key};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
+use crate::llm::LlmCommandConfig;
 use crate::{Command, HotkeyConfig};
 pub use parse::{parse_hotkey, HotkeyBinding};
 
@@ -34,7 +35,11 @@ struct HotkeyAction {
 /// matching commands through the provided channel. Retries with exponential
 /// backoff if no keyboards are found yet (common on boot when the daemon
 /// starts before input devices are fully initialized). Runs until dropped.
-pub async fn start_hotkey_listener(config: &HotkeyConfig, cmd_tx: mpsc::Sender<Command>) {
+pub async fn start_hotkey_listener(
+    config: &HotkeyConfig,
+    llm_commands: &[LlmCommandConfig],
+    cmd_tx: mpsc::Sender<Command>,
+) {
     let mut actions = Vec::new();
 
     if let Some(ref s) = config.toggle {
@@ -86,6 +91,45 @@ pub async fn start_hotkey_listener(config: &HotkeyConfig, cmd_tx: mpsc::Sender<C
                 });
             }
             Err(e) => warn!("invalid speak hotkey '{s}': {e}"),
+        }
+    }
+
+    for entry in llm_commands {
+        match parse_hotkey(&entry.hotkey) {
+            Ok(binding) => {
+                info!("hotkey: llm-command '{}' = {}", entry.name, entry.hotkey);
+                actions.push(HotkeyAction {
+                    binding,
+                    command: Command::LlmCommand {
+                        name: entry.name.clone(),
+                    },
+                });
+            }
+            Err(e) => warn!(
+                "invalid hotkey '{}' for llm-command '{}': {e}",
+                entry.hotkey, entry.name
+            ),
+        }
+
+        if let Some(set_hotkey) = &entry.set_hotkey {
+            match parse_hotkey(set_hotkey) {
+                Ok(binding) => {
+                    info!(
+                        "hotkey: llm-command '{}' set-instruction = {}",
+                        entry.name, set_hotkey
+                    );
+                    actions.push(HotkeyAction {
+                        binding,
+                        command: Command::SetLlmInstruction {
+                            name: entry.name.clone(),
+                        },
+                    });
+                }
+                Err(e) => warn!(
+                    "invalid set_hotkey '{}' for llm-command '{}': {e}",
+                    set_hotkey, entry.name
+                ),
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,21 @@ pub enum Command {
     /// Start command mode: copy selection → record voice instruction → LLM rewrite → paste.
     #[serde(rename = "command")]
     CommandMode,
+    /// Toggle a named custom LLM command (see `[[llm_commands]]`): dictate →
+    /// LLM applies the configured instruction to the transcribed text →
+    /// types the result at the cursor. A second press on the same command
+    /// (or any other) stops recording, same as `toggle`.
+    #[serde(rename = "llm-command")]
+    LlmCommand {
+        name: String,
+    },
+    /// Reprogram a named LLM command (see `[[llm_commands]]` `set_hotkey`):
+    /// the currently selected text becomes the command's new instruction,
+    /// saved to config and applied live. No recording, LLM call, or typing.
+    #[serde(rename = "set-llm-instruction")]
+    SetLlmInstruction {
+        name: String,
+    },
     /// Read the selected text aloud via TTS. A repeat `Speak` (or `Cancel`)
     /// stops any in-progress playback.
     #[serde(alias = "read")]
@@ -129,6 +144,10 @@ pub struct Config {
     /// Overlay appearance config (theme, dimensions, optional custom colors).
     #[serde(default)]
     pub overlay: Option<OverlayConfig>,
+    /// Named custom LLM commands, each with its own hotkey (see
+    /// [`llm::LlmCommandConfig`]). Empty by default.
+    #[serde(default)]
+    pub llm_commands: Vec<llm::LlmCommandConfig>,
 }
 
 /// Global hotkey configuration — key combos that trigger actions.
@@ -947,6 +966,65 @@ impl Config {
             });
         }
 
+        if !self.llm_commands.is_empty() {
+            if self.llm.is_none() {
+                warnings.push(ConfigWarning {
+                    message: "llm_commands configured but no [llm] section — add [llm] api_key \
+                              (or set WHISRS_OPENAI_API_KEY / WHISRS_GROQ_API_KEY) or these \
+                              hotkeys will fail at runtime"
+                        .to_string(),
+                });
+            }
+
+            let mut seen_names = std::collections::HashSet::new();
+            for entry in &self.llm_commands {
+                if entry.name.trim().is_empty() {
+                    warnings.push(ConfigWarning {
+                        message: "llm_commands entry has an empty name".to_string(),
+                    });
+                } else if !seen_names.insert(entry.name.clone()) {
+                    warnings.push(ConfigWarning {
+                        message: format!("llm_commands has a duplicate name: '{}'", entry.name),
+                    });
+                }
+                if entry.hotkey.trim().is_empty() {
+                    warnings.push(ConfigWarning {
+                        message: format!("llm_commands '{}' has an empty hotkey", entry.name),
+                    });
+                } else if let Err(e) = hotkey::parse_hotkey(&entry.hotkey) {
+                    warnings.push(ConfigWarning {
+                        message: format!(
+                            "llm_commands '{}' has an invalid hotkey '{}': {e}",
+                            entry.name, entry.hotkey
+                        ),
+                    });
+                }
+                if let Some(set_hotkey) = &entry.set_hotkey {
+                    if let Err(e) = hotkey::parse_hotkey(set_hotkey) {
+                        warnings.push(ConfigWarning {
+                            message: format!(
+                                "llm_commands '{}' has an invalid set_hotkey '{}': {e}",
+                                entry.name, set_hotkey
+                            ),
+                        });
+                    } else if *set_hotkey == entry.hotkey {
+                        warnings.push(ConfigWarning {
+                            message: format!(
+                                "llm_commands '{}' has set_hotkey equal to hotkey '{}' — one \
+                                 press can't both run and reprogram",
+                                entry.name, entry.hotkey
+                            ),
+                        });
+                    }
+                }
+                if entry.instruction.trim().is_empty() {
+                    warnings.push(ConfigWarning {
+                        message: format!("llm_commands '{}' has an empty instruction", entry.name),
+                    });
+                }
+            }
+        }
+
         Ok(warnings)
     }
 
@@ -1492,6 +1570,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
         };
         let err = config.validate().unwrap_err();
@@ -1537,6 +1616,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
         };
         let err = config.validate().unwrap_err();
@@ -1566,6 +1646,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
         };
         let result = config.validate();
@@ -1598,6 +1679,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
         };
         let warnings = config.validate().unwrap();
@@ -1637,6 +1719,7 @@ mod tests {
                 llm: None,
                 tts: None,
                 hotkeys: None,
+                llm_commands: Vec::new(),
                 overlay: None,
             };
             let warnings = config.validate().unwrap();
@@ -1687,6 +1770,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
         };
 
@@ -1735,6 +1819,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
         };
         let warnings = config.validate().unwrap();
@@ -1789,6 +1874,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
             tts: None,
         };
@@ -1821,6 +1907,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
             tts: None,
         };
@@ -1854,6 +1941,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
             tts: None,
         };
@@ -1887,6 +1975,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
             tts: None,
         };
@@ -1920,6 +2009,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
             tts: None,
         };
@@ -1950,6 +2040,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            llm_commands: Vec::new(),
             overlay: None,
             tts: None,
         };
@@ -2000,5 +2091,258 @@ mod tests {
 
         let _ = std::fs::remove_file(&sock_path);
         let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn llm_command_serialization_roundtrip() {
+        let cmd = Command::LlmCommand {
+            name: "translate-de".to_string(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(json, r#"{"cmd":"llm-command","name":"translate-de"}"#);
+        let parsed: Command = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, Command::LlmCommand { name } if name == "translate-de"));
+    }
+
+    #[test]
+    fn config_parses_llm_commands_array() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+
+            [[llm_commands]]
+            name = "translate-de"
+            hotkey = "Super+Shift+T"
+            instruction = "Translate the following into German, informal tone."
+
+            [[llm_commands]]
+            name = "summarize"
+            hotkey = "Super+Shift+S"
+            instruction = "Summarize the following in one sentence."
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.llm_commands.len(), 2);
+        assert_eq!(config.llm_commands[0].name, "translate-de");
+        assert_eq!(config.llm_commands[0].hotkey, "Super+Shift+T");
+        assert_eq!(config.llm_commands[1].name, "summarize");
+
+        // Round-trips back out and parses again identically.
+        let serialized = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.llm_commands.len(), 2);
+    }
+
+    #[test]
+    fn config_without_llm_commands_defaults_empty() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+            "#,
+        )
+        .unwrap();
+        assert!(config.llm_commands.is_empty());
+    }
+
+    #[test]
+    fn config_validate_warns_llm_commands_without_llm_section() {
+        let mut config = Config {
+            general: GeneralConfig {
+                backend: "groq".to_string(),
+                ..Default::default()
+            },
+            audio: Default::default(),
+            input: Default::default(),
+            deepgram: None,
+            groq: Some(GroqConfig {
+                api_key: "test-key".to_string(),
+                model: "whisper-large-v3-turbo".to_string(),
+            }),
+            openai: None,
+            local_whisper: None,
+            local_vosk: None,
+            local_parakeet: None,
+            asr_sidecar: None,
+            openai_compatible_realtime: None,
+            llm: None,
+            hotkeys: None,
+            llm_commands: Vec::new(),
+            overlay: None,
+            tts: None,
+        };
+        config.llm_commands.push(llm::LlmCommandConfig {
+            name: "translate-de".to_string(),
+            hotkey: "Super+Shift+T".to_string(),
+            set_hotkey: None,
+            instruction: "Translate to German.".to_string(),
+        });
+
+        let warnings = config.validate().unwrap();
+        assert!(warnings
+            .iter()
+            .any(|w| w.message.contains("no [llm] section")));
+    }
+
+    #[test]
+    fn config_validate_rejects_duplicate_llm_command_names() {
+        let mut config = Config {
+            general: GeneralConfig {
+                backend: "groq".to_string(),
+                ..Default::default()
+            },
+            audio: Default::default(),
+            input: Default::default(),
+            deepgram: None,
+            groq: Some(GroqConfig {
+                api_key: "test-key".to_string(),
+                model: "whisper-large-v3-turbo".to_string(),
+            }),
+            openai: None,
+            local_whisper: None,
+            local_vosk: None,
+            local_parakeet: None,
+            asr_sidecar: None,
+            openai_compatible_realtime: None,
+            llm: Some(llm::LlmConfig::default()),
+            hotkeys: None,
+            llm_commands: Vec::new(),
+            overlay: None,
+            tts: None,
+        };
+        for _ in 0..2 {
+            config.llm_commands.push(llm::LlmCommandConfig {
+                name: "dup".to_string(),
+                hotkey: "Super+Shift+T".to_string(),
+                set_hotkey: None,
+                instruction: "Translate to German.".to_string(),
+            });
+        }
+
+        let warnings = config.validate().unwrap();
+        assert!(warnings
+            .iter()
+            .any(|w| w.message.contains("duplicate name")));
+    }
+
+    #[test]
+    fn config_validate_rejects_invalid_llm_command_hotkey() {
+        let mut config = Config {
+            general: GeneralConfig {
+                backend: "groq".to_string(),
+                ..Default::default()
+            },
+            audio: Default::default(),
+            input: Default::default(),
+            deepgram: None,
+            groq: Some(GroqConfig {
+                api_key: "test-key".to_string(),
+                model: "whisper-large-v3-turbo".to_string(),
+            }),
+            openai: None,
+            local_whisper: None,
+            local_vosk: None,
+            local_parakeet: None,
+            asr_sidecar: None,
+            openai_compatible_realtime: None,
+            llm: Some(llm::LlmConfig::default()),
+            hotkeys: None,
+            llm_commands: Vec::new(),
+            overlay: None,
+            tts: None,
+        };
+        config.llm_commands.push(llm::LlmCommandConfig {
+            name: "translate-de".to_string(),
+            hotkey: "NotAKey".to_string(),
+            set_hotkey: None,
+            instruction: "Translate to German.".to_string(),
+        });
+
+        let warnings = config.validate().unwrap();
+        assert!(warnings
+            .iter()
+            .any(|w| w.message.contains("invalid hotkey")));
+    }
+
+    #[test]
+    fn llm_command_set_hotkey_defaults_none_and_parses() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+
+            [[llm_commands]]
+            name = "no-set"
+            hotkey = "Super+Shift+T"
+            instruction = "Translate to German."
+
+            [[llm_commands]]
+            name = "with-set"
+            hotkey = "Super+Shift+U"
+            set_hotkey = "Super+Shift+Alt+U"
+            instruction = "Summarize."
+            "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.llm_commands[0].set_hotkey, None);
+        assert_eq!(
+            cfg.llm_commands[1].set_hotkey.as_deref(),
+            Some("Super+Shift+Alt+U")
+        );
+    }
+
+    #[test]
+    fn set_llm_instruction_serialization_roundtrip() {
+        let cmd = Command::SetLlmInstruction {
+            name: "translate-de".to_string(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(
+            json,
+            r#"{"cmd":"set-llm-instruction","name":"translate-de"}"#
+        );
+        let parsed: Command = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, Command::SetLlmInstruction { name } if name == "translate-de"));
+    }
+
+    #[test]
+    fn config_validate_warns_set_hotkey_equal_to_hotkey() {
+        let mut config = Config {
+            general: GeneralConfig {
+                backend: "groq".to_string(),
+                ..Default::default()
+            },
+            audio: Default::default(),
+            input: Default::default(),
+            deepgram: None,
+            groq: Some(GroqConfig {
+                api_key: "test-key".to_string(),
+                model: "whisper-large-v3-turbo".to_string(),
+            }),
+            openai: None,
+            local_whisper: None,
+            local_vosk: None,
+            local_parakeet: None,
+            asr_sidecar: None,
+            openai_compatible_realtime: None,
+            llm: Some(llm::LlmConfig::default()),
+            hotkeys: None,
+            llm_commands: Vec::new(),
+            overlay: None,
+            tts: None,
+        };
+        config.llm_commands.push(llm::LlmCommandConfig {
+            name: "translate-de".to_string(),
+            hotkey: "Super+Shift+T".to_string(),
+            set_hotkey: Some("Super+Shift+T".to_string()),
+            instruction: "Translate to German.".to_string(),
+        });
+
+        let warnings = config.validate().unwrap();
+        assert!(warnings
+            .iter()
+            .any(|w| w.message.contains("set_hotkey equal to hotkey")));
     }
 }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,7 +1,12 @@
 //! LLM integration for command mode.
 //!
 //! Sends selected text + a voice instruction to an LLM chat API and returns
-//! the rewritten text. Supports OpenAI-compatible endpoints (OpenAI, Groq).
+//! the rewritten text. Supports any OpenAI-compatible `/chat/completions`
+//! endpoint — OpenAI, Groq, or a local server (LM Studio, Ollama, llama.cpp
+//! server, ...). Point `[llm] api_url` at the local server (e.g.
+//! `http://localhost:1234/v1/chat/completions` for LM Studio) and set
+//! `model` to whatever the server has loaded; local servers don't validate
+//! `api_key`, so any placeholder string works.
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -37,6 +42,37 @@ fn default_llm_model() -> String {
 
 fn default_llm_url() -> String {
     "https://api.openai.com/v1/chat/completions".to_string()
+}
+
+/// A named custom LLM command: dictate → the configured instruction is
+/// applied to the transcribed text by the LLM → the result is typed at the
+/// cursor. Unlike command mode (`[hotkeys] command`), this doesn't touch the
+/// selection or clipboard — it's a toggle-recording flavor of plain
+/// dictation, just with an LLM post-processing step and a fixed instruction
+/// instead of a spoken one.
+///
+/// Each entry gets its own global hotkey, registered the same way as the
+/// built-in `[hotkeys]` entries. Uses the shared `[llm]` config — there's no
+/// per-command model/key override (keep the config surface small; add one
+/// only if real usage shows it's needed).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmCommandConfig {
+    /// Unique identifier — used in logs and by `whisrs llm-command <name>`
+    /// for compositor keybind integration (same pattern as `whisrs toggle`).
+    pub name: String,
+    /// Key combo string (e.g. "Super+Shift+T"), same format as `[hotkeys]`.
+    /// Runs the command: dictate → LLM applies `instruction` → type at cursor.
+    pub hotkey: String,
+    /// Optional second key combo that *reprograms* this command: press it with
+    /// text selected and the highlighted text becomes the new `instruction`
+    /// (saved to config, applied live). Same format as `hotkey`. Absent = the
+    /// instruction can only be changed by editing the config.
+    #[serde(default)]
+    pub set_hotkey: Option<String>,
+    /// Instruction applied to the dictated text (e.g. "Translate the following
+    /// text into German. Return only the translated text."). Can be replaced at
+    /// runtime via `set_hotkey`.
+    pub instruction: String,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary

Adds **named custom LLM commands** — `[[llm_commands]]` entries, each with its own
global `hotkey` and an `instruction`. Running one is a toggle-recording flavour of plain
dictation with an LLM step: press the hotkey → dictate → press again (or silence
auto-stop) → the transcript is run through the instruction via the shared `[llm]` chat
backend → the result is typed at the cursor. Unlike command mode, no selection is involved
on the run path.

Each entry also takes an optional **`set_hotkey`** that **reprograms it by selection**:
highlight the new instruction text anywhere, press `set_hotkey`, and that text becomes the
command's `instruction` — saved to `config.toml` and applied immediately (no restart). So
you repurpose a command (translate → summarize → …) with a keypress instead of editing
config. It's selection-based on purpose: the instruction is a precise prompt every future
run depends on, so we avoid dictation/STT glitches there.

```toml
[llm]
api_key = "not-needed"                 # local servers ignore this
model = "google/gemma-3-4b"
api_url = "http://localhost:1234/v1/chat/completions"   # LM Studio / Ollama / etc.

[[llm_commands]]
name = "scratch"
hotkey = "Super+Shift+T"               # run: dictate -> LLM -> type
set_hotkey = "Super+Shift+Alt+T"       # reprogram: select new instruction, press
instruction = "Translate the following text into German. Return only the translation."
```

Also triggerable from compositor keybinds: `whisrs llm-command <name>` and
`whisrs llm-command-set <name>`.

## Changes

- **lib.rs**: `Command::LlmCommand` + `Command::SetLlmInstruction`;
  `Config.llm_commands: Vec<LlmCommandConfig>`; `validate()` warnings (no `[llm]` section,
  empty/duplicate name, invalid `hotkey`/`set_hotkey`, `set_hotkey == hotkey` collision,
  empty instruction).
- **llm.rs**: `LlmCommandConfig { name, hotkey, set_hotkey: Option<String>, instruction }`;
  the run path reuses `rewrite_text`.
- **hotkey**: register the run bind and, when present, the set bind per entry.
- **daemon**:
  - Run path — `handle_llm_command` / `llm_command_start` / `llm_command_background`
    (batch; record → transcribe → LLM → type), resolving the instruction from a runtime
    override first.
  - Set path — `handle_set_llm_instruction` (synchronous: capture selection via
    primary-selection/Ctrl+C, store in a `DaemonState` override map so it applies live, and
    persist to disk). No recording, LLM, or typing.
- **cli**: `whisrs llm-command <name>` and `whisrs llm-command-set <name>`.
- **config edit/setup**: interactive add/edit prompt for the optional `set_hotkey`.
- **setup::write_config** made `pub` so the daemon can persist a reprogrammed instruction.
- **docs/configuration.md**: document both binds.
- **set-instruction feedback** is signalled independent of the overlay (a done-sound + toast), since the set path never records and so shows no overlay.

## Relationship to #62

Soft dependency on #62 (exact modifier matching): if you set `set_hotkey` as a
*superset* of `hotkey` (e.g. run `Shift+F14`, set `Shift+Ctrl+F14`), the exact-match
fix in #62 is what stops the run bind from also firing. With distinct trigger keys it's
not required. Recommend merging #62 first, then rebasing this on it.

## Testing

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all
  clean; minimal build (`--no-default-features --features tray,overlay`) also builds.
- New unit tests: command serialization round-trips, `set_hotkey` serde default/parse,
  and the validation warnings (incl. `set_hotkey == hotkey`).
- Manually exercised end-to-end on **KDE Plasma (Wayland), Fedora** against a local
  OpenAI-compatible server (LM Studio): run a command (dictate → transform → typed), then
  `set_hotkey` on selected text → notification + `config.toml` updated + next run uses the
  new instruction; persists across a daemon restart.

## Notes / scope

- Batch (non-streaming) transcription backends only, same as command mode.
- Persisting a reprogrammed instruction rewrites `config.toml` via the existing writer,
  which normalizes formatting (matches current `whisrs setup`/`config` behavior).

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor (KDE Plasma / Wayland)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
