### PR TITLE
feat(config): add [input] terminal_classes for user-supplied terminals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,43 @@ key_delay_ms = 2
 # type incrementally and ignore it. `whisrsd` warns at startup if paste is set
 # with one of those backends.
 paste = false
+# Extra window classes to treat as terminal emulators, checked alongside the
+# built-in list. Default: [] (built-in list only).
+#
+# WARNING: terminal detection is what makes command mode clear the prompt line
+# with Ctrl+A then Ctrl+K before injecting its result. If you list a class that
+# is not a terminal, that Ctrl+A / Ctrl+K goes into an ordinary text field and
+# empties it. Terminal detection also swaps Ctrl+C for Ctrl+Shift+C in the
+# selection path, so a mis-listed class can instead open DevTools in browsers
+# and Electron apps. Only add classes you have confirmed belong to a terminal.
+#
+# The config is read once at daemon startup, so run `whisrs restart` after
+# changing this key or the new value has no effect.
+#
+# To debug a class that will not match, run `RUST_LOG=debug whisrsd` and look
+# for the `is_terminal_class(...)` line for that window. It names the class
+# under test, the verdict, and (on a match) which stage matched: built-in
+# whole identifier, your terminal_classes entry, or a built-in leaf name.
+#
+# Use this for the two cases the built-in list cannot cover:
+#   * an st build with a custom `termname` in config.h, which reports that name
+#     as its class instead of st-256color
+#   * scratchpad / dropdown windows launched under a renamed class, such as
+#     Alacritty-float, kitty-dropdown or wezterm-quake
+#
+# Entries are compared case-insensitively against the WHOLE window class, never
+# as substrings, so "st" matches a window whose class is exactly "st" and not
+# "steam". Unlike the built-in list, they are not matched by their last
+# dot-segment either: listing "warp" matches the class "warp" and leaves
+# "app.drey.Warp" (GNOME's Magic Wormhole client, not a terminal) alone. To
+# match a reverse-DNS app_id, write it out in full.
+#
+# Read the class off your compositor:
+#   hyprctl activewindow | grep class
+#   niri msg focused-window
+# Hyprland and Niri are also the only window trackers that report a class
+# today, so this key has no effect on KDE, GNOME, Sway or X11 (issue #71).
+terminal_classes = []
 
 [groq]
 api_key = "gsk_..."

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -289,6 +289,27 @@ pub struct InputConfig {
     /// this is set alongside one of those backends.
     #[serde(default)]
     pub paste: bool,
+    /// Extra window classes to treat as terminal emulators, checked alongside
+    /// the built-in list. Empty by default.
+    ///
+    /// Terminal detection picks Ctrl+Shift+C / Ctrl+Shift+V over Ctrl+C /
+    /// Ctrl+V and, in command mode, sends Ctrl+A then Ctrl+K to clear the
+    /// prompt line before injecting. That last one *empties the field* if it
+    /// fires in a GUI text input (#70), so the built-in list stays
+    /// conservative and this is the explicit, opt-in escape hatch for the two
+    /// cases it cannot know about: an `st` build with a custom `termname` in
+    /// `config.h`, and scratchpad/dropdown classes such as `Alacritty-float`,
+    /// `kitty-dropdown` or `wezterm-quake` (#92).
+    ///
+    /// Entries are compared case-insensitively against the *whole* focused
+    /// window class. They are never substring-matched, and they never go
+    /// through the reverse-DNS leaf stage the built-in list uses — so listing
+    /// a generic name like `warp` matches a window whose class is exactly
+    /// `warp`, and leaves `app.drey.Warp` (GNOME's Magic Wormhole client)
+    /// alone. Write the class exactly as the compositor reports it
+    /// (`hyprctl activewindow`, `niri msg focused-window`).
+    #[serde(default)]
+    pub terminal_classes: Vec<String>,
 }
 
 impl Default for InputConfig {
@@ -297,6 +318,7 @@ impl Default for InputConfig {
             key_delay_ms: default_key_delay_ms(),
             backend: InjectorBackend::default(),
             paste: false,
+            terminal_classes: Vec::new(),
         }
     }
 }

--- a/src/daemon/command_mode.rs
+++ b/src/daemon/command_mode.rs
@@ -381,7 +381,7 @@ async fn command_mode_background_inner(
     let is_terminal = context
         .window_tracker
         .get_focused_window_class()
-        .map(|c| is_terminal_class(&c))
+        .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
         .unwrap_or(false);
     match tokio::task::spawn_blocking(move || {
         if is_terminal {
@@ -798,7 +798,7 @@ async fn llm_command_background_inner(
         context
             .window_tracker
             .get_focused_window_class()
-            .map(|c| is_terminal_class(&c))
+            .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
             .unwrap_or(false)
     } else {
         false

--- a/src/daemon/injection.rs
+++ b/src/daemon/injection.rs
@@ -419,31 +419,73 @@ const TERMINAL_LEAF_CLASSES: &[&str] = &[
 /// Check if a window class corresponds to a terminal emulator.
 ///
 /// A false positive here is destructive (command mode clears the line), while a
-/// false negative merely degrades to plain injection — so both stages match on
-/// whole identifiers or whole dot-segments, never on substrings.
-pub(crate) fn is_terminal_class(class: &str) -> bool {
+/// false negative merely degrades to plain injection — so every stage matches
+/// on whole identifiers or whole dot-segments, never on substrings.
+///
+/// `user_classes` is `[input] terminal_classes`: the opt-in escape hatch for
+/// the classes the built-in list cannot know about — an `st` build with a
+/// custom `termname`, and scratchpad/dropdown classes like `Alacritty-float`
+/// (#92). It is checked *alongside* the built-in list, and only as a whole
+/// identifier:
+///
+/// - Case-insensitive, like the built-in path, because compositors disagree on
+///   casing (`Alacritty` on X11, `alacritty` elsewhere) and a config entry
+///   should not have to guess.
+/// - **Not** run through the leaf stage below. The leaf stage exists to rescue
+///   app_ids the user never had to think about; a user entry is already the
+///   exact string they read off `hyprctl activewindow`. Leaf-matching it would
+///   turn a one-word entry into a whole-namespace wildcard — listing `warp`
+///   would then also match `app.drey.Warp`, GNOME's Magic Wormhole client,
+///   which is the destructive direction. An entry that *is* a dotted app_id
+///   still matches that app_id exactly, so nothing is out of reach: it just
+///   has to be named.
+/// - Free to name a class the leaf set deliberately excludes (`warp`, `st`,
+///   `terminal`, ...). Whole-identifier matching keeps that scoped to the one
+///   window class the user actually opted into, so honoring it costs nothing
+///   the exclusions were protecting.
+pub(crate) fn is_terminal_class(class: &str, user_classes: &[String]) -> bool {
     let lower = class.trim().to_ascii_lowercase();
     if lower.is_empty() {
+        debug!("is_terminal_class({class:?}): false (empty class)");
         return false;
     }
-    // Stage 1: whole-identifier exact match.
+    // Stage 1: whole-identifier exact match against the built-in list.
     if TERMINAL_CLASSES.contains(&lower.as_str()) {
+        debug!("is_terminal_class({class:?}): true (built-in whole identifier)");
         return true;
     }
-    // Stage 2: exact match on the last dot-segment, so repackaged reverse-DNS
+    // Stage 2: whole-identifier exact match against the user's list. Entries
+    // are trimmed for the same reason the class is; a blank entry can never
+    // match, because an empty class returned above.
+    if user_classes
+        .iter()
+        .any(|entry| entry.trim().eq_ignore_ascii_case(&lower))
+    {
+        debug!("is_terminal_class({class:?}): true (user terminal_classes entry)");
+        return true;
+    }
+    // Stage 3: exact match on the last dot-segment, so repackaged reverse-DNS
     // app_ids still resolve. Only applies to dotted identifiers; a bare class
-    // must appear in TERMINAL_CLASSES verbatim.
+    // must appear in TERMINAL_CLASSES verbatim. Built-in leaves only — see the
+    // doc comment for why user entries stop at stage 2.
     if let Some((_, leaf)) = lower.rsplit_once('.') {
         if TERMINAL_LEAF_CLASSES.contains(&leaf) {
+            debug!("is_terminal_class({class:?}): true (built-in leaf {leaf:?})");
             return true;
         }
     }
+    debug!("is_terminal_class({class:?}): false (no match in built-in list, user list, or built-in leaves)");
     false
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `[input] terminal_classes` as the daemon hands it over.
+    fn user(classes: &[&str]) -> Vec<String> {
+        classes.iter().map(|c| c.to_string()).collect()
+    }
 
     /// Real-world strings, in the casing a compositor hands them to us: bare
     /// X11 WM_CLASS classes and reverse-DNS Wayland app_ids.
@@ -512,7 +554,7 @@ mod tests {
             "hyper",
         ] {
             assert!(
-                is_terminal_class(class),
+                is_terminal_class(class, &[]),
                 "{class} is a terminal but is_terminal_class says it is not"
             );
         }
@@ -524,7 +566,7 @@ mod tests {
     fn every_terminal_class_entry_matches() {
         for class in TERMINAL_CLASSES {
             assert!(
-                is_terminal_class(class),
+                is_terminal_class(class, &[]),
                 "{class} is in TERMINAL_CLASSES but is_terminal_class says it is not a terminal"
             );
         }
@@ -536,7 +578,7 @@ mod tests {
         for leaf in TERMINAL_LEAF_CLASSES {
             let class = format!("io.example.{leaf}");
             assert!(
-                is_terminal_class(&class),
+                is_terminal_class(&class, &[]),
                 "{class} should match via TERMINAL_LEAF_CLASSES but does not"
             );
             // Stage 2 only fires on dotted identifiers, so the bare class form
@@ -567,7 +609,7 @@ mod tests {
             "com.example.Wave",
         ] {
             assert!(
-                !is_terminal_class(class),
+                !is_terminal_class(class, &[]),
                 "{class} is not a terminal but is_terminal_class says it is"
             );
         }
@@ -586,7 +628,7 @@ mod tests {
             "ghostty-foo",
         ] {
             assert!(
-                !is_terminal_class(class),
+                !is_terminal_class(class, &[]),
                 "{class} is not a known terminal class but is_terminal_class says it is"
             );
         }
@@ -599,7 +641,7 @@ mod tests {
             "com.mitchellh.ghostty-debug",
         ] {
             assert!(
-                is_terminal_class(class),
+                is_terminal_class(class, &[]),
                 "{class} is a terminal but is_terminal_class says it is not"
             );
         }
@@ -609,9 +651,9 @@ mod tests {
     /// list: only `blackbox-terminal` is a real class, plain `blackbox` is not.
     #[test]
     fn leaf_set_requires_a_dot() {
-        assert!(!is_terminal_class("blackbox"));
-        assert!(is_terminal_class("blackbox-terminal"));
-        assert!(is_terminal_class("io.example.Ghostty"));
+        assert!(!is_terminal_class("blackbox", &[]));
+        assert!(is_terminal_class("blackbox-terminal", &[]));
+        assert!(is_terminal_class("io.example.Ghostty", &[]));
     }
 
     /// The destructive direction: anything matched here gets Ctrl+A/Ctrl+K sent
@@ -645,7 +687,7 @@ mod tests {
             "   ",
         ] {
             assert!(
-                !is_terminal_class(class),
+                !is_terminal_class(class, &[]),
                 "{class:?} is not a terminal but is_terminal_class says it is"
             );
         }
@@ -662,7 +704,7 @@ mod tests {
             "libreoffice-startcenter",
         ] {
             assert!(
-                !is_terminal_class(class),
+                !is_terminal_class(class, &[]),
                 "{class} is not a terminal but is_terminal_class says it is"
             );
         }
@@ -680,9 +722,197 @@ mod tests {
             "qterminal",
         ] {
             assert!(
-                is_terminal_class(class),
+                is_terminal_class(class, &[]),
                 "{class} is a terminal but is_terminal_class says it is not"
             );
         }
+    }
+
+    /// `[input] terminal_classes` entries match the whole class, in either
+    /// casing: the compositor's (X11 hands us `Alacritty-float`) and the
+    /// user's (they may have typed it lowercase, or with stray spaces).
+    #[test]
+    fn user_terminal_classes_match_whole_identifiers_case_insensitively() {
+        let extra = user(&["st-mytermname", "  Alacritty-float  ", "kitty-dropdown"]);
+        for class in [
+            "st-mytermname",
+            "ST-MYTERMNAME",
+            "Alacritty-float",
+            "alacritty-float",
+            "ALACRITTY-FLOAT",
+            "  alacritty-float  ",
+            "kitty-dropdown",
+            "Kitty-Dropdown",
+        ] {
+            assert!(
+                is_terminal_class(class, &extra),
+                "{class:?} is listed in terminal_classes but is_terminal_class says it is not a terminal"
+            );
+        }
+    }
+
+    /// Issue #92, first case: st takes its class from `termname` in
+    /// `config.h`, so a renamed build matches nothing built in.
+    #[test]
+    fn repro_renamed_st_needs_a_user_entry_issue92() {
+        for class in ["st-mytermname", "st-solarized", "mysuckless-term"] {
+            assert!(
+                !is_terminal_class(class, &[]),
+                "{class} is not a built-in class; the built-in list must stay conservative"
+            );
+            assert!(
+                is_terminal_class(class, &user(&[class])),
+                "{class} is listed in terminal_classes but is_terminal_class says it is not a terminal"
+            );
+        }
+    }
+
+    /// Issue #92, second case: scratchpad and dropdown setups rename the
+    /// class. The pre-#70 substring match caught these incidentally; exact
+    /// matching does not, so they need an explicit entry.
+    #[test]
+    fn repro_scratchpad_classes_need_a_user_entry_issue92() {
+        for class in ["Alacritty-float", "kitty-dropdown", "wezterm-quake"] {
+            assert!(
+                !is_terminal_class(class, &[]),
+                "{class} must not match on its own — exact matching is the #70 fix"
+            );
+            assert!(
+                is_terminal_class(class, &user(&[class])),
+                "{class} is listed in terminal_classes but is_terminal_class says it is not a terminal"
+            );
+        }
+    }
+
+    /// A user entry must not reintroduce the #70 substring bug. Someone who
+    /// lists a short generic name gets exactly that window class, nothing
+    /// that merely contains it.
+    #[test]
+    fn user_entries_are_never_substring_matched() {
+        let extra = user(&["st", "float", "term"]);
+        for class in [
+            "steam",
+            "Postman",
+            "systemsettings",
+            "com.obsproject.Studio",
+            "libreoffice-startcenter",
+            "floating-window",
+            "Alacritty-float",
+            "terminal-preferences",
+        ] {
+            assert!(
+                !is_terminal_class(class, &extra),
+                "{class} only contains a terminal_classes entry; it must not match"
+            );
+        }
+        // The entries themselves still match, as whole identifiers.
+        for class in ["st", "float", "term"] {
+            assert!(is_terminal_class(class, &extra));
+        }
+    }
+
+    /// User entries stop at the whole-identifier stage. They are never
+    /// leaf-matched in either direction, so a one-word entry can never turn
+    /// into a whole-namespace wildcard over the generic leaves the built-in
+    /// set deliberately excludes.
+    #[test]
+    fn user_entries_do_not_go_through_the_leaf_stage() {
+        // `warp` is an excluded leaf: `app.drey.Warp` is GNOME's Magic
+        // Wormhole client. Listing the bare word must not drag it in.
+        let bare = user(&["warp"]);
+        assert!(is_terminal_class("warp", &bare));
+        assert!(!is_terminal_class("app.drey.Warp", &bare));
+        assert!(!is_terminal_class("dev.example.warp", &bare));
+
+        // Naming the full app_id is honored: it is exact, and the user opted
+        // into that one class explicitly.
+        let dotted = user(&["dev.example.warp"]);
+        assert!(is_terminal_class("dev.example.warp", &dotted));
+        assert!(!is_terminal_class("app.drey.Warp", &dotted));
+
+        // Same in the other direction: a dotted entry does not match the bare
+        // leaf, and the other excluded generics behave identically.
+        assert!(!is_terminal_class("myterm", &user(&["com.example.myterm"])));
+        for (entry, class) in [
+            ("terminal", "com.paymentco.Terminal"),
+            ("console", "org.example.Console"),
+            ("blackbox", "com.example.BlackBox"),
+        ] {
+            assert!(
+                !is_terminal_class(class, &user(&[entry])),
+                "{class} must not match on a bare `{entry}` entry"
+            );
+        }
+    }
+
+    /// The default: an empty list is exactly today's behavior, and a list
+    /// that names something unrelated changes no built-in verdict — in
+    /// either direction.
+    #[test]
+    fn user_list_never_changes_the_builtin_verdicts() {
+        let unrelated = user(&["Alacritty-float", "st-mytermname"]);
+        for class in [
+            "alacritty",
+            "org.gnome.Terminal",
+            "st-256color",
+            "io.example.Ghostty",
+            "hyper",
+        ] {
+            assert!(is_terminal_class(class, &[]), "{class} regressed at &[]");
+            assert!(
+                is_terminal_class(class, &unrelated),
+                "{class} regressed with an unrelated terminal_classes list"
+            );
+        }
+        for class in [
+            "steam",
+            "Postman",
+            "systemsettings",
+            "com.obsproject.Studio",
+            "app.drey.Warp",
+            "st-link",
+            "",
+            "   ",
+        ] {
+            assert!(
+                !is_terminal_class(class, &[]),
+                "{class:?} must not match with no user classes"
+            );
+            assert!(
+                !is_terminal_class(class, &unrelated),
+                "{class:?} must not match because of an unrelated terminal_classes entry"
+            );
+        }
+    }
+
+    /// A blank or whitespace-only entry is inert. It must not match the empty
+    /// class, and above all it must not match everything.
+    #[test]
+    fn blank_user_entries_are_inert() {
+        let blanks = user(&["", "   ", "\t"]);
+        for class in ["", "   ", "steam", "firefox", "org.gnome.Settings"] {
+            assert!(
+                !is_terminal_class(class, &blanks),
+                "{class:?} matched a blank terminal_classes entry"
+            );
+        }
+    }
+
+    /// End to end through the config type: an `[input]` table written before
+    /// the key existed still parses, and the parsed list is what the daemon
+    /// hands to `is_terminal_class`.
+    #[test]
+    fn terminal_classes_parses_from_the_input_table() {
+        let old: whisrs::InputConfig = toml::from_str("key_delay_ms = 2\npaste = true\n").unwrap();
+        assert!(old.terminal_classes.is_empty());
+        assert!(!is_terminal_class("Alacritty-float", &old.terminal_classes));
+
+        let new: whisrs::InputConfig =
+            toml::from_str("terminal_classes = [\"Alacritty-float\", \"st-mytermname\"]\n")
+                .unwrap();
+        assert_eq!(new.terminal_classes, ["Alacritty-float", "st-mytermname"]);
+        assert!(is_terminal_class("alacritty-float", &new.terminal_classes));
+        assert!(is_terminal_class("st-mytermname", &new.terminal_classes));
+        assert!(!is_terminal_class("steam", &new.terminal_classes));
     }
 }

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -717,7 +717,7 @@ pub(crate) async fn process_recording_batch(
         context
             .window_tracker
             .get_focused_window_class()
-            .map(|c| is_terminal_class(&c))
+            .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
             .unwrap_or(false)
     } else {
         false

--- a/src/daemon/selection.rs
+++ b/src/daemon/selection.rs
@@ -173,10 +173,11 @@ pub(crate) async fn capture_selection(context: &DaemonContext) -> Result<String,
     // The terminal check is resolved lazily, inside the copy closure, so the
     // primary-selection fast path never queries the window tracker.
     let tracker = context.window_tracker.clone();
+    let user_terminal_classes = context.config.input.terminal_classes.clone();
     let copy = move || {
         let is_terminal = tracker
             .get_focused_window_class()
-            .map(|c| is_terminal_class(&c))
+            .map(|c| is_terminal_class(&c, &user_terminal_classes))
             .unwrap_or(false);
         if is_terminal {
             simulate_terminal_copy()

--- a/src/window/hyprland.rs
+++ b/src/window/hyprland.rs
@@ -63,15 +63,24 @@ impl WindowTracker for HyprlandTracker {
             .ok()?;
 
         if !output.status.success() {
+            debug!("hyprland focused window class: hyprctl activewindow failed");
             return None;
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let parsed: HyprctlActiveWindow = serde_json::from_str(&stdout).ok()?;
+        let parsed: HyprctlActiveWindow = match serde_json::from_str(&stdout) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                debug!("hyprland focused window class: failed to parse hyprctl JSON: {err}");
+                return None;
+            }
+        };
 
         if parsed.class.is_empty() {
+            debug!("hyprland focused window class: empty (no class reported)");
             None
         } else {
+            debug!("hyprland focused window class: {}", parsed.class);
             Some(parsed.class)
         }
     }

--- a/src/window/niri.rs
+++ b/src/window/niri.rs
@@ -77,8 +77,24 @@ impl WindowTracker for NiriTracker {
     }
 
     fn get_focused_window_class(&self) -> Option<String> {
-        let focused_window = query_focused_window().ok()?;
-        focused_window.app_id.filter(|app_id| !app_id.is_empty())
+        let focused_window = match query_focused_window() {
+            Ok(focused_window) => focused_window,
+            Err(err) => {
+                debug!("niri focused window class: query failed: {err}");
+                return None;
+            }
+        };
+
+        match focused_window.app_id.filter(|app_id| !app_id.is_empty()) {
+            Some(app_id) => {
+                debug!("niri focused window class: {app_id}");
+                Some(app_id)
+            }
+            None => {
+                debug!("niri focused window class: empty (no app_id reported)");
+                None
+            }
+        }
     }
 
     fn focus_window(&self, id: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
Terminal detection matches a fixed list, which cannot cover an st build with a custom termname, or the scratchpad and dropdown classes people give their terminals (Alacritty-float, kitty-dropdown, wezterm-quake). The substring matcher used to catch those incidentally; the exact matcher from #94 does not.

Adds `[input] terminal_classes`, empty by default, checked alongside the built-in list. Detection becomes three stages: built-in whole identifier, then user entries, then the built-in dot-segment leaf lookup.

User entries are matched case-insensitively and trimmed, but whole-identifier only, never through the leaf stage and never as a substring. That is the point of the design. Leaf-matching a one-word entry would turn it into a namespace wildcard, so listing `warp` would also match `app.drey.Warp`, which is GNOME's Magic Wormhole client, and sending Ctrl+A then Ctrl+K there empties a text field. Whole-identifier matching means an entry promotes exactly the one class the user read off their compositor and nothing else. Users can still name a class the built-in list deliberately excludes, since opting in explicitly is exactly the escape hatch this adds, and it stays scoped to that single class.

The matcher is otherwise untouched, so an empty list behaves identically to today. That is what the existing #94 test suite now proves, since every pre-existing case runs through the new signature with an empty list.

`is_terminal_class` now logs the class under test, the verdict, and which stage matched, and the Hyprland and Niri class lookups log too, so a non-matching entry can be diagnosed under RUST_LOG=debug rather than guessed at. The docs cover that, the required restart, and one fact users need up front: the key has no effect on KDE, GNOME, Sway or X11, because only Hyprland and Niri implement window-class detection (#71).

Considered and rejected, per the issue: moving detection into WindowTracker as `is_focused_terminal()`. A defaulted trait method is how `get_focused_window_class()` ended up silently returning None on four compositors.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)