### PR TITLE
fix(hotkey): exact modifier matching + F13–F24 key support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,6 +152,11 @@ response_format = "wav"     # audio format requested from the API
 #                           #   OpenAI-compatible server (Kokoro, Supertonic, ...)
 
 # Built-in global hotkeys (optional, works without WM keybinds)
+# Triggers: A-Z, 0-9, F1-F24, space, enter, escape, tab, backspace, delete,
+#   insert, home, end, pageup, pagedown, up, down, left, right.
+# Modifiers: Super, Alt, Ctrl, Shift. At least one is required, so a bare
+#   "F13" is rejected; write "Shift+F13". The modifier set must match exactly,
+#   so "Ctrl+Alt+Ins" does not fire while Shift is also held.
 [hotkeys]
 toggle = "Super+Shift+W"
 cancel = "Super+Shift+D"

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -247,24 +247,77 @@ async fn listen_device(
     }
 }
 
-/// Check if all required modifier keys (or their left/right variants) are held.
+/// True iff *exactly* the required modifiers are held — no more, no fewer —
+/// with left/right variants treated as equivalent.
+///
+/// Requiring an exact set (not just a subset) means a less-specific binding
+/// (e.g. `Ctrl+Alt+X`) does NOT also match when a more-specific one
+/// (`Ctrl+Alt+Shift+X`) is pressed, so both can be bound to the same trigger
+/// key with different modifier sets without shadowing each other.
 fn modifiers_held(held: &HashSet<Key>, required: &[Key]) -> bool {
-    required.iter().all(|m| {
-        // Accept either left or right variant.
-        match *m {
-            Key::KEY_LEFTMETA => {
-                held.contains(&Key::KEY_LEFTMETA) || held.contains(&Key::KEY_RIGHTMETA)
-            }
-            Key::KEY_LEFTALT => {
-                held.contains(&Key::KEY_LEFTALT) || held.contains(&Key::KEY_RIGHTALT)
-            }
-            Key::KEY_LEFTCTRL => {
-                held.contains(&Key::KEY_LEFTCTRL) || held.contains(&Key::KEY_RIGHTCTRL)
-            }
-            Key::KEY_LEFTSHIFT => {
-                held.contains(&Key::KEY_LEFTSHIFT) || held.contains(&Key::KEY_RIGHTSHIFT)
-            }
-            other => held.contains(&other),
+    /// Collapse right-hand modifier variants onto their left counterpart;
+    /// non-modifier keys map to themselves.
+    fn canon(k: Key) -> Key {
+        match k {
+            Key::KEY_RIGHTMETA => Key::KEY_LEFTMETA,
+            Key::KEY_RIGHTALT => Key::KEY_LEFTALT,
+            Key::KEY_RIGHTCTRL => Key::KEY_LEFTCTRL,
+            Key::KEY_RIGHTSHIFT => Key::KEY_LEFTSHIFT,
+            other => other,
         }
-    })
+    }
+    fn is_modifier(k: Key) -> bool {
+        matches!(
+            canon(k),
+            Key::KEY_LEFTMETA | Key::KEY_LEFTALT | Key::KEY_LEFTCTRL | Key::KEY_LEFTSHIFT
+        )
+    }
+
+    let required_canon: HashSet<Key> = required.iter().map(|k| canon(*k)).collect();
+
+    // Every required modifier must be held...
+    if !required_canon
+        .iter()
+        .all(|m| held.iter().any(|h| canon(*h) == *m))
+    {
+        return false;
+    }
+    // ...and no modifier outside the required set may be held.
+    !held
+        .iter()
+        .any(|h| is_modifier(*h) && !required_canon.contains(&canon(*h)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_modifier_match() {
+        let ctrl_alt = [Key::KEY_LEFTCTRL, Key::KEY_LEFTALT];
+        let ctrl_alt_shift = [Key::KEY_LEFTCTRL, Key::KEY_LEFTALT, Key::KEY_LEFTSHIFT];
+
+        // Ctrl+Alt held → matches Ctrl+Alt, not Ctrl+Alt+Shift.
+        let held: HashSet<Key> =
+            HashSet::from([Key::KEY_LEFTCTRL, Key::KEY_LEFTALT, Key::KEY_PAGEUP]);
+        assert!(modifiers_held(&held, &ctrl_alt));
+        assert!(!modifiers_held(&held, &ctrl_alt_shift));
+
+        // Ctrl+Alt+Shift held → matches Ctrl+Alt+Shift, NOT the Ctrl+Alt
+        // subset (the extra Shift must disqualify it — the shadowing bug).
+        let held: HashSet<Key> = HashSet::from([
+            Key::KEY_LEFTCTRL,
+            Key::KEY_LEFTALT,
+            Key::KEY_LEFTSHIFT,
+            Key::KEY_PAGEUP,
+        ]);
+        assert!(modifiers_held(&held, &ctrl_alt_shift));
+        assert!(!modifiers_held(&held, &ctrl_alt));
+    }
+
+    #[test]
+    fn right_hand_modifiers_are_equivalent() {
+        let held: HashSet<Key> = HashSet::from([Key::KEY_RIGHTCTRL, Key::KEY_PAGEUP]);
+        assert!(modifiers_held(&held, &[Key::KEY_LEFTCTRL]));
+    }
 }

--- a/src/hotkey/parse.rs
+++ b/src/hotkey/parse.rs
@@ -117,6 +117,20 @@ fn parse_key(s: &str) -> Option<Key> {
         "f10" => Some(Key::KEY_F10),
         "f11" => Some(Key::KEY_F11),
         "f12" => Some(Key::KEY_F12),
+        // F13–F24: no default binding in graphical Linux sessions, so ideal
+        // for macro-key hotkeys. (VT switching is Ctrl+Alt+F1–F12 only.)
+        "f13" => Some(Key::KEY_F13),
+        "f14" => Some(Key::KEY_F14),
+        "f15" => Some(Key::KEY_F15),
+        "f16" => Some(Key::KEY_F16),
+        "f17" => Some(Key::KEY_F17),
+        "f18" => Some(Key::KEY_F18),
+        "f19" => Some(Key::KEY_F19),
+        "f20" => Some(Key::KEY_F20),
+        "f21" => Some(Key::KEY_F21),
+        "f22" => Some(Key::KEY_F22),
+        "f23" => Some(Key::KEY_F23),
+        "f24" => Some(Key::KEY_F24),
         "0" => Some(Key::KEY_0),
         "1" => Some(Key::KEY_1),
         "2" => Some(Key::KEY_2),
@@ -160,6 +174,15 @@ mod tests {
     fn parse_case_insensitive() {
         let binding = parse_hotkey("super+shift+d").unwrap();
         assert_eq!(binding.trigger, Key::KEY_D);
+    }
+
+    #[test]
+    fn parse_high_function_keys() {
+        assert_eq!(parse_hotkey("Shift+F13").unwrap().trigger, Key::KEY_F13);
+        let b = parse_hotkey("Shift+Ctrl+F14").unwrap();
+        assert_eq!(b.trigger, Key::KEY_F14);
+        assert_eq!(b.modifiers.len(), 2);
+        assert_eq!(parse_hotkey("Alt+F24").unwrap().trigger, Key::KEY_F24);
     }
 
     #[test]

--- a/src/hotkey/parse.rs
+++ b/src/hotkey/parse.rs
@@ -186,6 +186,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_every_high_function_key() {
+        // Pin all twelve arms: a copy-paste mis-map inside the f13-f24 block
+        // is otherwise silent, and picks the wrong physical key at runtime.
+        let expected = [
+            ("F13", Key::KEY_F13),
+            ("F14", Key::KEY_F14),
+            ("F15", Key::KEY_F15),
+            ("F16", Key::KEY_F16),
+            ("F17", Key::KEY_F17),
+            ("F18", Key::KEY_F18),
+            ("F19", Key::KEY_F19),
+            ("F20", Key::KEY_F20),
+            ("F21", Key::KEY_F21),
+            ("F22", Key::KEY_F22),
+            ("F23", Key::KEY_F23),
+            ("F24", Key::KEY_F24),
+        ];
+        for (name, key) in expected {
+            let binding = parse_hotkey(&format!("Super+{name}")).unwrap();
+            assert_eq!(binding.trigger, key, "{name} mapped to the wrong keycode");
+        }
+    }
+
+    #[test]
     fn parse_no_modifier_fails() {
         assert!(parse_hotkey("D").is_err());
     }


### PR DESCRIPTION
## Summary

Two small, independent improvements to the global hotkey listener:

1. **Exact modifier matching (bug fix).** `modifiers_held()` matched when the required modifiers were a *subset* of those held, so a less-specific binding shadowed a more-specific one sharing the same trigger key. E.g. with `toggle = Ctrl+Alt+Ins` and `command = Ctrl+Alt+Shift+Ins`, pressing `Ctrl+Alt+Shift+Ins` fired **both** (the extra Shift was ignored) — `toggle` shadowed `command`. Now an exact modifier set is required (left/right variants still equivalent), so same-key/different-modifier binds coexist correctly.

2. **F13–F24 support (feature).** `parse_key` now recognizes `f13`–`f24`. These keys have no default binding in graphical Linux sessions (VT switching is `Ctrl+Alt+F1`–`F12` only), which makes them ideal macro-key targets that don't collide with app/compositor shortcuts (e.g. `Shift+Insert` = paste).

The two compose nicely: a single macro key mapped to e.g. `LSFT(KC_F13)` fires `Shift+F13` on its own, and `Shift+Alt+F13` when Alt is also held — the exact-match fix is what keeps those two distinct.

## Changes

- `src/hotkey/mod.rs`: `modifiers_held()` now rejects any held modifier outside the required set; added unit tests (exact match, subset rejection, left/right equivalence).
- `src/hotkey/parse.rs`: add `f13`–`f24` to `parse_key`; added a parse test.

## Testing

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and the minimal build (`--no-default-features --features tray,overlay`) all pass.
- Verified on **KDE Plasma (Wayland), Fedora**: a macro key sending `LSFT(KC_F13)` triggers a `Shift+F13` bind; adding a held Alt correctly selects a distinct `Shift+Alt+F13` bind instead of firing both.

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor (KDE Plasma / Wayland)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
