### PR TITLE
docs(man): fix section order and stale .TH version, with a test to keep it fresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ If any check fails, fix the issue before pushing. Do not push with the intent to
 
 When a feature or set of changes warrants a version bump:
 
-1. **Bump version** in `Cargo.toml` and `flake.nix` (semver: `MAJOR.MINOR.PATCH`)
+1. **Bump version** in `Cargo.toml`, `flake.nix`, and the `.TH` lines of `contrib/whisrs.1` and `contrib/whisrsd.1` (semver: `MAJOR.MINOR.PATCH`). `cargo test` fails if the man page versions are stale, but the revision date in the same `.TH` line is only checked by eye — bump it too.
 2. **Always include `Cargo.lock`** in the version bump commit
 3. **Run all CI checks** locally (see above)
 4. **Commit** and **push**

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -1,4 +1,4 @@
-.TH WHISRS 1 "2026-03-14" "whisrs 0.1.0" "User Commands"
+.TH WHISRS 1 "2026-07-29" "whisrs 0.1.20" "User Commands"
 .SH NAME
 whisrs \- Linux-first voice-to-text dictation CLI
 .SH SYNOPSIS

--- a/contrib/whisrsd.1
+++ b/contrib/whisrsd.1
@@ -1,16 +1,9 @@
-.TH WHISRSD 1 "2026-03-14" "whisrs 0.1.0" "User Commands"
+.TH WHISRSD 1 "2026-07-29" "whisrs 0.1.20" "User Commands"
 .SH NAME
 whisrsd \- whisrs dictation daemon
 .SH SYNOPSIS
 .B whisrsd
 .RI [ OPTIONS ]
-.SH OPTIONS
-.TP
-.BR \-h ", " \-\-help
-Print a short help message and exit.
-.TP
-.BR \-V ", " \-\-version
-Print version information and exit.
 .SH DESCRIPTION
 .B whisrsd
 is the background daemon for the whisrs dictation system. It manages audio
@@ -36,6 +29,13 @@ Auto-detects the active window manager/compositor
 Initializes the selected transcription backend
 .IP \(bu 2
 Binds the Unix domain socket and begins accepting commands
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Print a short help message and exit.
+.TP
+.BR \-V ", " \-\-version
+Print version information and exit.
 .SH STATE MACHINE
 The daemon maintains one of five states:
 .TP

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1014,6 +1014,24 @@ pub async fn read_message<T: serde::de::DeserializeOwned>(
 mod tests {
     use super::*;
 
+    /// The man pages carry the version by hand and drifted for 20 releases, so
+    /// assert it rather than trusting the release checklist. The revision date
+    /// in the same `.TH` line stays manual — nothing in the build knows it.
+    #[test]
+    fn man_pages_declare_current_version() {
+        let expected = format!("\"whisrs {}\"", env!("CARGO_PKG_VERSION"));
+        for (name, page) in [
+            ("contrib/whisrs.1", include_str!("../contrib/whisrs.1")),
+            ("contrib/whisrsd.1", include_str!("../contrib/whisrsd.1")),
+        ] {
+            let th = page.lines().next().unwrap_or_default();
+            assert!(
+                th.starts_with(".TH ") && th.contains(&expected),
+                "{name}: .TH should carry {expected}, got: {th}"
+            );
+        }
+    }
+
     #[test]
     fn command_serialization_roundtrip() {
         let cmd = Command::Toggle { language: None };


### PR DESCRIPTION
Fixes #63.

## What changed

**`contrib/whisrsd.1`** — moved the `OPTIONS` section from between `SYNOPSIS` and
`DESCRIPTION` to after `DESCRIPTION`, matching man-pages(7) ordering and the order
`contrib/whisrs.1` already uses.

**`contrib/whisrs.1`, `contrib/whisrsd.1`** — `.TH` now reads `whisrs 0.1.20`
instead of `whisrs 0.1.0`, and the revision date moves to the date of this change.

**`src/lib.rs`** — new `man_pages_declare_current_version` test asserting the `.TH`
version equals `CARGO_PKG_VERSION`.

**`CLAUDE.md`** — release-checklist step 1 now names the man pages alongside
`Cargo.toml` and `flake.nix`.

## Why a test and not just a checklist step

The issue suggests a checklist step, and notes that is "the more useful half". A
checklist step alone did not look sufficient: both pages carried `whisrs 0.1.0`
through 20 releases, across 7 commits that edited those very files. The version is
mechanically derivable from `CARGO_PKG_VERSION`, CI already runs `cargo test`, and
the assertion is ~12 lines in the `mod tests` block that `src/lib.rs` already has —
no new file, dependency, or CI step. Checked by reverting `whisrsd.1` to `0.1.0`,
which fails with:

```
contrib/whisrsd.1: .TH should carry "whisrs 0.1.20", got: .TH WHISRSD 1 "2026-07-29" "whisrs 0.1.0" "User Commands"
```

The checklist step stays, because the revision date in the same `.TH` line is not
derivable from anything in the build and remains manual.

Not done: generating the pages with `clap_mangen`. Both are mostly hand-written
prose (`STATE MACHINE`, `TRANSCRIPTION BACKENDS`, `SOCKET`, `SIGNALS`), and
`whisrsd`'s clap surface is two flags — generating would delete documentation to
automate a two-field bump.

`flake.nix` carries the version by hand too and is guarded only by the checklist.
It is correct at 0.1.20 today, so I left it out of the test as out of scope for this
issue; extending the same test to cover it is a few more lines if you want it.

## Verification

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build`
- `man --warnings -l` renders both pages with zero warnings; `whisrsd.1` footer reads `whisrs 0.1.20 / 2026-07-29` and section order is NAME, SYNOPSIS, DESCRIPTION, OPTIONS, ...
- The `OPTIONS` content matches the binary: `Args` at `src/daemon/main.rs` is empty with `#[command(version)]`, so `-h/--help` and `-V/--version` are the only options.
