### PR TITLE
fix(udev): resolve the setfacl path instead of assuming FHS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ curl -sSL -o whisrs.tar.gz https://github.com/y0sif/whisrs/releases/latest/downl
 tar xzf whisrs.tar.gz
 sudo install -m755 whisrs whisrsd /usr/local/bin/
 sudo install -m644 contrib/99-whisrs.rules /etc/udev/rules.d/
+# On NixOS/Guix, point the rule's ACL fallback at your setfacl:
+# sudo sed -i "s|/usr/bin/setfacl|$(command -v setfacl)|g" /etc/udev/rules.d/99-whisrs.rules
 sudo udevadm control --reload-rules && sudo udevadm trigger
 sudo usermod -aG input $USER   # log out / back in for the group change
 whisrs setup

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tar xzf whisrs.tar.gz
 sudo install -m755 whisrs whisrsd /usr/local/bin/
 sudo install -m644 contrib/99-whisrs.rules /etc/udev/rules.d/
 # On NixOS/Guix, point the rule's ACL fallback at your setfacl:
-# sudo sed -i "s|/usr/bin/setfacl|$(command -v setfacl)|g" /etc/udev/rules.d/99-whisrs.rules
+# command -v setfacl >/dev/null && sudo sed -i "s|/usr/bin/setfacl|$(command -v setfacl)|g" /etc/udev/rules.d/99-whisrs.rules
 sudo udevadm control --reload-rules && sudo udevadm trigger
 sudo usermod -aG input $USER   # log out / back in for the group change
 whisrs setup

--- a/contrib/99-whisrs.rules
+++ b/contrib/99-whisrs.rules
@@ -6,9 +6,9 @@
 # The setfacl call below ensures the input group always has read-write access
 # regardless of ACL state.
 #
-# Packagers: /usr/bin/setfacl is the FHS location. On distributions that put it
-# elsewhere (NixOS, Guix), rewrite both occurrences below at build time — the
-# TEST== guard makes this rule a silent no-op when the path does not exist.
+# Packagers: the rule below uses the FHS setfacl path. On distributions that put
+# it elsewhere (NixOS, Guix), rewrite both occurrences at build time — the TEST==
+# guard makes this rule a silent no-op when the path does not exist.
 #
 # Installation instructions live in README.md and docs/troubleshooting.md.
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", TAG+="uaccess"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,12 +5,25 @@
 Copy the udev rule and add yourself to the `input` group:
 
 ```bash
-sudo cp contrib/99-whisrs.rules /etc/udev/rules.d/
+sudo install -m644 contrib/99-whisrs.rules /etc/udev/rules.d/
 sudo udevadm control --reload-rules && sudo udevadm trigger
 sudo usermod -aG input $USER
 ```
 
 Log out and back in for the group change to take effect.
+
+The rule also grants the `input` group an ACL on `/dev/uinput`, which matters when
+another rule (e.g. brltty) sets one — ACLs override plain group permissions. That
+line is written against the FHS path `/usr/bin/setfacl` and is skipped when the
+path does not exist, so on distributions that put `setfacl` elsewhere (NixOS,
+Guix) rewrite it after copying:
+
+```bash
+sudo sed -i "s|/usr/bin/setfacl|$(command -v setfacl)|g" /etc/udev/rules.d/99-whisrs.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+`whisrs setup` and the Nix package do this substitution for you.
 
 ## No microphone detected
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,11 +19,14 @@ path does not exist, so on distributions that put `setfacl` elsewhere (NixOS,
 Guix) rewrite it after copying:
 
 ```bash
-sudo sed -i "s|/usr/bin/setfacl|$(command -v setfacl)|g" /etc/udev/rules.d/99-whisrs.rules
+command -v setfacl >/dev/null && sudo sed -i "s|/usr/bin/setfacl|$(command -v setfacl)|g" /etc/udev/rules.d/99-whisrs.rules
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 
-`whisrs setup` and the Nix package do this substitution for you.
+The `command -v` guard matters: with `setfacl` not installed the substitution would
+rewrite the rule to `TEST==""`, which stays dead even after you install `acl`.
+
+The Nix package does this substitution at build time.
 
 ## No microphone detected
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,11 @@
           inherit nativeBuildInputs buildInputs;
 
           postInstall = ''
+            # The shipped rule is written against the FHS setfacl path, which does
+            # not exist here — without this the ACL fallback is a silent no-op.
+            substituteInPlace contrib/99-whisrs.rules \
+              --replace-fail /usr/bin/setfacl ${pkgs.acl}/bin/setfacl
+
             install -Dm644 contrib/whisrs.1 $out/share/man/man1/whisrs.1
             install -Dm644 contrib/whisrsd.1 $out/share/man/man1/whisrsd.1
             install -Dm644 contrib/99-whisrs.rules $out/lib/udev/rules.d/99-whisrs.rules

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -358,7 +358,11 @@ fn check_uinput_access() {
                      Fix: sudo usermod -aG input $USER\n\
                           # Then log out and log back in\n\
                      Or install the udev rule:\n\
-                          sudo cp contrib/99-whisrs.rules /etc/udev/rules.d/\n\
+                          sudo install -m644 contrib/99-whisrs.rules /etc/udev/rules.d/\n\
+                          # On NixOS/Guix, point the rule at your setfacl:\n\
+                          command -v setfacl >/dev/null && sudo sed -i \\\n\
+                              \"s|/usr/bin/setfacl|$(command -v setfacl)|g\" \\\n\
+                              /etc/udev/rules.d/99-whisrs.rules\n\
                           sudo udevadm control --reload-rules\n\
                           sudo udevadm trigger"
                 );


### PR DESCRIPTION
Fixes #64.

Narrowed per review: this is now only the packaging half. The `whisrs setup` runtime resolution moved to #75, `flake.lock` to #74.

The ACL fallback in `contrib/99-whisrs.rules` is guarded by `TEST=="/usr/bin/setfacl"`. On distributions that do not use FHS paths (NixOS, Guix) that test never passes, so the line is a silent no-op — users do not get the ACL that keeps `/dev/uinput` writable when another rule (e.g. brltty) sets one.

**`flake.nix`** — `postInstall` now runs `substituteInPlace contrib/99-whisrs.rules --replace-fail /usr/bin/setfacl ${pkgs.acl}/bin/setfacl`. `--replace-fail` makes the FHS literal a load-bearing contract: reword the rule so the literal disappears and the build fails loudly instead of shipping a dead line.

The packager comment in the rule file is reworded so it no longer spells out `/usr/bin/setfacl`. `substituteInPlace` rewrites every occurrence, and a comment claiming the store path "is the FHS location" would be nonsense in the installed file. The two occurrences left are both on the rule line itself.

**Docs** — every place that tells users to install the rule by hand still shipped the FHS path: the README install snippet, `docs/troubleshooting.md`, and the daemon's permission-denied hint. A NixOS user following any of them reproduced the issue. Each now carries a `sed` one-liner that repoints the rule at the local `setfacl`, guarded with `command -v setfacl >/dev/null &&` — unguarded, `$(command -v setfacl)` expands to empty on a system without `acl` and rewrites the rule to `TEST==""`, which stays dead even after `acl` is installed later. The guard is valid in bash, POSIX sh and fish 3.4+.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean; `cargo test` passes (232 + 42).
- `nix build .#default` on NixOS, with the installed rule verified to point at the acl store path:

```
KERNEL=="uinput", SUBSYSTEM=="misc", TEST=="/nix/store/…-acl-2.4.0-bin/bin/setfacl", RUN+="/nix/store/…-acl-2.4.0-bin/bin/setfacl -m g:input:rw /dev/$name"
```

Not verified: that the resulting ACL actually applies on a NixOS system with a conflicting rule installed — that needs a machine where the brltty-style conflict reproduces. The `sed` instructions were not run end to end either.
