### PR TITLE
feat(tray): add a tray menu and left-click toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ plain-toggle key is unaffected.
 
 ## Project Status
 
-whisrs is functional and usable for daily dictation. Streaming transcription, command mode, read-selection-aloud (TTS via Groq, OpenAI, Deepgram, or a local sidecar), multi-language support, system tray, OSD overlay, layout-aware injection (incl. AltGr + dead keys), the generic ASR sidecar backend (Moonshine, Parakeet, VibeVoice-ASR), and packaging for AUR / Nix / crates.io all ship today. Native local Vosk and Parakeet backends are next.
+whisrs is functional and usable for daily dictation. Streaming transcription, command mode, read-selection-aloud (TTS via Groq, OpenAI, Deepgram, or a local sidecar), multi-language support, system tray (left-click toggles recording; right-click menu shows status and offers restart and quit), OSD overlay, layout-aware injection (incl. AltGr + dead keys), the generic ASR sidecar backend (Moonshine, Parakeet, VibeVoice-ASR), and packaging for AUR / Nix / crates.io all ship today. Native local Vosk and Parakeet backends are next.
 
 Per-release details: [docs/version-roadmap.md](docs/version-roadmap.md).
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ plain-toggle key is unaffected.
 
 ## Project Status
 
-whisrs is functional and usable for daily dictation. Streaming transcription, command mode, read-selection-aloud (TTS via Groq, OpenAI, Deepgram, or a local sidecar), multi-language support, system tray (left-click toggles recording; right-click menu shows status and offers restart and quit), OSD overlay, layout-aware injection (incl. AltGr + dead keys), the generic ASR sidecar backend (Moonshine, Parakeet, VibeVoice-ASR), and packaging for AUR / Nix / crates.io all ship today. Native local Vosk and Parakeet backends are next.
+whisrs is functional and usable for daily dictation. Streaming transcription, command mode, read-selection-aloud (TTS via Groq, OpenAI, Deepgram, or a local sidecar), multi-language support, system tray (status, restart and quit in the menu; left-click toggles recording where the tray host forwards it, as waybar and Plasma do), OSD overlay, layout-aware injection (incl. AltGr + dead keys), the generic ASR sidecar backend (Moonshine, Parakeet, VibeVoice-ASR), and packaging for AUR / Nix / crates.io all ship today. Native local Vosk and Parakeet backends are next.
 
 Per-release details: [docs/version-roadmap.md](docs/version-roadmap.md).
 

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -102,10 +102,42 @@ async fn main() -> Result<()> {
         overlay_enabled,
     });
 
+    let daemon_state = Arc::new(Mutex::new(DaemonState::new()));
+
+    // Shared command channel for in-process command sources (hotkeys, tray
+    // menu). One dispatch loop drains it and routes every command through
+    // `handle_command`, exactly like commands arriving over the IPC socket.
+    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<Command>(16);
+    {
+        let dispatch_state = Arc::clone(&daemon_state);
+        let dispatch_ctx = Arc::clone(&context);
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                info!("internal command (hotkey/tray): {cmd:?}");
+                let _response =
+                    handle_command(cmd, Arc::clone(&dispatch_state), Arc::clone(&dispatch_ctx))
+                        .await;
+                // Broadcast state for tray.
+                let current = dispatch_state.lock().await.state_machine.state();
+                let _ = dispatch_ctx.state_tx.send(current);
+            }
+        });
+    }
+
     // Start system tray if enabled.
     // Spawned as a background task so retries don't block the IPC server.
     if tray_enabled {
-        tokio::spawn(whisrs::tray::spawn_tray(state_rx.clone()));
+        // Hand the tray the daemon's toast helper so menu failures (a failed
+        // "Restart Daemon" click) reach the user, not just the journal. Gated
+        // like every other error notification.
+        let tray_notify = context
+            .notify_error()
+            .then_some(send_notification as whisrs::tray::NotifyFn);
+        tokio::spawn(whisrs::tray::spawn_tray(
+            state_rx.clone(),
+            cmd_tx.clone(),
+            tray_notify,
+        ));
     }
 
     // Start bottom recording overlay if enabled.
@@ -133,8 +165,6 @@ async fn main() -> Result<()> {
     let listener = UnixListener::bind(&sock_path).context("failed to bind Unix socket")?;
     info!("listening on {}", sock_path.display());
 
-    let daemon_state = Arc::new(Mutex::new(DaemonState::new()));
-
     let sock_path_clone = sock_path.clone();
     tokio::spawn(async move {
         tokio::signal::ctrl_c().await.ok();
@@ -150,21 +180,10 @@ async fn main() -> Result<()> {
     if context.config.hotkeys.is_some() || !context.config.llm_commands.is_empty() {
         let hk_config = context.config.hotkeys.clone().unwrap_or_default();
         let llm_commands = context.config.llm_commands.clone();
-        let hk_state = Arc::clone(&daemon_state);
-        let hk_ctx = Arc::clone(&context);
+        let hk_tx = cmd_tx.clone();
         tokio::spawn(async move {
-            let (hotkey_tx, mut hotkey_rx) = tokio::sync::mpsc::channel::<Command>(16);
-            whisrs::hotkey::start_hotkey_listener(&hk_config, &llm_commands, hotkey_tx).await;
-
-            // Process hotkey commands.
-            while let Some(cmd) = hotkey_rx.recv().await {
-                info!("hotkey command: {cmd:?}");
-                let _response =
-                    handle_command(cmd, Arc::clone(&hk_state), Arc::clone(&hk_ctx)).await;
-                // Broadcast state for tray.
-                let current = hk_state.lock().await.state_machine.state();
-                let _ = hk_ctx.state_tx.send(current);
-            }
+            // Hotkey presses feed the shared dispatch loop above.
+            whisrs::hotkey::start_hotkey_listener(&hk_config, &llm_commands, hk_tx).await;
         });
     }
 

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -10,7 +10,18 @@ mod service;
 #[cfg(feature = "tray")]
 pub use service::spawn_tray;
 
+/// Desktop-toast hook the daemon hands to the tray so failures inside menu
+/// callbacks (currently a failed "Restart Daemon" click) surface to the user
+/// instead of only reaching the journal. A bare `fn` pointer keeps the tray
+/// decoupled from the daemon's notification module; `None` means the user has
+/// notifications disabled.
+pub type NotifyFn = fn(&str, &str);
+
 #[cfg(not(feature = "tray"))]
-pub async fn spawn_tray(_state_rx: tokio::sync::watch::Receiver<crate::State>) {
+pub async fn spawn_tray(
+    _state_rx: tokio::sync::watch::Receiver<crate::State>,
+    _cmd_tx: tokio::sync::mpsc::Sender<crate::Command>,
+    _notify: Option<NotifyFn>,
+) {
     // Tray feature not enabled — no-op.
 }

--- a/src/tray/service.rs
+++ b/src/tray/service.rs
@@ -308,3 +308,37 @@ pub async fn spawn_tray(
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Brings the `activate` trait method into scope for method-call syntax
+    // below; `impl ksni::Tray for WhisrsTray` above only qualifies the path,
+    // it doesn't import the trait.
+    use ksni::Tray as _;
+
+    /// `activate()` (left-click on the tray icon) is the only tray-driven
+    /// command, and nothing checks that it still sends `Toggle` after a
+    /// refactor — a typo'd variant here would ship silently. Pin it.
+    #[test]
+    fn activate_queues_toggle_command() {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        let mut tray = WhisrsTray {
+            state: TrayState {
+                current: State::Idle,
+            },
+            cmd_tx,
+            notify: None,
+        };
+
+        tray.activate(0, 0);
+
+        let cmd = cmd_rx
+            .try_recv()
+            .expect("activate() should queue a command");
+        assert!(
+            matches!(cmd, Command::Toggle { language: None }),
+            "expected Command::Toggle {{ language: None }}, got {cmd:?}"
+        );
+    }
+}

--- a/src/tray/service.rs
+++ b/src/tray/service.rs
@@ -1,10 +1,13 @@
 //! System tray implementation using ksni (StatusNotifierItem).
 
-use ksni::{Icon, ToolTip, TrayMethods};
-use tokio::sync::watch;
+use ksni::menu::StandardItem;
+use ksni::{Icon, MenuItem, ToolTip, TrayMethods};
+use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 
-use crate::State;
+use super::NotifyFn;
+use crate::service_ctl::{restart_daemon_via_systemd, RestartOutcome};
+use crate::{Command, State};
 
 /// 16x16 ARGB icon data for each state.
 /// Format: each pixel is 4 bytes (ARGB, big-endian).
@@ -69,9 +72,41 @@ struct TrayState {
     current: State,
 }
 
+/// Human-readable word for a state, used in the title and menu status line.
+fn state_word(state: State) -> &'static str {
+    match state {
+        State::Idle => "idle",
+        State::Recording => "recording",
+        State::Transcribing => "transcribing",
+        State::Synthesizing => "synthesizing",
+        State::Speaking => "speaking",
+    }
+}
+
 /// The ksni tray implementation.
 struct WhisrsTray {
     state: TrayState,
+    /// Sender into the daemon's shared command dispatch loop — the same loop
+    /// the hotkey listener feeds — so tray clicks drive `handle_command`
+    /// exactly like hotkey presses do.
+    cmd_tx: mpsc::Sender<Command>,
+    /// Desktop-toast hook from the daemon (`None` when notifications are
+    /// disabled), used to surface menu-callback failures the journal alone
+    /// would hide — currently a failed "Restart Daemon" click.
+    notify: Option<NotifyFn>,
+}
+
+impl WhisrsTray {
+    /// Queue a command for the daemon without blocking.
+    ///
+    /// ksni invokes tray callbacks on the tray service task and warns against
+    /// blocking there, so use `try_send`; if the queue is somehow full the
+    /// click is dropped with a warning instead of freezing the tray.
+    fn send(&self, cmd: Command) {
+        if let Err(e) = self.cmd_tx.try_send(cmd) {
+            warn!("tray: failed to queue command for daemon: {e}");
+        }
+    }
 }
 
 impl ksni::Tray for WhisrsTray {
@@ -80,13 +115,13 @@ impl ksni::Tray for WhisrsTray {
     }
 
     fn title(&self) -> String {
-        match self.state.current {
-            State::Idle => "whisrs — idle".to_string(),
-            State::Recording => "whisrs — recording".to_string(),
-            State::Transcribing => "whisrs — transcribing".to_string(),
-            State::Synthesizing => "whisrs — synthesizing".to_string(),
-            State::Speaking => "whisrs — speaking".to_string(),
-        }
+        format!("whisrs — {}", state_word(self.state.current))
+    }
+
+    /// Left-click on the icon: toggle recording, same as `whisrs toggle`.
+    fn activate(&mut self, _x: i32, _y: i32) {
+        debug!("tray activated (left-click): toggle");
+        self.send(Command::Toggle { language: None });
     }
 
     fn icon_pixmap(&self) -> Vec<Icon> {
@@ -119,6 +154,90 @@ impl ksni::Tray for WhisrsTray {
             icon_pixmap: Vec::new(),
         }
     }
+
+    /// Right-click menu.
+    ///
+    /// Deliberately holds no recording controls: whisrs is driven by hotkeys,
+    /// and toggle/cancel each already have a hotkey, a CLI command, and (for
+    /// toggle) the left-click above. A menu item for them would be a fourth
+    /// way to do the same thing. What is left is what has no other trigger.
+    fn menu(&self) -> Vec<MenuItem<Self>> {
+        let state = self.state.current;
+        vec![
+            // Non-interactive status line: version + current state.
+            MenuItem::Standard(StandardItem {
+                label: format!(
+                    "whisrs v{} — {}",
+                    env!("CARGO_PKG_VERSION"),
+                    state_word(state)
+                ),
+                enabled: false,
+                ..Default::default()
+            }),
+            MenuItem::Separator,
+            MenuItem::Standard(StandardItem {
+                label: "Restart Daemon".to_string(),
+                activate: Box::new(|tray: &mut Self| {
+                    restart_daemon(tray.notify);
+                }),
+                ..Default::default()
+            }),
+            MenuItem::Standard(StandardItem {
+                label: "Quit".to_string(),
+                activate: Box::new(|_tray: &mut Self| {
+                    quit_daemon();
+                }),
+                ..Default::default()
+            }),
+        ]
+    }
+}
+
+/// Restart the daemon through systemd, from the tray menu.
+///
+/// This cannot go through the daemon's own command loop: a successful restart
+/// kills this very process before it could reply. Runs on its own thread
+/// because ksni menu callbacks must not block and `systemctl` is a subprocess
+/// round-trip.
+///
+/// Failure raises a desktop toast (when `notify` is set): without one, a
+/// click on a non-systemd setup would silently do nothing, since journal
+/// warnings are invisible from the tray.
+fn restart_daemon(notify: Option<NotifyFn>) {
+    info!("tray: restart requested");
+    std::thread::spawn(move || match restart_daemon_via_systemd() {
+        // When this daemon runs under the unit, systemd kills it mid-restart,
+        // so this line is normally never reached.
+        RestartOutcome::Restarted => info!("tray: daemon restarted via systemd"),
+        RestartOutcome::NoSystemdUnit => {
+            warn!("tray: no whisrs.service user unit loaded — restart the daemon manually");
+            if let Some(notify) = notify {
+                notify(
+                    "whisrs",
+                    "Restart from the tray needs the whisrs.service systemd unit. \
+                     Restart the daemon manually.",
+                );
+            }
+        }
+        RestartOutcome::Failed => {
+            warn!("tray: `systemctl --user restart whisrs.service` failed");
+            if let Some(notify) = notify {
+                notify(
+                    "whisrs",
+                    "Daemon restart failed: `systemctl --user restart whisrs.service` \
+                     returned an error.",
+                );
+            }
+        }
+    });
+}
+
+/// Quit from the tray menu, mirroring the daemon's SIGINT handler:
+/// remove the IPC socket, then exit cleanly.
+fn quit_daemon() {
+    info!("tray: quit requested, shutting down");
+    let _ = std::fs::remove_file(crate::socket_path());
+    std::process::exit(0);
 }
 
 /// Maximum number of attempts to connect to the SNI tray host.
@@ -132,7 +251,11 @@ const TRAY_INITIAL_DELAY: std::time::Duration = std::time::Duration::from_secs(1
 /// Runs in the background and updates the icon whenever the daemon state changes.
 /// Retries with exponential backoff if the SNI host isn't available yet (common
 /// on boot when the daemon starts before the desktop environment is fully ready).
-pub async fn spawn_tray(mut state_rx: watch::Receiver<State>) {
+pub async fn spawn_tray(
+    mut state_rx: watch::Receiver<State>,
+    cmd_tx: mpsc::Sender<Command>,
+    notify: Option<NotifyFn>,
+) {
     // Retry spawning the tray with exponential backoff.
     let mut delay = TRAY_INITIAL_DELAY;
     let mut handle = None;
@@ -142,6 +265,8 @@ pub async fn spawn_tray(mut state_rx: watch::Receiver<State>) {
             state: TrayState {
                 current: *state_rx.borrow(),
             },
+            cmd_tx: cmd_tx.clone(),
+            notify,
         };
 
         match tray.spawn().await {


### PR DESCRIPTION
The ksni::Tray impl had no menu() and no activate(), so the right-click menu was empty and clicking the icon did nothing.

Left-click now toggles recording, and the right-click menu shows a disabled status line with the version and current state, plus Restart Daemon and Quit.

The menu deliberately has no start, stop or cancel items. Every one of those already has a hotkey and a CLI command, and toggle now has the left-click as well, so a menu entry would be a fourth path to the same action. Live testing confirmed they read as clutter rather than convenience. Switching the transcription backend and model is the thing the menu has no substitute for, and that is filed separately as #103.

Restart calls service_ctl::restart_daemon_via_systemd directly on a spawned thread, since a self-restart cannot flow through the daemon's own command loop, and a failure raises a desktop notification through the same general.notify gate every other error toast uses. Quit mirrors the existing SIGINT handler, socket removal included.

To make the icon actionable, the hotkey listener's private command channel is hoisted into main() as one shared channel with a single dispatch loop calling handle_command. Tray and hotkey commands take the identical path; hotkey dispatch behavior is unchanged. ksni callbacks are sync and must not block, so the tray uses try_send.

Tested on Hyprland with waybar: left-click starts and stops dictation, the status line tracks state, restart cycles the unit, quit exits cleanly, and the configured hotkeys still work through the shared loop.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)