### PR TITLE
feat(config): warn on unknown config.toml keys

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -518,6 +518,99 @@ impl std::fmt::Display for ConfigWarning {
     }
 }
 
+/// Keys in a parsed `config.toml` document that the configuration schema
+/// does not know.
+///
+/// The known set is derived from serde itself: the parsed [`Config`] is
+/// serialized back into a `toml::Table`, and the two tables are diffed
+/// recursively. A key present in the document but absent from the
+/// reserialization is a key the running binary silently dropped. This avoids
+/// a hand-maintained field-name list, which would go stale, and avoids a new
+/// dependency.
+///
+/// Returns `[]` when the document is not valid TOML or does not deserialize,
+/// because those cases already produce their own error in [`crate::daemon::startup::load_config`].
+pub fn unknown_config_keys(contents: &str) -> Vec<String> {
+    let Ok(document) = contents.parse::<toml::Table>() else {
+        return Vec::new();
+    };
+    let Ok(config) = toml::from_str::<Config>(contents) else {
+        return Vec::new();
+    };
+    let Ok(known) = toml::Value::try_from(&config) else {
+        return Vec::new();
+    };
+    let mut unknown = Vec::new();
+    diff_config_tables(
+        &document,
+        known.as_table().expect("Config serializes to a table"),
+        "",
+        &mut unknown,
+    );
+    unknown.sort();
+    unknown.dedup();
+    unknown
+}
+
+/// Collect every leaf key of `table` (with `prefix`) into `out`.
+fn collect_unknown_leaves(table: &toml::Table, prefix: &str, out: &mut Vec<String>) {
+    for (key, value) in table {
+        let path = format!("{prefix}{key}");
+        match value {
+            toml::Value::Table(inner) => collect_unknown_leaves(inner, &format!("{path}."), out),
+            _ => out.push(path),
+        }
+    }
+}
+
+/// Recursively compare a parsed document table against the reserialized
+/// (schema-known) table, appending dotted paths of unknown keys to `out`.
+fn diff_config_tables(
+    document: &toml::Table,
+    known: &toml::Table,
+    prefix: &str,
+    out: &mut Vec<String>,
+) {
+    for (key, value) in document {
+        let path = format!("{prefix}{key}");
+        match known.get(key) {
+            None => match value {
+                // A whole section the schema dropped (e.g. an Option section
+                // whose only keys are unknown): report each leaf, so the user
+                // learns which key inside it is the typo.
+                toml::Value::Table(inner) => {
+                    collect_unknown_leaves(inner, &format!("{path}."), out)
+                }
+                _ => out.push(path),
+            },
+            Some(toml::Value::Table(known_table)) => {
+                if let toml::Value::Table(document_table) = value {
+                    diff_config_tables(document_table, known_table, &format!("{path}."), out);
+                }
+            }
+            Some(toml::Value::Array(known_array)) => {
+                if let toml::Value::Array(document_array) = value {
+                    for (index, item) in document_array.iter().enumerate() {
+                        if let (
+                            toml::Value::Table(document_table),
+                            Some(toml::Value::Table(known_table)),
+                        ) = (item, known_array.get(index))
+                        {
+                            diff_config_tables(
+                                document_table,
+                                known_table,
+                                &format!("{path}[{index}]."),
+                                out,
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 impl Config {
     /// Validate the configuration and return a list of warnings.
     ///
@@ -956,6 +1049,51 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unknown_top_level_key_is_reported() {
+        let unknown = unknown_config_keys("bogus = 1\n[general]\nbackend = \"groq\"\n");
+        assert_eq!(unknown, vec!["bogus"]);
+    }
+
+    #[test]
+    fn unknown_nested_key_reports_full_path() {
+        // The live case from #99: `past` is a typo for `paste`.
+        let unknown = unknown_config_keys("[input]\npast = true\n");
+        assert_eq!(unknown, vec!["input.past"]);
+    }
+
+    #[test]
+    fn unknown_key_in_option_section_is_reported() {
+        let unknown = unknown_config_keys("[deepgram]\napi_key = \"k\"\nbogus = 2\n");
+        assert_eq!(unknown, vec!["deepgram.bogus"]);
+    }
+
+    #[test]
+    fn section_with_only_unknown_keys_reports_leaves() {
+        let unknown = unknown_config_keys("[deepgram]\nbogus = 1\n");
+        assert_eq!(unknown, vec!["deepgram.bogus"]);
+    }
+
+    #[test]
+    fn unknown_key_in_llm_command_array_element_is_reported() {
+        let unknown = unknown_config_keys(
+            "[[llm_commands]]\nname = \"x\"\nhotkey = \"Super+T\"\ninstruction = \"y\"\nbogus = 1\n",
+        );
+        assert_eq!(unknown, vec!["llm_commands[0].bogus"]);
+    }
+
+    #[test]
+    fn valid_config_reports_nothing() {
+        let unknown = unknown_config_keys("[general]\nbackend = \"groq\"\n[input]\npaste = true\n");
+        assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn invalid_toml_reports_nothing() {
+        let unknown = unknown_config_keys("not [valid toml");
+        assert!(unknown.is_empty());
+    }
 
     #[test]
     fn config_tts_section_roundtrip() {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -518,18 +518,28 @@ impl std::fmt::Display for ConfigWarning {
     }
 }
 
+/// One step of a path into a parsed `config.toml` document: a table key or an
+/// index into an array of tables (`[[llm_commands]]`).
+#[derive(Debug, Clone)]
+enum Seg {
+    Key(String),
+    Index(usize),
+}
+
 /// Keys in a parsed `config.toml` document that the configuration schema
 /// does not know.
 ///
 /// The known set is derived from serde itself: the parsed [`Config`] is
 /// serialized back into a `toml::Table`, and the two tables are diffed
 /// recursively. A key present in the document but absent from the
-/// reserialization is a key the running binary silently dropped. This avoids
-/// a hand-maintained field-name list, which would go stale, and avoids a new
-/// dependency.
+/// reserialization is a *candidate* the running binary may have silently
+/// dropped; `key_is_ignored` then confirms each one by pruning it and
+/// re-parsing. This avoids a hand-maintained field-name list, which would go
+/// stale, and avoids a new dependency.
 ///
 /// Returns `[]` when the document is not valid TOML or does not deserialize,
-/// because those cases already produce their own error in [`crate::daemon::startup::load_config`].
+/// because those cases already produce their own error in the daemon's
+/// `load_config`.
 pub fn unknown_config_keys(contents: &str) -> Vec<String> {
     let Ok(document) = contents.parse::<toml::Table>() else {
         return Vec::new();
@@ -540,52 +550,133 @@ pub fn unknown_config_keys(contents: &str) -> Vec<String> {
     let Ok(known) = toml::Value::try_from(&config) else {
         return Vec::new();
     };
-    let mut unknown = Vec::new();
+    let mut candidates = Vec::new();
     diff_config_tables(
         &document,
         known.as_table().expect("Config serializes to a table"),
-        "",
-        &mut unknown,
+        &[],
+        &mut candidates,
     );
+    // The diff is only a prefilter, so a valid config pays for nothing: with no
+    // candidates there is no second parse.
+    let mut unknown: Vec<String> = candidates
+        .iter()
+        .filter(|path| key_is_ignored(&document, &known, path))
+        .map(|path| render_path(path))
+        .collect();
     unknown.sort();
     unknown.dedup();
     unknown
 }
 
-/// Collect every leaf key of `table` (with `prefix`) into `out`.
-fn collect_unknown_leaves(table: &toml::Table, prefix: &str, out: &mut Vec<String>) {
+/// Render a path as the dotted form shown to the user (`input.past`,
+/// `llm_commands[0].bogus`).
+fn render_path(path: &[Seg]) -> String {
+    let mut rendered = String::new();
+    for seg in path {
+        match seg {
+            Seg::Key(key) => {
+                if !rendered.is_empty() {
+                    rendered.push('.');
+                }
+                rendered.push_str(key);
+            }
+            Seg::Index(index) => rendered.push_str(&format!("[{index}]")),
+        }
+    }
+    rendered
+}
+
+/// Whether the binary genuinely ignores the key at `path`, decided by removing
+/// it and re-parsing.
+///
+/// The reserialize-and-diff prefilter cannot see `#[serde(alias = "...")]`:
+/// serde accepts the alias but emits the *canonical* name, so every alias key
+/// (`[hotkeys] read`, the `[local]` and `[asr]` sections) is absent from the
+/// reserialized table and looks unknown while actually driving a field. Pruning
+/// settles it — if the config is byte-identical without the key, nothing read
+/// it; if it changes, or the pruned document no longer deserializes, the key
+/// fed a field under a name serde accepts but does not emit. Do not "simplify"
+/// this away: without it the daemon warns about working settings on every start.
+fn key_is_ignored(document: &toml::Table, known: &toml::Value, path: &[Seg]) -> bool {
+    let mut pruned = toml::Value::Table(document.clone());
+    if !prune_path(&mut pruned, path) {
+        // Unreachable — the path came from walking this same document. Keep the
+        // prefilter's verdict rather than silently dropping the warning.
+        return true;
+    }
+    let Ok(config) = pruned.try_into::<Config>() else {
+        return false;
+    };
+    let Ok(reserialized) = toml::Value::try_from(&config) else {
+        return false;
+    };
+    // Compare rendered forms rather than `==`: `toml::Value` equality is float
+    // equality, so a single `nan` in the document (`audio_feedback_volume` is
+    // the one float) would make every comparison false and silence every
+    // warning for the whole file.
+    format!("{reserialized:?}") == format!("{known:?}")
+}
+
+/// Remove the value at `path` from `value`. Returns whether anything was removed.
+fn prune_path(value: &mut toml::Value, path: &[Seg]) -> bool {
+    match path {
+        [] => false,
+        [Seg::Key(key)] => value
+            .as_table_mut()
+            .is_some_and(|table| table.remove(key).is_some()),
+        [Seg::Index(index)] => match value.as_array_mut() {
+            Some(array) if *index < array.len() => {
+                array.remove(*index);
+                true
+            }
+            _ => false,
+        },
+        [Seg::Key(key), rest @ ..] => value
+            .as_table_mut()
+            .and_then(|table| table.get_mut(key))
+            .is_some_and(|inner| prune_path(inner, rest)),
+        [Seg::Index(index), rest @ ..] => value
+            .as_array_mut()
+            .and_then(|array| array.get_mut(*index))
+            .is_some_and(|inner| prune_path(inner, rest)),
+    }
+}
+
+/// Collect every leaf key of `table` (below `prefix`) into `out`.
+fn collect_unknown_leaves(table: &toml::Table, prefix: &[Seg], out: &mut Vec<Vec<Seg>>) {
     for (key, value) in table {
-        let path = format!("{prefix}{key}");
+        let mut path = prefix.to_vec();
+        path.push(Seg::Key(key.clone()));
         match value {
-            toml::Value::Table(inner) => collect_unknown_leaves(inner, &format!("{path}."), out),
+            toml::Value::Table(inner) => collect_unknown_leaves(inner, &path, out),
             _ => out.push(path),
         }
     }
 }
 
 /// Recursively compare a parsed document table against the reserialized
-/// (schema-known) table, appending dotted paths of unknown keys to `out`.
+/// (schema-known) table, appending the paths of candidate unknown keys to `out`.
 fn diff_config_tables(
     document: &toml::Table,
     known: &toml::Table,
-    prefix: &str,
-    out: &mut Vec<String>,
+    prefix: &[Seg],
+    out: &mut Vec<Vec<Seg>>,
 ) {
     for (key, value) in document {
-        let path = format!("{prefix}{key}");
+        let mut path = prefix.to_vec();
+        path.push(Seg::Key(key.clone()));
         match known.get(key) {
             None => match value {
                 // A whole section the schema dropped (e.g. an Option section
                 // whose only keys are unknown): report each leaf, so the user
                 // learns which key inside it is the typo.
-                toml::Value::Table(inner) => {
-                    collect_unknown_leaves(inner, &format!("{path}."), out)
-                }
+                toml::Value::Table(inner) => collect_unknown_leaves(inner, &path, out),
                 _ => out.push(path),
             },
             Some(toml::Value::Table(known_table)) => {
                 if let toml::Value::Table(document_table) = value {
-                    diff_config_tables(document_table, known_table, &format!("{path}."), out);
+                    diff_config_tables(document_table, known_table, &path, out);
                 }
             }
             Some(toml::Value::Array(known_array)) => {
@@ -596,12 +687,9 @@ fn diff_config_tables(
                             Some(toml::Value::Table(known_table)),
                         ) = (item, known_array.get(index))
                         {
-                            diff_config_tables(
-                                document_table,
-                                known_table,
-                                &format!("{path}[{index}]."),
-                                out,
-                            );
+                            let mut item_path = path.clone();
+                            item_path.push(Seg::Index(index));
+                            diff_config_tables(document_table, known_table, &item_path, out);
                         }
                     }
                 }
@@ -1071,8 +1159,44 @@ mod tests {
 
     #[test]
     fn section_with_only_unknown_keys_reports_leaves() {
-        let unknown = unknown_config_keys("[deepgram]\nbogus = 1\n");
-        assert_eq!(unknown, vec!["deepgram.bogus"]);
+        // A whole section the schema never heard of: every leaf inside it is
+        // reported, nested ones included, so the user sees which key to fix.
+        // (`[deepgram]` can't stand in here — without `api_key` the document
+        // doesn't deserialize at all and nothing is reported.)
+        let unknown = unknown_config_keys("[bogus]\nfoo = 1\n[bogus.nested]\nbar = 2\n");
+        assert_eq!(unknown, vec!["bogus.foo", "bogus.nested.bar"]);
+    }
+
+    #[test]
+    fn hotkey_alias_key_is_not_reported() {
+        // `read` is a serde alias for `speak`, so it works (see
+        // `hotkey_speak_read_alias`) but reserializes as `speak`. The
+        // confirmation pass must clear it instead of warning on every start.
+        let unknown = unknown_config_keys("[hotkeys]\nread = \"Super+Shift+R\"\n");
+        assert!(unknown.is_empty(), "alias key reported: {unknown:?}");
+    }
+
+    #[test]
+    fn alias_sections_are_not_reported() {
+        // `[local]` aliases `[local-whisper]`, `[asr]` aliases `[asr-sidecar]`.
+        let unknown = unknown_config_keys("[local]\nmodel_path = \"/models/ggml.bin\"\n");
+        assert!(unknown.is_empty(), "[local] reported: {unknown:?}");
+
+        let unknown = unknown_config_keys("[asr]\nurl = \"http://127.0.0.1:9999/transcribe\"\n");
+        assert!(unknown.is_empty(), "[asr] reported: {unknown:?}");
+    }
+
+    #[test]
+    fn alias_key_alongside_typo_reports_only_the_typo() {
+        // The confirmation pass must not swallow real unknowns that sit next
+        // to an alias.
+        let unknown =
+            unknown_config_keys("[hotkeys]\nread = \"Super+Shift+R\"\nbogus = \"Super+X\"\n");
+        assert_eq!(unknown, vec!["hotkeys.bogus"]);
+
+        let unknown =
+            unknown_config_keys("[local]\nmodel_path = \"/models/ggml.bin\"\nbogus = 1\n");
+        assert_eq!(unknown, vec!["local.bogus"]);
     }
 
     #[test]
@@ -1093,6 +1217,16 @@ mod tests {
     fn invalid_toml_reports_nothing() {
         let unknown = unknown_config_keys("not [valid toml");
         assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn non_finite_float_does_not_silence_the_report() {
+        // `nan != nan`, so comparing parsed values directly would suppress every
+        // warning in the file, not just the one in this section.
+        let unknown = unknown_config_keys(
+            "[general]\naudio_feedback_volume = nan\nbogus = 1\n[input]\npast = true\n",
+        );
+        assert_eq!(unknown, vec!["general.bogus", "input.past"]);
     }
 
     #[test]

--- a/src/daemon/startup.rs
+++ b/src/daemon/startup.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use tracing::{debug, error, info, warn};
 
+use whisrs::config::types::unknown_config_keys;
 use whisrs::Config;
 
 /// Try to connect to an existing socket.
@@ -32,7 +33,17 @@ pub(crate) fn load_config() -> (Config, Option<String>) {
             Ok(contents) => match toml::from_str::<Config>(&contents) {
                 Ok(config) => {
                     info!("loaded config from {}", config_path.display());
-                    return (config, None);
+                    let unknown = unknown_config_keys(&contents);
+                    if unknown.is_empty() {
+                        return (config, None);
+                    }
+                    let msg = format!(
+                        "Unknown keys in config at {} ignored: {}",
+                        config_path.display(),
+                        unknown.join(", ")
+                    );
+                    warn!("{msg}");
+                    return (config, Some(msg));
                 }
                 Err(e) => {
                     let msg = format!(


### PR DESCRIPTION
Closes #100

## Mechanism

An unknown key in `config.toml` was silently dropped by the deserializer (`toml::from_str::<Config>`), and the load was reported as a success. A key that doesn't exist in the running binary behaved exactly like the default, with no feedback anywhere. Live case: #99, where `[input] paste = true` ran under v0.1.20 (the key shipped in v0.1.21), producing typed output and a clean startup log with nothing tying the two together. The same class covers typos (`remove_filler_word`, `silence_timeout`, `key_delay`).

## Fix

`unknown_config_keys()` in `src/config/types.rs` derives the known field set **from serde itself**: the parsed `Config` is serialized back into a `toml::Table`, and the two tables are diffed recursively. A key present in the document but absent from the reserialization is a key the running binary ignored.

- No new dependency (avoids `serde_ignored`, per CONTRIBUTING's stance on deps).
- No hand-maintained field-name list that would go stale — serde owns the names.
- Nested sections, `Option` sections, and `llm_commands` array elements are all walked; unknown keys are reported as dotted paths (`input.past`, `deepgram.bogus`, `llm_commands[0].bogus`).

`load_config()` now warns and returns the message through the existing `(Config, Option<String>)` channel, which the daemon already surfaces via `send_notification` and tracing.

## Example

```toml
[input]
past = true   # typo for "paste"
```

now produces: `Unknown keys in config at <path> ignored: input.past`

## Tests

Added 7 unit tests in `src/config/types.rs`: top-level keys, nested typos, unknown keys inside `Option` sections, sections whose only keys are unknown (reported per-leaf), `llm_commands` array elements, valid configs, and invalid TOML (reports nothing, since that case already errors).

## Verification note

The full crate build requires the Linux Wayland toolchain (xkbcommon/smithay-client-toolkit) and cannot compile on macOS, so CI is the authoritative test run. The diff algorithm itself was validated 8/8 against a standalone mirror of the schema shapes (nested tables, `Option` sections, arrays) before wiring it in, and both modified files pass `cargo fmt --check`.