### PR TITLE
fix(llm-commands): honor [input] paste when injecting command results

### DIFF
--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -2908,7 +2908,8 @@ async fn llm_command_background(
         return;
     }
 
-    // Restore window focus, then type the result at the cursor.
+    // Restore window focus, then inject the result at the cursor — keystrokes,
+    // or clipboard paste when `[input] paste = true` (layout-independent).
     if let Some(wid) = &window_id {
         if let Err(e) = context.window_tracker.focus_window(wid) {
             warn!("failed to restore window focus: {e}");
@@ -2920,15 +2921,34 @@ async fn llm_command_background(
     let result_clone = result.clone();
     let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
     let injector_backend = context.config.input.backend;
+    let paste = context.config.input.paste;
+    let is_terminal = if paste {
+        context
+            .window_tracker
+            .get_focused_window_class()
+            .map(|c| is_terminal_class(&c))
+            .unwrap_or(false)
+    } else {
+        false
+    };
     match tokio::task::spawn_blocking(move || {
-        type_text_at_cursor(&result_clone, key_delay, injector_backend)
+        inject_text(
+            &result_clone,
+            is_terminal,
+            key_delay,
+            injector_backend,
+            paste,
+        )
     })
     .await
     {
         Ok(Ok(())) => {}
-        Ok(Err(e)) => warn!("llm-command '{}': failed to type text: {e:#}", cmd_ctx.name),
+        Ok(Err(e)) => warn!(
+            "llm-command '{}': failed to inject text: {e:#}",
+            cmd_ctx.name
+        ),
         Err(e) => warn!(
-            "llm-command '{}': failed to join typing task: {e}",
+            "llm-command '{}': failed to join injection task: {e}",
             cmd_ctx.name
         ),
     }


### PR DESCRIPTION
## Summary

**Depends on #60** — this branch is `feat/llm-commands` (#60) plus one commit on top. The diff below will shrink to just that one commit once #60 merges and this is rebased onto `main`. Opening now (rather than waiting) since it's ready and small; happy to hold off review until #60 lands if you'd rather review it in isolation.

The llm-commands run path (#60) always typed its result via simulated keystrokes, ignoring `[input] paste` entirely. Regular dictation already respects `paste` (#61) — on compositors without the Wayland virtual-keyboard protocol, or with per-window/non-US layouts, keystroke injection can garble output, which is exactly what `paste = true` exists to avoid. llm-commands quietly opted out of that fix since it predates it (#60 and #61 were developed in parallel).

## Change

Routes `llm_command_background`'s result injection through the shared `inject_text` helper instead of calling `type_text_at_cursor` directly — so with `paste = true` it now sets the clipboard, sends Ctrl+V (Ctrl+Shift+V in terminals), and restores the previous clipboard afterward, identical to plain dictation's behavior. With `paste = false` (default), no behavior change.

## Testing

`cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)