### PR TITLE
feat(input): optional clipboard-paste text injection (`[input] paste`)

### DIFF
--- a/crates/xkb-type/src/clipboard.rs
+++ b/crates/xkb-type/src/clipboard.rs
@@ -8,25 +8,53 @@ use std::process::Command;
 // Wayland: shell out to wl-paste / wl-copy
 // ---------------------------------------------------------------------------
 
+/// Run `wl-paste` with the given extra args (e.g. `--primary`) and return its
+/// text, distinguishing a genuinely empty clipboard from one holding
+/// non-text content (image, files, ...).
+///
+/// wl-clipboard reports these as two different messages: an empty clipboard
+/// (no selection owner at all) says "Nothing is copied"; a selection that
+/// exists but doesn't offer a text MIME type says "Clipboard content is not
+/// available as \[inferred output|requested\] type ...". Only the former is a
+/// legitimate empty string — the latter must surface as an error, or a
+/// caller restoring a saved clipboard value (see `whisrs`'s paste-injection
+/// path) would overwrite non-text content with `""`.
+///
+/// Matched case-insensitively since wl-clipboard's exact capitalization has
+/// varied across versions; verified against wl-clipboard 2.2.1's actual
+/// wording (embedded strings), which no longer matches the older "no
+/// suitable type" phrasing this used to check for.
+fn run_wl_paste(extra_args: &[&str], command_desc: &str) -> anyhow::Result<String> {
+    let output = Command::new("wl-paste")
+        .arg("--no-newline")
+        .args(extra_args)
+        .output()
+        .context("failed to run wl-paste — is wl-clipboard installed?")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_empty_clipboard_message(&stderr) {
+            return Ok(String::new());
+        }
+        anyhow::bail!("{command_desc} failed: {stderr}");
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Whether a `wl-paste` stderr message means "the clipboard has no selection
+/// at all" (a legitimate empty string), as opposed to "a selection exists but
+/// isn't text" (which must propagate as an error — see [`run_wl_paste`]).
+fn is_empty_clipboard_message(stderr: &str) -> bool {
+    stderr.to_lowercase().contains("nothing is copied")
+}
+
 /// Clipboard backend that shells out to `wl-paste` (get) and `wl-copy` (set).
 pub struct WaylandClipboard;
 
 impl ClipboardBackend for WaylandClipboard {
     fn get_text(&self) -> anyhow::Result<String> {
-        let output = Command::new("wl-paste")
-            .arg("--no-newline")
-            .output()
-            .context("failed to run wl-paste — is wl-clipboard installed?")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("no suitable type") || stderr.contains("nothing is copied") {
-                return Ok(String::new());
-            }
-            anyhow::bail!("wl-paste failed: {stderr}");
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        run_wl_paste(&[], "wl-paste")
     }
 
     fn set_text(&self, text: &str) -> anyhow::Result<()> {
@@ -53,20 +81,7 @@ impl ClipboardBackend for WaylandClipboard {
     }
 
     fn get_primary_selection(&self) -> anyhow::Result<String> {
-        let output = Command::new("wl-paste")
-            .args(["--no-newline", "--primary"])
-            .output()
-            .context("failed to run wl-paste --primary — is wl-clipboard installed?")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("no suitable type") || stderr.contains("nothing is copied") {
-                return Ok(String::new());
-            }
-            anyhow::bail!("wl-paste --primary failed: {stderr}");
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        run_wl_paste(&["--primary"], "wl-paste --primary")
     }
 }
 
@@ -156,5 +171,46 @@ pub fn default_clipboard() -> Box<dyn ClipboardBackend> {
         Box::new(WaylandClipboard)
     } else {
         Box::new(X11Clipboard)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact message wl-clipboard emits for a truly empty clipboard (no
+    /// selection owner at all), verified against wl-clipboard 2.2.1's
+    /// embedded strings.
+    #[test]
+    fn recognizes_truly_empty_clipboard() {
+        assert!(is_empty_clipboard_message("Nothing is copied\n"));
+        // Case-insensitive: wording/casing has varied across wl-clipboard
+        // versions.
+        assert!(is_empty_clipboard_message("nothing is copied\n"));
+    }
+
+    /// A selection that exists but isn't text must NOT be treated as empty —
+    /// doing so is exactly the bug this fixes: a caller restoring a saved
+    /// clipboard value after a paste would silently overwrite an image or
+    /// file selection with `""`.
+    #[test]
+    fn does_not_treat_non_text_content_as_empty() {
+        assert!(!is_empty_clipboard_message(
+            "Clipboard content is not available as inferred output type \"text/plain\"\n\
+             Use \"wl-paste --list-types\" to view available types."
+        ));
+        assert!(!is_empty_clipboard_message(
+            "Clipboard content is not available as requested type \"text/plain\"\n\
+             Use \"wl-paste --list-types\" to view available types."
+        ));
+    }
+
+    #[test]
+    fn does_not_match_stale_no_suitable_type_phrasing() {
+        // The old pattern this used to check for; confirm it alone (without
+        // "nothing is copied") is correctly treated as an error, not empty.
+        assert!(!is_empty_clipboard_message(
+            "no suitable type of content copied"
+        ));
     }
 }

--- a/crates/xkb-type/src/wayland_vk.rs
+++ b/crates/xkb-type/src/wayland_vk.rs
@@ -190,6 +190,26 @@ const SHIFT_MOD_MASK: u32 = 1 << 0;
 /// 7 — mask bit `1 << 7`. Asserted in `modifier_masks_select_levels`.
 const ALTGR_MOD_MASK: u32 = 1 << 7;
 
+/// XKB keycode of the Control key, present in every keymap and bound via
+/// `modifier_map Control`. `KEY_LEFTCTRL` (evdev 29) + 8.
+const CTRL_XKB_KEYCODE: u32 = 37;
+
+/// Modifier **mask** that declares Control depressed, for combos like
+/// Ctrl+V sent via [`WaylandVkKeyboard::send_combo`].
+///
+/// Our keymap binds `modifier_map Control { <K37> }`, so Control is the real
+/// modifier at its standard index 2 — mask bit `1 << 2`. Asserted in
+/// `modifier_masks_select_levels`.
+///
+/// `send_combo` declares this mask via `zwp_virtual_keyboard_v1.modifiers`
+/// rather than pressing the Ctrl keycode directly, for the same reason
+/// [`WaylandVkKeyboard::tap_char_key`] declares Shift/AltGr that way: without
+/// `modifier_map Control` binding a keycode to the real Control modifier, and
+/// without explicitly asserting the mask, the compositor has nothing telling
+/// it that a pressed Ctrl keycode means "Control is down" — the receiving
+/// client would see a bare key press instead of a Ctrl-chord.
+const CTRL_MOD_MASK: u32 = 1 << 2;
+
 /// The XKB level reached by a per-character key tap, encoding which modifier
 /// (if any) must be held.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -479,8 +499,10 @@ fn base_keys() -> Vec<BaseKey> {
 ///   skipped (warned once). At most [`dynamic_capacity`] are placed; any beyond
 ///   that are ignored here (callers batch).
 /// * Base/modifier keys (BackSpace, Ctrl, Shift, Alt, AltGr, Return, Tab) are
-///   pinned at their real `evdev + 8` positions, with `modifier_map` entries so
-///   pressing Shift reaches level 1 and pressing AltGr reaches level 2.
+///   pinned at their real `evdev + 8` positions. Shift, AltGr, and Control
+///   each have a `modifier_map` entry making them *real* modifiers — Shift and
+///   AltGr so declaring their mask reaches level 1/2, Control so `send_combo`
+///   can declare it depressed for chords like Ctrl+V.
 ///
 /// This is factored out as a pure function so it can be unit-tested without a
 /// Wayland connection (see the roundtrip tests).
@@ -572,6 +594,11 @@ pub(crate) fn build_keymap_string(chars: &[char]) -> (String, HashMap<char, Char
     ));
     keymap.push_str(&format!(
         "modifier_map Mod5 {{ <K{ALTGR_XKB_KEYCODE}> }};\n"
+    ));
+    // Bind Control so combos (Ctrl+V, Ctrl+Shift+V, ...) sent via
+    // `send_combo` register as real Control-held state, not a bare keycode.
+    keymap.push_str(&format!(
+        "modifier_map Control {{ <K{CTRL_XKB_KEYCODE}> }};\n"
     ));
     // Permanent ASCII keys, each FOUR_LEVEL with an optional dynamic level-2.
     for &(kc, l0, l1) in PERMANENT_ASCII_KEYS {
@@ -1080,19 +1107,53 @@ impl KeyInjector for WaylandVkKeyboard {
         Ok(())
     }
 
+    /// Send a key combo (e.g. Ctrl+V, Ctrl+Shift+V).
+    ///
+    /// Recognized modifier keys (Ctrl, Shift) are declared via
+    /// `zwp_virtual_keyboard_v1.modifiers` — the same "wtype model" atomic
+    /// mask declaration [`Self::tap_char_key`] uses — rather than pressed as
+    /// keycodes. Pressing a modifier keycode directly is not sufficient here:
+    /// our uploaded keymap only makes a key a *real* modifier via
+    /// `modifier_map`, and even then, propagating "held" state from a raw key
+    /// press to the level/combo interpretation the focused client uses can
+    /// lag the press (see [`Self::tap_char_key`]'s doc comment). Declaring the
+    /// mask directly is atomic and reliable. Any other keys in `keys` (e.g.
+    /// `KEY_V`) are tapped while the mask is held, in the order given.
     fn send_combo(&mut self, keys: &[evdev::Key]) -> anyhow::Result<()> {
         if !self.keymap_uploaded {
             self.upload_keymap(&[])?;
         }
-        // Press each key (evdev code + 8) in order, release in reverse.
-        for key in keys {
+
+        use evdev::Key;
+        let mut mask = 0u32;
+        let mut real_keys = Vec::with_capacity(keys.len());
+        for &key in keys {
+            match key {
+                Key::KEY_LEFTCTRL | Key::KEY_RIGHTCTRL => mask |= CTRL_MOD_MASK,
+                Key::KEY_LEFTSHIFT | Key::KEY_RIGHTSHIFT => mask |= SHIFT_MOD_MASK,
+                other => real_keys.push(other),
+            }
+        }
+
+        if mask != 0 {
+            self.set_modifiers(mask)?;
+        }
+
+        // Press the non-modifier keys (evdev code + 8) in order, release in
+        // reverse.
+        for key in &real_keys {
             let keycode = u32::from(key.code()) + 8;
             self.emit_key(keycode, KEY_STATE_PRESSED)?;
         }
-        for key in keys.iter().rev() {
+        for key in real_keys.iter().rev() {
             let keycode = u32::from(key.code()) + 8;
             self.emit_key(keycode, KEY_STATE_RELEASED)?;
         }
+
+        if mask != 0 {
+            self.set_modifiers(0)?;
+        }
+
         Ok(())
     }
 
@@ -1743,6 +1804,11 @@ mod tests {
             ALTGR_MOD_MASK.trailing_zeros(),
             "Mod5/AltGr modifier index mismatch with ALTGR_MOD_MASK"
         );
+        assert_eq!(
+            keymap.mod_get_index(xkb::MOD_NAME_CTRL),
+            CTRL_MOD_MASK.trailing_zeros(),
+            "Control modifier index mismatch with CTRL_MOD_MASK"
+        );
 
         // Drive a single keycode through all three masks and confirm the level.
         let a = map[&'a'];
@@ -1770,7 +1836,8 @@ mod tests {
             "ALTGR_MOD_MASK must select the AltGr (dynamic) level"
         );
         eprintln!(
-            "modifier-mask OK: Shift={SHIFT_MOD_MASK} Mod5={ALTGR_MOD_MASK} select levels 1/2"
+            "modifier-mask OK: Shift={SHIFT_MOD_MASK} Mod5={ALTGR_MOD_MASK} select levels 1/2, \
+             Control={CTRL_MOD_MASK} is a real modifier"
         );
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,8 +66,10 @@ key_delay_ms = 2
 #
 # Trade-offs: briefly replaces the clipboard (restored right after), the
 # target app must support Ctrl+V (terminals get Ctrl+Shift+V), and it applies
-# to batch (non-streaming) dictation only — streaming backends type
-# incrementally and ignore it.
+# to batch (non-streaming) dictation only — streaming backends (including
+# local-whisper, which always streams regardless of its `segmentation` mode)
+# type incrementally and silently ignore it. `whisrsd` warns at startup if
+# paste is set with one of those backends.
 paste = false
 
 [groq]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,22 @@ device = "default"
 # drops characters while whisrs is typing — e.g. Node/Ink-based apps like
 # Claude Code in raw mode. Default: 2.
 key_delay_ms = 2
+# Inject text by clipboard paste (Ctrl+V) instead of typing keystrokes.
+# Default: false.
+#
+# The uinput backend emits raw keycodes that the compositor decodes through
+# the target window's ACTIVE XKB layout. On compositors without the Wayland
+# virtual-keyboard protocol (e.g. KWin), when that active layout differs from
+# the one whisrs detected — typically with per-window layouts (KDE
+# SwitchMode=WinClass) or a non-US keymap — output is garbled (z<->y, mangled
+# punctuation, dropped accents/umlauts). Pasting goes through the clipboard,
+# which is layout-independent and Unicode-complete, so text comes out verbatim.
+#
+# Trade-offs: briefly replaces the clipboard (restored right after), the
+# target app must support Ctrl+V (terminals get Ctrl+Shift+V), and it applies
+# to batch (non-streaming) dictation only — streaming backends type
+# incrementally and ignore it.
+paste = false
 
 [groq]
 api_key = "gsk_..."

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -1818,6 +1818,14 @@ fn paste_via_keyboard(
 /// injection for compositors that lack the Wayland virtual-keyboard protocol
 /// (see [`whisrs::InputConfig::paste`]). Runs in a blocking context (callers
 /// wrap it in `spawn_blocking`), so the sleeps/restore use std threads.
+///
+/// The restore is skipped, rather than clobbering the clipboard, when:
+/// - the original clipboard couldn't be read as text (e.g. it held an image
+///   or a file list) — there is nothing valid to restore to, so the pasted
+///   text is left in place instead of wiping it with `""`;
+/// - the clipboard no longer holds the text we set — something else (the
+///   user, another app) copied over it during the paste, and restoring would
+///   race that copy and discard it.
 fn inject_text(
     text: &str,
     is_terminal: bool,
@@ -1830,7 +1838,7 @@ fn inject_text(
     }
 
     let clipboard = xkb_type::default_clipboard();
-    let saved = clipboard.get_text().unwrap_or_default();
+    let saved = clipboard.get_text().ok();
     clipboard
         .set_text(text)
         .context("failed to set clipboard for paste injection")?;
@@ -1841,11 +1849,28 @@ fn inject_text(
     let paste_result = paste_via_keyboard(is_terminal, key_delay, backend);
 
     // Restore the user's clipboard after the paste has landed, regardless of
-    // whether the keystroke succeeded.
+    // whether the keystroke succeeded — but only if it's safe to (see doc
+    // comment above).
+    let pasted_text = text.to_string();
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(500));
-        if let Err(e) = xkb_type::default_clipboard().set_text(&saved) {
-            warn!("failed to restore clipboard: {e}");
+        let Some(saved) = saved else {
+            // Original clipboard wasn't text; nothing we can restore to.
+            return;
+        };
+        let clipboard = xkb_type::default_clipboard();
+        match clipboard.get_text() {
+            Ok(current) if current == pasted_text => {
+                if let Err(e) = clipboard.set_text(&saved) {
+                    warn!("failed to restore clipboard: {e}");
+                }
+            }
+            Ok(_) => {
+                debug!("clipboard changed during paste injection; skipping restore");
+            }
+            Err(e) => {
+                warn!("failed to read clipboard before restore, skipping restore: {e}");
+            }
         }
     });
 

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -1657,18 +1657,29 @@ async fn process_recording_batch(
         }
     }
 
-    // Type the text at the cursor.
+    // Inject the text at the cursor — type keystrokes, or paste via the
+    // clipboard when `[input] paste = true` (layout-independent).
     let text_clone = text.clone();
     let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
     let injector_backend = context.config.input.backend;
+    let paste = context.config.input.paste;
+    let is_terminal = if paste {
+        context
+            .window_tracker
+            .get_focused_window_class()
+            .map(|c| is_terminal_class(&c))
+            .unwrap_or(false)
+    } else {
+        false
+    };
     match tokio::task::spawn_blocking(move || {
-        type_text_at_cursor(&text_clone, key_delay, injector_backend)
+        inject_text(&text_clone, is_terminal, key_delay, injector_backend, paste)
     })
     .await
     {
         Ok(Ok(())) => {}
-        Ok(Err(e)) => warn!("failed to type text: {e:#}"),
-        Err(e) => warn!("failed to join typing task: {e}"),
+        Ok(Err(e)) => warn!("failed to inject text: {e:#}"),
+        Err(e) => warn!("failed to join injection task: {e}"),
     }
 
     Ok(text)
@@ -1750,6 +1761,95 @@ fn type_text_at_cursor(
     }
     result?;
     Ok(())
+}
+
+/// Send a paste keystroke — Ctrl+V, or Ctrl+Shift+V in terminals — via the
+/// **persistent** virtual keyboard (the same device `type_text_at_cursor`
+/// uses).
+///
+/// Must NOT use a fresh per-call uinput device: on some compositors (e.g.
+/// KWin) keystrokes from a device the compositor hasn't finished enumerating
+/// are dropped, so the paste silently no-ops. The persistent device is already
+/// recognized, so its keystrokes land. The combo is raw keycodes (`KEY_V` is
+/// `v` in every common layout), so it stays layout-independent.
+fn paste_via_keyboard(
+    is_terminal: bool,
+    key_delay: std::time::Duration,
+    backend: InjectorBackend,
+) -> Result<()> {
+    use evdev::Key;
+
+    let keyboard_slot = KEYBOARD.get_or_init(|| StdMutex::new(None));
+    let mut keyboard_guard = keyboard_slot
+        .lock()
+        .map_err(|_| anyhow::anyhow!("keyboard mutex poisoned"))?;
+
+    if keyboard_guard.is_none() {
+        *keyboard_guard = Some(new_keyboard(
+            key_delay, /* prewarm = */ false, backend,
+        )?);
+    }
+
+    let keyboard = keyboard_guard
+        .as_mut()
+        .expect("keyboard exists after initialization");
+    keyboard.set_key_delay(key_delay);
+
+    let combo: &[Key] = if is_terminal {
+        &[Key::KEY_LEFTCTRL, Key::KEY_LEFTSHIFT, Key::KEY_V]
+    } else {
+        &[Key::KEY_LEFTCTRL, Key::KEY_V]
+    };
+
+    let result = keyboard
+        .send_combo(combo)
+        .context("failed to send paste combo");
+    if result.is_err() {
+        *keyboard_guard = None;
+    }
+    result
+}
+
+/// Inject `text` at the cursor, choosing keystrokes or clipboard paste.
+///
+/// With `paste = false` (default) this types via the virtual keyboard. With
+/// `paste = true` it sets the clipboard, sends Ctrl+V (Ctrl+Shift+V for
+/// terminals), then restores the previous clipboard — layout-independent
+/// injection for compositors that lack the Wayland virtual-keyboard protocol
+/// (see [`whisrs::InputConfig::paste`]). Runs in a blocking context (callers
+/// wrap it in `spawn_blocking`), so the sleeps/restore use std threads.
+fn inject_text(
+    text: &str,
+    is_terminal: bool,
+    key_delay: std::time::Duration,
+    backend: InjectorBackend,
+    paste: bool,
+) -> Result<()> {
+    if !paste {
+        return type_text_at_cursor(text, key_delay, backend);
+    }
+
+    let clipboard = xkb_type::default_clipboard();
+    let saved = clipboard.get_text().unwrap_or_default();
+    clipboard
+        .set_text(text)
+        .context("failed to set clipboard for paste injection")?;
+
+    // Let the clipboard settle before the paste keystroke.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let paste_result = paste_via_keyboard(is_terminal, key_delay, backend);
+
+    // Restore the user's clipboard after the paste has landed, regardless of
+    // whether the keystroke succeeded.
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        if let Err(e) = xkb_type::default_clipboard().set_text(&saved) {
+            warn!("failed to restore clipboard: {e}");
+        }
+    });
+
+    paste_result
 }
 
 fn warm_keyboard(key_delay: std::time::Duration, backend: InjectorBackend) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,10 @@ pub struct InputConfig {
     ///
     /// Trade-offs: briefly replaces the clipboard (restored right after), the
     /// target app must support Ctrl+V, and it applies to batch (non-streaming)
-    /// dictation only — streaming backends type incrementally and ignore it.
+    /// dictation only — streaming backends (including `local-whisper`, which
+    /// always streams regardless of its `segmentation` mode) type incrementally
+    /// and silently ignore it. [`Config::validate`] warns when this is set
+    /// alongside one of those backends.
     #[serde(default)]
     pub paste: bool,
 }
@@ -916,6 +919,31 @@ impl Config {
         if self.general.silence_timeout_ms == 0 {
             warnings.push(ConfigWarning {
                 message: "silence_timeout_ms is 0 — auto-stop is effectively disabled".to_string(),
+            });
+        }
+
+        // Streaming backends (including local-whisper, which always streams
+        // regardless of its `segmentation` mode) type text incrementally as
+        // it arrives and never go through the paste-injection path, so
+        // `[input] paste` is a silent no-op for them.
+        if self.input.paste
+            && matches!(
+                backend,
+                "deepgram-streaming"
+                    | "openai-realtime"
+                    | "openai-compatible-realtime"
+                    | "local-whisper"
+                    | "local"
+            )
+        {
+            warnings.push(ConfigWarning {
+                message: format!(
+                    "[input] paste = true has no effect with backend = \"{backend}\": streaming \
+                     backends (deepgram-streaming, openai-realtime, openai-compatible-realtime, \
+                     local-whisper) type text incrementally as it arrives and never use the paste \
+                     path. Switch to a non-streaming backend (deepgram, groq, openai, local-vosk, \
+                     local-parakeet, asr-sidecar) to use paste injection."
+                ),
             });
         }
 
@@ -1524,6 +1552,81 @@ mod tests {
         };
         let result = config.validate();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn config_validate_paste_with_non_streaming_backend_no_warning() {
+        let config = Config {
+            general: GeneralConfig {
+                backend: "groq".to_string(),
+                ..Default::default()
+            },
+            audio: Default::default(),
+            input: InputConfig {
+                paste: true,
+                ..Default::default()
+            },
+            deepgram: None,
+            groq: Some(GroqConfig {
+                api_key: "test-key".to_string(),
+                model: "whisper-large-v3-turbo".to_string(),
+            }),
+            openai: None,
+            local_whisper: None,
+            local_vosk: None,
+            local_parakeet: None,
+            asr_sidecar: None,
+            openai_compatible_realtime: None,
+            llm: None,
+            tts: None,
+            hotkeys: None,
+            overlay: None,
+        };
+        let warnings = config.validate().unwrap();
+        assert!(
+            warnings.iter().all(|w| !w.message.contains("paste")),
+            "groq is not a streaming backend; paste should not warn: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn config_validate_paste_with_streaming_backend_warns() {
+        for backend in ["deepgram-streaming", "openai-realtime", "local-whisper"] {
+            let config = Config {
+                general: GeneralConfig {
+                    backend: backend.to_string(),
+                    ..Default::default()
+                },
+                audio: Default::default(),
+                input: InputConfig {
+                    paste: true,
+                    ..Default::default()
+                },
+                deepgram: Some(DeepgramConfig {
+                    api_key: "test-key".to_string(),
+                    model: default_deepgram_model(),
+                }),
+                groq: None,
+                openai: Some(OpenAiConfig {
+                    api_key: "test-key".to_string(),
+                    model: default_openai_model(),
+                }),
+                local_whisper: None,
+                local_vosk: None,
+                local_parakeet: None,
+                asr_sidecar: None,
+                openai_compatible_realtime: None,
+                llm: None,
+                tts: None,
+                hotkeys: None,
+                overlay: None,
+            };
+            let warnings = config.validate().unwrap();
+            assert!(
+                warnings.iter().any(|w| w.message.contains("paste")),
+                "backend {backend} streams and ignores paste; expected a warning, got: {warnings:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,22 @@ pub struct InputConfig {
     /// backend can only emit characters present in the active XKB layout.
     #[serde(default)]
     pub backend: InjectorBackend,
+    /// Inject text by clipboard paste (Ctrl+V) instead of typing keystrokes.
+    ///
+    /// The uinput backend emits raw keycodes that the compositor decodes
+    /// through the target window's *active* XKB layout. On compositors without
+    /// the Wayland virtual-keyboard protocol (e.g. KWin), when that active
+    /// layout isn't the one whisrs detected — most commonly with per-window
+    /// layouts (KDE `SwitchMode=WinClass`) or a non-US keymap — the output is
+    /// garbled (`z`↔`y`, mangled punctuation, dropped accents). Pasting sends
+    /// the text through the clipboard, which is layout-independent and
+    /// Unicode-complete, so it comes out verbatim.
+    ///
+    /// Trade-offs: briefly replaces the clipboard (restored right after), the
+    /// target app must support Ctrl+V, and it applies to batch (non-streaming)
+    /// dictation only — streaming backends type incrementally and ignore it.
+    #[serde(default)]
+    pub paste: bool,
 }
 
 impl Default for InputConfig {
@@ -350,6 +366,7 @@ impl Default for InputConfig {
         Self {
             key_delay_ms: default_key_delay_ms(),
             backend: InjectorBackend::default(),
+            paste: false,
         }
     }
 }
@@ -1376,6 +1393,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(input.backend, InjectorBackend::WaylandVk);
+    }
+
+    #[test]
+    fn input_config_paste_defaults_false_and_parses() {
+        // Omitted → false (back-compat for configs written before the field).
+        let input: InputConfig = toml::from_str("key_delay_ms = 5").unwrap();
+        assert!(!input.paste);
+
+        // Explicit value honoured.
+        let input: InputConfig = toml::from_str("paste = true").unwrap();
+        assert!(input.paste);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an opt-in **`[input] paste`** (default `false`). When enabled, batch dictation injects text by setting the clipboard and sending **Ctrl+V** (Ctrl+Shift+V in terminals) instead of typing keystrokes, then restores the previous clipboard.

**Why:** the uinput backend emits raw keycodes that the compositor decodes through the target window's *active* XKB layout. On compositors that don't expose the Wayland virtual-keyboard protocol (`zwp_virtual_keyboard_manager_v1`) — notably **KWin/Plasma** — the `wayland-vk` backend isn't available, so whisrs falls back to uinput. When the active layout then differs from the one whisrs detected, output is garbled. Two common cases:

- **Per-window layouts** (KDE `SwitchMode=WinClass`): different apps have different active layouts, so no single keymap whisrs picks is correct everywhere.
- **Non-US keymaps** (e.g. German QWERTZ): `z`↔`y` swap, mangled punctuation (`?`→`/`), dropped accents/umlauts.

Concrete repro: on KWin + German QWERTZ, dictating "Zusammenfassung?" typed "Yusammenfassung/". `wayland-vk` would fix it, but KWin doesn't implement that protocol, so there was no working option on KDE. Pasting sidesteps keycode→layout translation entirely — the clipboard is layout-independent and Unicode-complete. This complements `backend = "wayland-vk"`: use that where the protocol exists, `paste = true` where it doesn't.

## Changes

- **lib.rs**: `InputConfig.paste: bool` (serde default `false`) + docs + unit test (default-false + explicit parse).
- **daemon**:
  - `paste_via_keyboard` — sends the paste combo through the **persistent** virtual keyboard. (A fresh per-call uinput device gets its keystrokes dropped on KWin because the compositor hasn't finished enumerating it — a real failure observed during testing.)
  - `inject_text` — thin wrapper choosing type-vs-paste; the batch dictation path routes through it, detecting terminals for Ctrl+Shift+V and restoring the clipboard after the paste lands.
- **docs/configuration.md**: document `paste`.

## Testing

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all clean. Minimal build (`--no-default-features --features tray,overlay`) also builds.
- Verified end-to-end on **KDE Plasma (Wayland) + German QWERTZ, Fedora**: with `paste = true`, previously-garbled German (incl. umlauts and punctuation) is injected verbatim; with `paste = false` behaviour is unchanged (types keystrokes as before).

## Scope / trade-offs

- **Batch (non-streaming) dictation only** — streaming backends type incrementally and ignore the flag (pasting per-delta would clobber the clipboard repeatedly). Documented in the config comment.
- Briefly replaces the clipboard (restored ~500 ms after the paste); target app must support Ctrl+V.

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor (KDE Plasma / Wayland)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
