### PR TITLE
test(daemon): cover whisrsd argument parsing

### DIFF
--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -694,6 +694,7 @@ struct Args {}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Not dead code: this call is what makes the flags above exit.
     Args::parse();
 
     tracing_subscriber::fmt()
@@ -2810,6 +2811,45 @@ async fn handle_cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::{error::ErrorKind, CommandFactory};
+
+    /// Catches a malformed arg definition — duplicate names, conflicting
+    /// shorts — the moment `Args` grows a real flag.
+    #[test]
+    fn daemon_args_are_valid() {
+        Args::command().debug_assert();
+    }
+
+    /// `Args` exists only so `--version` and `--help` are answered and exit
+    /// instead of being ignored and starting a daemon. Pin that behaviour,
+    /// since nothing else in the daemon would notice if it regressed.
+    ///
+    /// `try_parse_from` rather than `parse`, which would exit the test harness.
+    #[test]
+    fn daemon_answers_version_and_help_instead_of_starting() {
+        let Err(err) = Args::try_parse_from(["whisrsd", "--version"]) else {
+            panic!("--version parsed as a normal start instead of exiting");
+        };
+        assert_eq!(err.kind(), ErrorKind::DisplayVersion);
+        assert!(err.to_string().contains(env!("CARGO_PKG_VERSION")));
+
+        let Err(err) = Args::try_parse_from(["whisrsd", "--help"]) else {
+            panic!("--help parsed as a normal start instead of exiting");
+        };
+        assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+    }
+
+    #[test]
+    fn daemon_rejects_unknown_flags() {
+        assert!(Args::try_parse_from(["whisrsd", "--nope"]).is_err());
+    }
+
+    /// `contrib/whisrs.service` runs `whisrsd` with no arguments, so a
+    /// required field or positional on `Args` would break every install.
+    #[test]
+    fn daemon_parses_with_no_arguments() {
+        assert!(Args::try_parse_from(["whisrsd"]).is_ok());
+    }
 
     #[test]
     fn resolve_language_prefers_override() {


### PR DESCRIPTION
Fixes #65.

## What changed

Four tests in the existing `mod tests` of `src/daemon/main.rs`, plus a comment on
the `Args::parse()` call in `main()`.

The issue asks for `Args::command().debug_assert()` and is candid that it "asserts
close to nothing" today, since `Args` has no fields. That test is here as the
forward guard it was proposed as, but on its own it would leave the issue title
("No test coverage for whisrsd argument parsing") only nominally addressed. So the
other three pin what the struct was actually declared for in #59:

- `daemon_answers_version_and_help_instead_of_starting` — `--version` and `--help`
  return `ErrorKind::DisplayVersion` / `DisplayHelp` rather than falling through to
  a daemon start, and the version text carries `CARGO_PKG_VERSION`. Catches the
  `version` attribute being dropped, a hardcoded version drifting from
  `Cargo.toml`, and `disable_help_flag` being introduced.
- `daemon_rejects_unknown_flags` — a typo is rejected, not swallowed into a normal
  startup.
- `daemon_parses_with_no_arguments` — looks trivial, but `contrib/whisrs.service`
  is `ExecStart=whisrsd` with no arguments, so a required field or positional added
  to `Args` would break every systemd install.

## Notes for review

`try_parse_from`, not `parse` — `Args::parse()` with `--version` calls
`std::process::exit(0)`, which would take the test harness down with it.

`let ... else` rather than `unwrap_err` because `Args` does not implement `Debug`.
Deriving `Debug` on it would be shorter, but changing a production type for test
ergonomics seemed the worse trade in a test-only change.

The tests are pure in-memory clap work: no process spawned, no socket bound, no
filesystem touched. The `whisrsd` bin target does not set `test = false`, so plain
`cargo test` runs them and CI needs no change.

**Known gap:** `Args::parse()` in `main()` is not covered. Deleting that one line
leaves all four tests passing while `whisrsd --version` goes straight back to being
ignored and starting a daemon. Closing it means an integration test spawning
`CARGO_BIN_EXE_whisrsd`, and if the regression were present the spawned daemon
would bind `$XDG_RUNTIME_DIR/whisrs.sock` — possibly stealing it from the
developer's running `whisrs.service` — and never exit, so the failure mode is a
hang rather than a red test. Doing it safely needs a scratch `XDG_RUNTIME_DIR` and
`HOME` plus deadline-and-kill plumbing, which wants designing rather than bolting
on here. The comment on that line is the cheap mitigation: the realistic way it
dies is a future reader seeing a call whose result nobody binds, on a struct with
no fields, and removing it as dead code. Happy to file the spawn test as a
follow-up if you want it.

## Verification

`cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`,
`cargo build` — all clean. The `whisrsd` suite goes from 38 to 42 tests.
