### PR TITLE
fix(daemon): fall back to typing instead of destroying non-text clipboard

### DIFF
--- a/crates/xkb-type/src/clipboard.rs
+++ b/crates/xkb-type/src/clipboard.rs
@@ -8,43 +8,90 @@ use std::process::Command;
 // Wayland: shell out to wl-paste / wl-copy
 // ---------------------------------------------------------------------------
 
+/// MIME types treated as "this clipboard offer is text" — the standard
+/// `text/plain` variants plus the legacy X11-selection type names wl-paste
+/// also reports under Xwayland interop.
+const TEXT_MIME_TYPES: &[&str] = &[
+    "text/plain",
+    "text/plain;charset=utf-8",
+    "TEXT",
+    "STRING",
+    "UTF8_STRING",
+];
+
 /// Run `wl-paste` with the given extra args (e.g. `--primary`) and return its
 /// text, distinguishing a genuinely empty clipboard from one holding
 /// non-text content (image, files, ...).
 ///
-/// wl-clipboard reports these as two different messages: an empty clipboard
-/// (no selection owner at all) says "Nothing is copied"; a selection that
-/// exists but doesn't offer a text MIME type says "Clipboard content is not
-/// available as \[inferred output|requested\] type ...". Only the former is a
-/// legitimate empty string — the latter must surface as an error, or a
-/// caller restoring a saved clipboard value (see `whisrs`'s paste-injection
-/// path) would overwrite non-text content with `""`.
+/// Does **not** rely on `wl-paste`'s own "inferred type" content negotiation
+/// (a bare `wl-paste --no-newline` with no explicit `--type`): that path was
+/// observed, live, to sometimes return a non-text selection's raw bytes as
+/// if they were text — even immediately after copying an image, with
+/// `wl-paste --list-types` correctly reporting only `image/png` on offer.
+/// The negotiation wl-paste performs when no type is given is apparently not
+/// reliable across all wl-clipboard/compositor/clipboard-manager
+/// combinations (reproduced under KDE Plasma 6 / KWin with Klipper active).
 ///
-/// Matched case-insensitively since wl-clipboard's exact capitalization has
-/// varied across versions; verified against wl-clipboard 2.2.1's actual
-/// wording (embedded strings), which no longer matches the older "no
-/// suitable type" phrasing this used to check for.
+/// Instead, this always queries `--list-types` first (a plain listing, no
+/// negotiation involved) and only issues a real read with an explicit
+/// `--type text/plain` if a text MIME type is actually listed. If the list is
+/// empty, the clipboard genuinely has no selection — a legitimate empty
+/// string. If it's non-empty but contains no text type, the selection holds
+/// non-text content and this errors, so a caller restoring a saved clipboard
+/// value (see `whisrs`'s paste-injection path) doesn't mistake "can't read
+/// this" for "empty" and overwrite it with `""`.
 fn run_wl_paste(extra_args: &[&str], command_desc: &str) -> anyhow::Result<String> {
+    let list_output = Command::new("wl-paste")
+        .arg("--list-types")
+        .args(extra_args)
+        .output()
+        .context("failed to run wl-paste --list-types — is wl-clipboard installed?")?;
+
+    if !list_output.status.success() {
+        let stderr = String::from_utf8_lossy(&list_output.stderr);
+        if is_empty_clipboard_message(&stderr) {
+            return Ok(String::new());
+        }
+        anyhow::bail!("{command_desc} --list-types failed: {stderr}");
+    }
+
+    let types = String::from_utf8_lossy(&list_output.stdout);
+    let offered: Vec<&str> = types.lines().map(str::trim).collect();
+
+    if offered.is_empty() {
+        // No selection owner at all — genuinely empty clipboard.
+        return Ok(String::new());
+    }
+
+    if !offers_text(&offered) {
+        anyhow::bail!(
+            "{command_desc}: clipboard holds non-text content (offered types: {offered:?})"
+        );
+    }
+
     let output = Command::new("wl-paste")
-        .arg("--no-newline")
+        .args(["--no-newline", "--type", "text/plain"])
         .args(extra_args)
         .output()
         .context("failed to run wl-paste — is wl-clipboard installed?")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if is_empty_clipboard_message(&stderr) {
-            return Ok(String::new());
-        }
         anyhow::bail!("{command_desc} failed: {stderr}");
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+/// Whether any of `offered` (as reported by `wl-paste --list-types`) is a
+/// text MIME type.
+fn offers_text(offered: &[&str]) -> bool {
+    offered.iter().any(|t| TEXT_MIME_TYPES.contains(t))
+}
+
 /// Whether a `wl-paste` stderr message means "the clipboard has no selection
-/// at all" (a legitimate empty string), as opposed to "a selection exists but
-/// isn't text" (which must propagate as an error — see [`run_wl_paste`]).
+/// at all" (a legitimate empty string). Kept as a defensive fallback in case
+/// `--list-types` itself ever errors instead of returning an empty listing.
 fn is_empty_clipboard_message(stderr: &str) -> bool {
     stderr.to_lowercase().contains("nothing is copied")
 }
@@ -212,5 +259,38 @@ mod tests {
         assert!(!is_empty_clipboard_message(
             "no suitable type of content copied"
         ));
+    }
+
+    /// `offers_text` is what `get_text`/`get_primary_selection` now gate on
+    /// (via `wl-paste --list-types`) instead of trusting wl-paste's own
+    /// "inferred type" negotiation — that negotiation was observed, live, to
+    /// sometimes return an image selection's raw bytes as if they were text,
+    /// even when `--list-types` correctly listed only `image/png`. Listing
+    /// types first and only reading with an explicit `--type text/plain`
+    /// when a text type is actually present avoids depending on that
+    /// negotiation at all.
+    #[test]
+    fn offers_text_true_for_plain_text_types() {
+        assert!(offers_text(&["text/plain"]));
+        assert!(offers_text(&["text/plain;charset=utf-8"]));
+        assert!(offers_text(&["TEXT"]));
+        assert!(offers_text(&["STRING"]));
+        assert!(offers_text(&["UTF8_STRING"]));
+        assert!(offers_text(&["image/png", "text/plain"]));
+    }
+
+    #[test]
+    fn offers_text_false_for_image_only() {
+        assert!(!offers_text(&["image/png"]));
+        assert!(!offers_text(&[
+            "image/png",
+            "application/x-qt-image",
+            "image/bmp"
+        ]));
+    }
+
+    #[test]
+    fn offers_text_false_for_empty_list() {
+        assert!(!offers_text(&[]));
     }
 }

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -1834,13 +1834,18 @@ fn paste_via_keyboard(
 /// (see [`whisrs::InputConfig::paste`]). Runs in a blocking context (callers
 /// wrap it in `spawn_blocking`), so the sleeps/restore use std threads.
 ///
-/// The restore is skipped, rather than clobbering the clipboard, when:
-/// - the original clipboard couldn't be read as text (e.g. it held an image
-///   or a file list) — there is nothing valid to restore to, so the pasted
-///   text is left in place instead of wiping it with `""`;
-/// - the clipboard no longer holds the text we set — something else (the
-///   user, another app) copied over it during the paste, and restoring would
-///   race that copy and discard it.
+/// `ClipboardBackend` is text-only, so a clipboard holding non-text content
+/// (an image, a file list, ...) can't be captured and round-tripped at all.
+/// If the pre-paste read fails, this falls back to typing instead of pasting
+/// — overwriting the clipboard via `set_text` first and only then discovering
+/// there's nothing valid to restore would destroy that content permanently
+/// (see #69), which skipping the *restore* alone can't undo since the damage
+/// already happened at `set_text`.
+///
+/// The restore is otherwise skipped, rather than clobbering the clipboard,
+/// when the clipboard no longer holds the text we set — something else (the
+/// user, another app) copied over it during the paste, and restoring would
+/// race that copy and discard it.
 fn inject_text(
     text: &str,
     is_terminal: bool,
@@ -1853,7 +1858,13 @@ fn inject_text(
     }
 
     let clipboard = xkb_type::default_clipboard();
-    let saved = clipboard.get_text().ok();
+    let saved = match clipboard.get_text() {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("clipboard unreadable as text, typing instead of pasting: {e:#}");
+            return type_text_at_cursor(text, key_delay, backend);
+        }
+    };
     clipboard
         .set_text(text)
         .context("failed to set clipboard for paste injection")?;
@@ -1869,10 +1880,6 @@ fn inject_text(
     let pasted_text = text.to_string();
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(500));
-        let Some(saved) = saved else {
-            // Original clipboard wasn't text; nothing we can restore to.
-            return;
-        };
         let clipboard = xkb_type::default_clipboard();
         match clipboard.get_text() {
             Ok(current) if current == pasted_text => {


### PR DESCRIPTION
## Summary

Fixes #69.

`inject_text`'s paste path called `clipboard.set_text(text)` before checking whether the *original* clipboard content could actually be restored afterward. When the clipboard held non-text content (an image, a file list, ...), `get_text()` returned `Err`, and the restore was correctly skipped — but by then `set_text` had already overwritten the original content. `ClipboardBackend` is text-only, so non-text content can never be captured/round-tripped no matter when we check; skipping the restore alone can't undo damage already done at `set_text`.

## Fix, part 1: reorder the check

Moves the `get_text()` check before `set_text()`. If the clipboard can't be read as text, the paste path is skipped entirely and the text is typed via the virtual keyboard instead — the clipboard is left completely untouched.

## Fix, part 2: found and fixed a second bug while verifying this live

I set up a live end-to-end test (real daemon, a stub ASR sidecar for deterministic transcription, a real image on the clipboard) rather than relying on unit tests alone, since this is exactly the kind of bug that looks fixed on paper but isn't. On KDE Plasma 6 / KWin with Klipper active, `WaylandClipboard::get_text()`'s underlying `wl-paste --no-newline` (no explicit `--type`) sometimes returned a non-text selection's **raw image bytes as if they were text** — reproduced against the actual running daemon, not just ad-hoc shell testing — even though `wl-paste --list-types` correctly listed only `image/png` moments before. That silently defeated fix part 1: `get_text()` would return `Ok(<garbled bytes>)` instead of erroring, so the paste path proceeded and clobbered the image anyway.

Root cause: relying on wl-paste's own "inferred type" content negotiation (what happens when no `--type` is given) isn't reliably strict about refusing non-text content under this compositor/clipboard-manager combination.

Fix: `get_text()`/`get_primary_selection()` now query `wl-paste --list-types` first (a plain listing, no negotiation involved) and only issue a real read with an explicit `--type text/plain` if a text MIME type is actually present in that list. Empty list → `Ok("")` (genuinely empty clipboard). Non-empty list with no text type → error, deterministically, without depending on wl-paste's negotiation at all.

## Testing

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build` all clean.
- New unit tests for the `--list-types`-based text/non-text decision.
- Live-verified end-to-end on KDE Plasma 6 (Wayland, KWin, Klipper), with a real image on the clipboard: confirmed `get_text()` now correctly errors with the offered-types list in the message, the injection path falls back to typing, and the clipboard image survives the whole cycle untouched. Also verified the normal case (text already on the clipboard) still pastes and restores correctly afterward — no regression there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)