### PR TITLE
feat(config): add [general] llm_post_process for the toggle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,41 @@ bindsym F2 exec whisrs toggle -l pl
 Without `-l`, `whisrs toggle` keeps using `general.language`, so an existing
 plain-toggle key is unaffected.
 
+### LLM post-processing
+
+Three ways to put an LLM between your voice and the cursor, all sharing the one
+`[llm]` section:
+
+- `whisrs command`: select text, speak an instruction, the selection is rewritten in place.
+- `[[llm_commands]]`: a named instruction on its own hotkey. Dictate, the LLM applies it, the result is typed. One hotkey per entry.
+- `[general] llm_post_process`: the same rewrite on the normal toggle key, with no extra binding.
+
+```toml
+[general]
+backend = "groq"           # a batch backend
+llm_post_process = true    # off by default
+llm_instruction = "Fix punctuation and obvious transcription errors. Keep the wording unchanged. Return only the corrected text."
+```
+
+With it on, every `whisrs toggle` dictation goes through `[llm]` before it is
+typed.
+
+**Batch backends only:** `deepgram`, `groq`, `openai`, `asr-sidecar`. The
+streaming backends, which are `deepgram-streaming`, `openai-realtime`,
+`openai-compatible-realtime` **and `local-whisper`**, type text at the cursor as
+it arrives, so no whole transcript ever exists to post-process and the flag does
+nothing at all. `local-whisper` is the one to watch: it runs offline and
+transcribes in a single call, but dictation with it always streams, so
+`llm_post_process` is a silent no-op there too. `whisrsd` warns at startup if you
+pair the two. Use an `[[llm_commands]]` hotkey instead, which works whatever the
+backend.
+
+If the LLM call fails, times out, or returns nothing, the raw transcript is typed
+instead, so a dictation is never lost to post-processing. A post-processed entry
+shows up in `whisrs log` tagged `<backend>+llm` (for example `groq+llm`); a
+dictation that fell back to the raw transcript keeps the plain backend name. See
+[docs/configuration.md](docs/configuration.md).
+
 ---
 
 ## Supported Environments

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,33 @@ prompt = "Speech is in English or Spanish. Transcribe in the language spoken; ne
 tray = true                 # system tray icon (requires SNI host like waybar)
 overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 
+# Run every dictation through the [llm] backend before it is typed.
+# Default: false. This is the always-on flavor of [[llm_commands]] below:
+# same rewrite, but on the normal `whisrs toggle` key instead of a dedicated
+# hotkey per entry. Needs an [llm] section (or WHISRS_OPENAI_API_KEY /
+# WHISRS_GROQ_API_KEY).
+#
+# Batch backends only: deepgram, groq, openai, asr-sidecar. The streaming
+# backends, which are deepgram-streaming, openai-realtime,
+# openai-compatible-realtime AND local-whisper, type text as it arrives, so
+# there is never a whole transcript to post-process and the flag does nothing
+# at all. local-whisper is the one to watch: it runs offline and transcribes
+# in a single call, but dictation with it always streams, so llm_post_process
+# is a silent no-op there too. `whisrsd` warns at startup if you pair the two.
+# Use an [[llm_commands]] hotkey instead, which works whatever the backend.
+#
+# If the LLM call fails, times out (30s), or returns nothing, the raw
+# transcript is typed instead, so a dictation is never lost to post-processing.
+# A post-processed dictation is logged as <backend>+llm (e.g. "groq+llm") in
+# `whisrs log`; one that fell back to the raw transcript keeps the plain
+# backend name.
+llm_post_process = false
+# Instruction applied to the transcript when llm_post_process is on. This is
+# NOT `prompt` above: that one is a hint for the transcription backend and
+# never reaches the LLM. Defaults to the conservative cleanup pass below, so
+# `llm_post_process = true` alone already does something sensible.
+llm_instruction = "Fix punctuation, capitalization and obvious transcription errors in the following text. Keep the wording and the meaning unchanged. Return only the corrected text, with no explanations and no quotes."
+
 # Optional — controls overlay appearance when enabled.
 # Defaults to a 100×40 pill with the "carbon" theme.
 # When the overlay is on, recording/transcribing toast notifications are
@@ -169,7 +196,8 @@ url = "http://127.0.0.1:8765/transcribe"
 model = "microsoft/VibeVoice-ASR-HF"
 
 # Command mode: LLM for voice-driven text rewriting.
-# Also used by [[llm_commands]] (see below). Any OpenAI-compatible
+# Also used by [[llm_commands]] (see below) and by
+# [general] llm_post_process. Any OpenAI-compatible
 # /chat/completions endpoint works here, including a local server:
 #   [llm]
 #   api_key = "not-needed"   # local servers don't validate this
@@ -186,6 +214,8 @@ api_url = "https://api.openai.com/v1/chat/completions"
 # there's no text selection involved. Uses the [llm] config above.
 # Optional; can also be triggered via `whisrs llm-command <name>` for
 # compositor keybind integration (same pattern as `whisrs toggle`).
+# For one instruction applied to every dictation with no extra hotkey, use
+# [general] llm_post_process instead.
 #
 # set_hotkey (optional): reprogram this command by selection. Highlight the new
 # instruction text anywhere, press set_hotkey, and it becomes the command's

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -152,6 +152,9 @@ pub fn run_setup() -> Result<()> {
             prompt: None,
             tray: true,
             overlay,
+            // Onboarding stays minimal: LLM post-processing of dictation is
+            // opt-in and edited by hand (see docs/configuration.md).
+            ..GeneralConfig::default()
         },
         audio: AudioConfig {
             device: "default".to_string(),

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -203,6 +203,28 @@ pub struct GeneralConfig {
     /// Enable bottom-screen recording overlay.
     #[serde(default)]
     pub overlay: bool,
+    /// Run every finished dictation through the shared `[llm]` backend, using
+    /// [`Self::llm_instruction`], before the text is injected. Off by default,
+    /// so existing setups keep typing the raw transcript.
+    ///
+    /// Unlike `[[llm_commands]]` — which does the same rewrite but needs a
+    /// dedicated hotkey per entry — this is simply on for `whisrs toggle`
+    /// (issue #85). Batch path only, and that is not an oversight: streaming
+    /// backends type partials at the cursor as they arrive, so there is never
+    /// a whole transcript to hand the LLM. [`Config::validate`] warns when
+    /// this is paired with one of them.
+    #[serde(default)]
+    pub llm_post_process: bool,
+    /// Instruction applied to the transcript when [`Self::llm_post_process`]
+    /// is on — the LLM's "voice instruction", the same role an
+    /// `[[llm_commands]]` entry's `instruction` plays.
+    ///
+    /// Deliberately *not* [`Self::prompt`]: that one is a hint for the
+    /// *transcription* backend and never reaches the LLM. Defaults to a
+    /// conservative cleanup pass so flipping the flag alone does something
+    /// sensible; blank means "post-process nothing" (and is warned about).
+    #[serde(default = "default_llm_instruction")]
+    pub llm_instruction: String,
 }
 
 impl Default for GeneralConfig {
@@ -220,6 +242,8 @@ impl Default for GeneralConfig {
             prompt: None,
             tray: true,
             overlay: false,
+            llm_post_process: false,
+            llm_instruction: default_llm_instruction(),
         }
     }
 }
@@ -476,6 +500,15 @@ fn default_device() -> String {
 fn default_audio_feedback_volume() -> f32 {
     0.5
 }
+/// Default toggle-path post-processing instruction. Conservative on purpose:
+/// dictation is content, not a request, so the out-of-the-box behavior is a
+/// cleanup pass that must not reword anything.
+fn default_llm_instruction() -> String {
+    "Fix punctuation, capitalization and obvious transcription errors in the following text. \
+     Keep the wording and the meaning unchanged. Return only the corrected text, with no \
+     explanations and no quotes."
+        .to_string()
+}
 fn default_key_delay_ms() -> u64 {
     2
 }
@@ -727,7 +760,9 @@ impl Config {
                 return Err(WhisrsError::Config(format!(
                     "Unknown backend '{other}'. Valid options: deepgram, deepgram-streaming, \
                      groq, openai, openai-realtime, openai-compatible-realtime, \
-                     local-whisper, local-vosk, local-parakeet, asr-sidecar"
+                     local-whisper, asr-sidecar. (local-vosk and local-parakeet are also \
+                     accepted here but are not implemented yet — they fail at transcription \
+                     time, so do not pick one to get out of this error.)"
                 )));
             }
         }
@@ -746,6 +781,12 @@ impl Config {
         // transcribed the instruction: the instruction is never injected, and
         // the LLM result goes out in a single injection call through the same
         // wrapper the batch dictation path uses.
+        //
+        // The "switch to" list must stay limited to backends that actually
+        // transcribe: `local-vosk` and `local-parakeet` parse as valid config
+        // but their `transcribe()` bails with "not yet implemented", so
+        // recommending them would trade a no-op flag for broken dictation.
+        // Keep them out of every recommendation here until they are real.
         if self.input.paste
             && matches!(
                 backend,
@@ -763,10 +804,65 @@ impl Config {
                      openai-compatible-realtime, local-whisper) type text incrementally as it \
                      arrives and never use the paste path. Command mode output is injected in \
                      one shot, so it still uses paste where that mode is configured. Switch to \
-                     a non-streaming backend (deepgram, groq, openai, local-vosk, \
-                     local-parakeet, asr-sidecar) to use paste injection for dictation too."
+                     a non-streaming backend (deepgram, groq, openai, asr-sidecar) to use \
+                     paste injection for dictation too."
                 ),
             });
+        }
+
+        // Toggle-path LLM post-processing (issue #85). Same shape as the
+        // llm_commands block below — missing [llm] section, empty instruction,
+        // streaming backend — but the failure modes differ, so the wording
+        // does too.
+        if self.general.llm_post_process {
+            if self.llm.is_none() {
+                warnings.push(ConfigWarning {
+                    message: "[general] llm_post_process = true but no [llm] section — add \
+                              [llm] api_key (or set WHISRS_OPENAI_API_KEY / \
+                              WHISRS_GROQ_API_KEY) or every dictation will fall back to the \
+                              raw transcript"
+                        .to_string(),
+                });
+            }
+
+            if self.general.llm_instruction.trim().is_empty() {
+                warnings.push(ConfigWarning {
+                    message: "[general] llm_post_process = true but llm_instruction is empty \
+                              — there is nothing to apply, so dictation is typed unmodified"
+                        .to_string(),
+                });
+            }
+
+            // Same backend list as the `[input] paste` warning above — both
+            // the matched set and the recommended replacements, and for the
+            // same reasons (see the note there on the unimplemented stubs).
+            // With these, dictation never reaches the batch path, so there is
+            // never a whole transcript to post-process. local-whisper belongs
+            // here even though its `transcribe()` is a real batch path (which
+            // is why the llm_commands warning below excludes it) — dictation
+            // with it always streams. Unlike llm_commands there is no degraded
+            // mode: the flag does nothing at all.
+            if matches!(
+                backend,
+                "deepgram-streaming"
+                    | "openai-realtime"
+                    | "openai-compatible-realtime"
+                    | "local-whisper"
+                    | "local"
+            ) {
+                warnings.push(ConfigWarning {
+                    message: format!(
+                        "[general] llm_post_process = true does not apply to dictation with \
+                         backend = \"{backend}\": streaming backends (deepgram-streaming, \
+                         openai-realtime, openai-compatible-realtime, local-whisper) type text \
+                         incrementally as it arrives, so there is never a whole transcript to \
+                         post-process. Nothing runs — dictation is typed unmodified. Switch to \
+                         a non-streaming backend (deepgram, groq, openai, asr-sidecar) to \
+                         post-process dictation, or use an [[llm_commands]] hotkey, which \
+                         works whatever the backend."
+                    ),
+                });
+            }
         }
 
         if !self.llm_commands.is_empty() {
@@ -1363,6 +1459,21 @@ mod tests {
                 warning.message.contains("Command mode"),
                 "the warning must say command mode still pastes: {}",
                 warning.message
+            );
+            assert_no_stub_backend_advice(&warning.message);
+        }
+    }
+
+    /// `local-vosk` and `local-parakeet` parse as valid config but their
+    /// `transcribe()` bails with "not yet implemented", so a warning that
+    /// tells the user to switch to one trades a no-op setting for dictation
+    /// that does not work at all. No warning may recommend them.
+    fn assert_no_stub_backend_advice(message: &str) {
+        for stub in ["local-vosk", "local-parakeet"] {
+            assert!(
+                !message.contains(stub),
+                "{stub} is an unimplemented stub — recommending it breaks dictation \
+                 outright: {message}"
             );
         }
     }
@@ -2166,6 +2277,163 @@ mod tests {
                 warning.message
             );
         }
+    }
+
+    // ── Toggle-path LLM post-processing (issue #85) ─────────────────────
+
+    #[test]
+    fn general_llm_post_process_defaults_off_with_a_usable_instruction() {
+        // Configs written before the keys existed keep the old behavior.
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+            "#,
+        )
+        .unwrap();
+        assert!(!config.general.llm_post_process);
+        // The instruction still defaults to something usable, so turning the
+        // flag on alone is a working configuration.
+        assert!(config
+            .general
+            .llm_instruction
+            .contains("Return only the corrected text"));
+    }
+
+    #[test]
+    fn general_llm_post_process_parses_and_roundtrips() {
+        let config: Config = toml::from_str(
+            r#"
+            [general]
+            backend = "groq"
+            llm_post_process = true
+            llm_instruction = "Translate the following text into German. Return only the translation."
+            "#,
+        )
+        .unwrap();
+        assert!(config.general.llm_post_process);
+        assert_eq!(
+            config.general.llm_instruction,
+            "Translate the following text into German. Return only the translation."
+        );
+
+        // Round-trips back out and parses again identically.
+        let serialized = toml::to_string(&config).unwrap();
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        assert!(reparsed.general.llm_post_process);
+        assert_eq!(
+            reparsed.general.llm_instruction,
+            config.general.llm_instruction
+        );
+    }
+
+    #[test]
+    fn config_validate_warns_llm_post_process_with_streaming_backend() {
+        // local-whisper is in this list even though it is absent from the
+        // llm_commands one: its transcribe() is a real batch path, but
+        // dictation with it always streams, so the flag no-ops there too.
+        for backend in [
+            "deepgram-streaming",
+            "openai-realtime",
+            "openai-compatible-realtime",
+            "local-whisper",
+        ] {
+            let mut config = validatable_config(backend);
+            config.general.llm_post_process = true;
+
+            let warnings = config.validate().unwrap();
+            let warning = warnings
+                .iter()
+                .find(|w| {
+                    w.message
+                        .contains("[general] llm_post_process = true does not apply")
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "backend {backend} streams dictation, so there is no whole transcript \
+                         to post-process; expected a warning, got: {warnings:?}"
+                    )
+                });
+            assert!(
+                warning
+                    .message
+                    .contains(&format!("backend = \"{backend}\"")),
+                "the warning must name the backend: {}",
+                warning.message
+            );
+            assert!(
+                warning.message.contains("Nothing runs"),
+                "the warning must say the flag does nothing, not that it degrades: {}",
+                warning.message
+            );
+            assert!(
+                warning.message.contains("asr-sidecar"),
+                "the warning must name a backend the user can actually switch to: {}",
+                warning.message
+            );
+            assert_no_stub_backend_advice(&warning.message);
+        }
+    }
+
+    #[test]
+    fn config_validate_no_llm_post_process_warning_for_batch_backend() {
+        for backend in ["groq", "deepgram", "openai"] {
+            let mut config = validatable_config(backend);
+            config.general.llm_post_process = true;
+
+            let warnings = config.validate().unwrap();
+            assert!(
+                warnings.iter().all(|w| !w
+                    .message
+                    .contains("[general] llm_post_process = true does not apply")),
+                "backend {backend} goes through the batch path; no streaming warning expected: \
+                 {warnings:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn config_validate_quiet_when_llm_post_process_is_off() {
+        // The flag is what triggers the warning — a streaming backend on its
+        // own must stay quiet about post-processing.
+        let config = validatable_config("openai-realtime");
+        let warnings = config.validate().unwrap();
+        assert!(
+            warnings
+                .iter()
+                .all(|w| !w.message.contains("llm_post_process")),
+            "post-processing is off; no warning expected: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn config_validate_warns_llm_post_process_without_llm_section() {
+        let mut config = validatable_config("groq");
+        config.general.llm_post_process = true;
+        config.llm = None;
+
+        let warnings = config.validate().unwrap();
+        assert!(
+            warnings.iter().any(|w| w
+                .message
+                .contains("llm_post_process = true but no [llm] section")),
+            "expected a missing-[llm] warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn config_validate_warns_llm_post_process_with_empty_instruction() {
+        let mut config = validatable_config("groq");
+        config.general.llm_post_process = true;
+        config.general.llm_instruction = "   ".to_string();
+
+        let warnings = config.validate().unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.message.contains("llm_instruction is empty")),
+            "expected an empty-instruction warning, got: {warnings:?}"
+        );
     }
 
     #[test]

--- a/src/daemon/dictation.rs
+++ b/src/daemon/dictation.rs
@@ -12,8 +12,9 @@ use whisrs::{validate_language_override, Response, State};
 use crate::context::{DaemonContext, DaemonState};
 use crate::notify::{send_notification, truncate_preview};
 use crate::pipeline::{
-    build_transcription_config, format_no_microphone_error, process_recording_batch,
-    run_streaming_pipeline, save_history_entry, StreamingPipelineParams,
+    build_transcription_config, format_no_microphone_error, history_backend_tag,
+    process_recording_batch, run_streaming_pipeline, save_history_entry, DictationOutcome,
+    StreamingPipelineParams,
 };
 
 pub(crate) async fn handle_toggle(
@@ -222,7 +223,12 @@ pub(crate) async fn handle_toggle(
                             tokio::task::spawn_blocking(move || drop(cap));
                         }
                         match task.await {
-                            Ok(Ok(text)) => Ok(text),
+                            // Never post-processed: the streaming pipeline
+                            // types partials as they arrive, so there is no
+                            // whole transcript to hand the LLM.
+                            // `Config::validate` warns when `llm_post_process`
+                            // is paired with a streaming backend.
+                            Ok(Ok(text)) => Ok(DictationOutcome::raw(text)),
                             Ok(Err(e)) => Err(e),
                             Err(e) => Err(anyhow::anyhow!("streaming task panicked: {e}")),
                         }
@@ -251,12 +257,19 @@ pub(crate) async fn handle_toggle(
                                 let _ = level_tx.send(0.0);
                             }
                             match result {
-                                Ok(text) => {
-                                    info!("transcription complete: {} chars", text.len());
-                                    if !text.is_empty() {
+                                Ok(dictation) => {
+                                    info!("transcription complete: {} chars", dictation.text.len());
+                                    if !dictation.text.is_empty() {
+                                        // The tag records whether the words
+                                        // came from the backend or from the
+                                        // LLM that rewrote them, so `whisrs
+                                        // log` can tell the two apart.
                                         save_history_entry(
-                                            &text,
-                                            &context.config.general.backend,
+                                            &dictation.text,
+                                            &history_backend_tag(
+                                                &context.config.general.backend,
+                                                dictation.post_processed,
+                                            ),
                                             &session_language,
                                             duration_secs,
                                         );
@@ -267,7 +280,7 @@ pub(crate) async fn handle_toggle(
                                         );
                                     }
                                     if context.notify_state() {
-                                        let preview = truncate_preview(&text, 77);
+                                        let preview = truncate_preview(&dictation.text, 77);
                                         send_notification("whisrs", &format!("Done: {preview}"));
                                     }
                                     Response::Ok { state: new_state }
@@ -296,10 +309,10 @@ pub(crate) async fn handle_toggle(
                                 let _ = level_tx.send(0.0);
                             }
                             match &result {
-                                Ok(text) => {
+                                Ok(dictation) => {
                                     info!(
                                         "transcription complete (pipeline-finalized): {} chars",
-                                        text.len()
+                                        dictation.text.len()
                                     )
                                 }
                                 Err(e) => error!("transcription failed: {e:#}"),

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -12,6 +12,7 @@ use prompt_echo::is_prompt_echo;
 use whisrs::audio::capture::{AudioCaptureHandle, SAMPLE_RATE};
 use whisrs::audio::feedback;
 use whisrs::history::{self, HistoryEntry};
+use whisrs::llm;
 use whisrs::state::Action;
 use whisrs::transcription::{TranscriptionBackend, TranscriptionConfig};
 use whisrs::window::WindowTracker;
@@ -27,6 +28,13 @@ const TYPING_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Minimum recording duration accepted by the gate. Anything shorter is almost
 /// certainly an accidental hotkey tap.
 const AUDIO_GATE_MIN_MS: u64 = 300;
+
+/// Wall-clock budget for the toggle-path LLM post-processing call
+/// (`[general] llm_post_process`). `llm::rewrite_text` sets no client-side
+/// timeout, so without this a hung endpoint would strand the daemon in
+/// `Transcribing` and the dictation would never land. On expiry the raw
+/// transcript is injected instead.
+const LLM_POST_PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Everything [`run_streaming_pipeline`] needs, bundled so the single call
 /// site (`handle_toggle`'s Idle branch in `dictation.rs`) builds one value
@@ -670,6 +678,162 @@ pub(crate) async fn transcribe_batch_audio(
     Ok(text)
 }
 
+/// The instruction a finished transcript should be post-processed with, or
+/// `None` when the toggle path must inject it unmodified.
+///
+/// `None` covers both "`llm_post_process` is off" (the default) and "on but
+/// the instruction is blank" — an empty instruction buys a round trip and a
+/// non-deterministic rewrite for nothing. `Config::validate` warns about the
+/// second case at startup.
+fn llm_post_process_instruction(config: &Config) -> Option<&str> {
+    if !config.general.llm_post_process {
+        return None;
+    }
+    let instruction = config.general.llm_instruction.trim();
+    (!instruction.is_empty()).then_some(instruction)
+}
+
+/// What a finished dictation produced: the text that reached the cursor, and
+/// whether `[general] llm_post_process` is what produced it.
+///
+/// The flag is carried out of the pipeline purely so `whisrs log` can tell a
+/// post-processed dictation from a raw one (see [`history_backend_tag`]). It
+/// is `true` only when the LLM actually returned the words that were typed,
+/// never for a fallback: with the flag off, a blank instruction, an API error,
+/// a timeout or an empty completion, the entry holds the raw transcript and
+/// labelling it post-processed would be a lie.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DictationOutcome {
+    pub(crate) text: String,
+    pub(crate) post_processed: bool,
+}
+
+impl DictationOutcome {
+    /// Text that reached the cursor untouched by the LLM. Also what the
+    /// streaming path always produces: it types partials as they arrive and
+    /// never holds a whole transcript to post-process.
+    pub(crate) fn raw(text: String) -> Self {
+        Self {
+            text,
+            post_processed: false,
+        }
+    }
+}
+
+/// The history `backend` field for a finished dictation.
+///
+/// A raw dictation keeps the bare backend name, byte for byte what has always
+/// been recorded, so existing history semantics do not shift. A dictation the
+/// LLM rewrote gets a `+llm` suffix (`groq` becomes `groq+llm`), so `whisrs
+/// log` distinguishes the LLM's words from the microphone's.
+///
+/// The suffix mirrors the llm-command path's `llm:<name>` tag, which reads as
+/// "the LLM produced this". It is a suffix rather than that prefix for two
+/// reasons: the transcription backend still matters here (it produced the LLM's
+/// input, whereas command mode never logs it), and `llm:<backend>` would be
+/// indistinguishable from an `[[llm_commands]]` entry that happens to be named
+/// after a backend.
+pub(crate) fn history_backend_tag(backend: &str, post_processed: bool) -> String {
+    if post_processed {
+        format!("{backend}+llm")
+    } else {
+        backend.to_string()
+    }
+}
+
+/// Pick the text to inject after a post-processing attempt. `rewritten` is
+/// `None` when the call failed or timed out, and a blank completion counts the
+/// same: the original transcript wins in every one of those cases.
+///
+/// This is where the toggle path deliberately diverges from the llm-command
+/// path (`llm_command_background_inner`), which propagates the LLM error and
+/// injects nothing. There the user pressed a hotkey to run *that command*, so
+/// a failure means the command did not happen; here they pressed plain
+/// dictate, and losing a whole dictation to a flaky endpoint would be a
+/// regression against `llm_post_process = false`.
+/// The completion is trimmed before it is injected. A trailing newline typed at
+/// a shell prompt submits the line, and unlike the llm-command hotkey this runs
+/// on every dictation, so a chatty model would append one every time.
+fn post_processed_or_raw(original: String, rewritten: Option<String>) -> DictationOutcome {
+    match rewritten {
+        Some(text) if !text.trim().is_empty() => DictationOutcome {
+            text: text.trim().to_string(),
+            post_processed: true,
+        },
+        _ => DictationOutcome::raw(original),
+    }
+}
+
+/// Run a finished transcript through the shared `[llm]` backend when
+/// `[general] llm_post_process` is on, returning the text to inject.
+///
+/// Fails soft on every path — flag off, blank instruction, missing `[llm]`
+/// section, API error, timeout, empty completion — by returning `text`
+/// unchanged, so a post-processing problem never costs the user their words.
+/// Reuses `llm::rewrite_text` exactly as the llm-command path does, with the
+/// dictated text as the "selected text" and the configured instruction as the
+/// "voice instruction".
+async fn apply_llm_post_process(text: String, context: &DaemonContext) -> DictationOutcome {
+    let Some(instruction) = llm_post_process_instruction(&context.config) else {
+        return DictationOutcome::raw(text);
+    };
+
+    info!(
+        "llm post-processing: sending {} chars to the LLM",
+        text.len()
+    );
+    // Same resolution as command mode: an absent [llm] section falls back to
+    // the defaults, where an empty api_key sends `rewrite_text` to the
+    // WHISRS_OPENAI_API_KEY / WHISRS_GROQ_API_KEY env vars.
+    let llm_config = context.config.llm.clone().unwrap_or_default();
+
+    let rewritten = match tokio::time::timeout(
+        LLM_POST_PROCESS_TIMEOUT,
+        llm::rewrite_text(&llm_config, &text, instruction),
+    )
+    .await
+    {
+        Ok(Ok(rewritten)) => {
+            if rewritten.trim().is_empty() {
+                warn!("llm post-processing returned empty text — injecting the raw transcript");
+                if context.notify_error() {
+                    send_notification(
+                        "whisrs",
+                        "LLM post-processing returned nothing — typing the raw transcript",
+                    );
+                }
+            }
+            Some(rewritten)
+        }
+        Ok(Err(e)) => {
+            let friendly = format_api_error(&e);
+            error!("llm post-processing failed: {e:#}");
+            if context.notify_error() {
+                send_notification(
+                    "whisrs",
+                    &format!("LLM post-processing failed: {friendly}\nTyping the raw transcript"),
+                );
+            }
+            None
+        }
+        Err(_elapsed) => {
+            let secs = LLM_POST_PROCESS_TIMEOUT.as_secs();
+            error!("llm post-processing timed out after {secs}s");
+            if context.notify_error() {
+                send_notification(
+                    "whisrs",
+                    &format!(
+                        "LLM post-processing timed out after {secs}s\nTyping the raw transcript"
+                    ),
+                );
+            }
+            None
+        }
+    };
+
+    post_processed_or_raw(text, rewritten)
+}
+
 /// Batch mode: collect all audio, transcribe in one shot, type result.
 /// `language` is the resolved session language (per-toggle override or
 /// config default) captured when recording started.
@@ -678,7 +842,7 @@ pub(crate) async fn process_recording_batch(
     window_id: Option<&str>,
     context: &DaemonContext,
     language: &str,
-) -> Result<String> {
+) -> Result<DictationOutcome> {
     let samples = match capture {
         Some(cap) => cap.stop_and_collect().await?,
         None => anyhow::bail!("no audio capture to collect"),
@@ -695,8 +859,18 @@ pub(crate) async fn process_recording_batch(
 
     if text.is_empty() {
         // Gated, echo-dropped, or empty — the helper already said so.
-        return Ok(text);
+        return Ok(DictationOutcome::raw(text));
     }
+
+    // `[general] llm_post_process`: rewrite the finished transcript through
+    // the shared `[llm]` backend before it reaches the cursor (issue #85).
+    // Batch-only by design — the streaming pipeline types partials as they
+    // arrive and never holds a whole transcript, so this must NOT be wired
+    // into `run_streaming_pipeline`; the usual "wire it into both paths" rule
+    // is inverted here and `Config::validate` warns instead. The rewritten
+    // text is what this function returns, so history records what was actually
+    // typed, tagged by `history_backend_tag` with whether the LLM produced it.
+    let outcome = apply_llm_post_process(text, context).await;
 
     // Restore window focus.
     if let Some(wid) = window_id {
@@ -709,7 +883,7 @@ pub(crate) async fn process_recording_batch(
 
     // Inject the text at the cursor — type keystrokes, or paste via the
     // clipboard when `[input] paste = true` (layout-independent).
-    let text_clone = text.clone();
+    let text_clone = outcome.text.clone();
     let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
     let injector_backend = context.config.input.backend;
     let paste = context.config.input.paste;
@@ -732,7 +906,7 @@ pub(crate) async fn process_recording_batch(
         Err(e) => warn!("failed to join injection task: {e}"),
     }
 
-    Ok(text)
+    Ok(outcome)
 }
 
 pub(crate) fn format_no_microphone_error() -> String {
@@ -1230,5 +1404,151 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    // ── Toggle-path LLM post-processing (issue #85) ─────────────────────
+
+    /// Parse a config from TOML, with a `[general] backend` already set so
+    /// only the keys under test have to be spelled out.
+    fn config_from(general_extra: &str) -> Config {
+        toml::from_str(&format!("[general]\nbackend = \"groq\"\n{general_extra}\n"))
+            .expect("test config parses")
+    }
+
+    /// The flag is opt-in: an untouched config never post-processes, whatever
+    /// the (defaulted) instruction says.
+    #[test]
+    fn llm_post_process_off_by_default() {
+        let config = config_from("");
+        assert!(!config.general.llm_post_process);
+        assert!(llm_post_process_instruction(&config).is_none());
+    }
+
+    /// Flag on: the trimmed instruction is what gets sent to the LLM.
+    #[test]
+    fn llm_post_process_instruction_is_trimmed() {
+        let config =
+            config_from("llm_post_process = true\nllm_instruction = \"  Translate to German.  \"");
+        assert_eq!(
+            llm_post_process_instruction(&config),
+            Some("Translate to German.")
+        );
+    }
+
+    /// Flag on with the key omitted still has something to apply — the built
+    /// in cleanup instruction — so the flag alone is a working configuration.
+    #[test]
+    fn llm_post_process_uses_default_instruction_when_key_omitted() {
+        let config = config_from("llm_post_process = true");
+        let instruction = llm_post_process_instruction(&config).expect("default instruction");
+        assert!(
+            instruction.contains("Return only the corrected text"),
+            "unexpected default instruction: {instruction}"
+        );
+    }
+
+    /// A blank instruction disables post-processing rather than sending an
+    /// empty instruction to the LLM.
+    #[test]
+    fn llm_post_process_blank_instruction_skips() {
+        let config = config_from("llm_post_process = true\nllm_instruction = \"   \"");
+        assert!(llm_post_process_instruction(&config).is_none());
+    }
+
+    /// The failure contract: only a non-blank completion may replace the
+    /// transcript. Errors, timeouts (both `None`) and blank completions all
+    /// keep the user's words — the toggle path never loses a dictation to a
+    /// post-processing problem.
+    ///
+    /// The `post_processed` flag tracks the same split, because it is what
+    /// `whisrs log` is tagged from: a fallback holds the raw transcript, so it
+    /// must not be labelled as the LLM's work.
+    #[test]
+    fn post_processed_or_raw_falls_back_to_the_transcript() {
+        let raw = || "hello world".to_string();
+        let cases = [
+            (
+                "rewrite wins",
+                Some("Hello, world.".to_string()),
+                "Hello, world.",
+                true,
+            ),
+            ("llm error or timeout", None, "hello world", false),
+            (
+                "empty completion",
+                Some(String::new()),
+                "hello world",
+                false,
+            ),
+            (
+                "whitespace-only completion",
+                Some("  \n ".to_string()),
+                "hello world",
+                false,
+            ),
+            (
+                "trailing newline is trimmed, it would submit the line in a terminal",
+                Some("Hello, world.\n".to_string()),
+                "Hello, world.",
+                true,
+            ),
+            (
+                "surrounding whitespace is trimmed",
+                Some("\n  Hello, world.  \n\n".to_string()),
+                "Hello, world.",
+                true,
+            ),
+        ];
+        for (name, rewritten, expected, post_processed) in cases {
+            let outcome = post_processed_or_raw(raw(), rewritten);
+            assert_eq!(outcome.text, expected, "{name}");
+            assert_eq!(
+                outcome.post_processed, post_processed,
+                "{name}: post_processed must be true only when the LLM produced the text \
+                 that was typed"
+            );
+        }
+    }
+
+    /// A dictation that was not post-processed keeps the bare backend name it
+    /// has always been logged under, byte for byte. Anything else would shift
+    /// the meaning of every pre-existing history entry.
+    #[test]
+    fn history_backend_tag_is_unchanged_for_raw_dictation() {
+        for backend in ["groq", "deepgram", "openai", "local-whisper", "asr-sidecar"] {
+            assert_eq!(history_backend_tag(backend, false), backend);
+        }
+    }
+
+    /// A post-processed dictation is tagged `<backend>+llm`, so `whisrs log`
+    /// shows which entries hold the LLM's words rather than the microphone's.
+    #[test]
+    fn history_backend_tag_marks_post_processed_dictation() {
+        assert_eq!(history_backend_tag("groq", true), "groq+llm");
+        assert_eq!(history_backend_tag("deepgram", true), "deepgram+llm");
+    }
+
+    /// The tag must not collide with the llm-command path's `llm:<name>`
+    /// entries (`command_mode.rs`), which name a configured command rather
+    /// than a transcription backend. Keeping the backend in front and the
+    /// marker behind means neither form can be mistaken for the other, even
+    /// when an `[[llm_commands]]` entry is named after a backend.
+    #[test]
+    fn history_backend_tag_does_not_collide_with_llm_command_tags() {
+        let post_processed = history_backend_tag("groq", true);
+        assert!(!post_processed.starts_with("llm:"));
+        assert_ne!(post_processed, "llm:groq");
+    }
+
+    /// The streaming path can only ever produce raw dictation, so its
+    /// constructor must never claim otherwise.
+    #[test]
+    fn dictation_outcome_raw_is_not_post_processed() {
+        let outcome = DictationOutcome::raw("hello".to_string());
+        assert!(!outcome.post_processed);
+        assert_eq!(
+            history_backend_tag("openai-realtime", outcome.post_processed),
+            "openai-realtime"
+        );
     }
 }


### PR DESCRIPTION
#60 shipped LLM post-processing as named [[llm_commands]], each with its own hotkey, so post-processing is something you invoke rather than something that is simply on. The workaround was to bind the dictation key to `whisrs llm-command <name>`, which then costs a second binding for plain dictation and tags every history entry with the command name.

Adds `[general] llm_post_process`, off by default, with `[general] llm_instruction` defaulting to a punctuation and capitalization cleanup so the flag alone is a working configuration. It reuses the existing `[llm]` backend rather than adding a section.

Batch path only, as the issue specifies: the streaming pipeline types partials at the cursor as they arrive, so there is never a whole transcript to post-process. The CLAUDE.md rule about wiring features into both transcription paths is deliberately inverted here, and there are comments at the call site and on the config field saying so. Config validation warns instead, and that warning covers `local-whisper` too, which is the surprising case: it reports as a streaming backend, so dictation with it never reaches the batch path and the flag would otherwise no-op in silence.

Failure is soft. An API error, a timeout, or a blank completion all fall back to injecting the raw transcript, because losing a whole dictation to a flaky endpoint would be a regression against having the flag off. A 30 second timeout wraps the call, since `rewrite_text` sets no client timeout and a hung endpoint would otherwise strand the daemon in Transcribing. The completion is trimmed before injection: a trailing newline typed at a shell prompt submits the line, and unlike an opt-in hotkey this runs on every dictation.

History distinguishes the two: post-processed entries are tagged `<backend>+llm`, and only when the LLM actually produced the typed words, so a fallback is never mislabeled.

Also removes advice to switch to `local-vosk` or `local-parakeet` from every warning and doc, including the pre-existing `[input] paste` warning this one was modeled on. Both backends parse but bail with "not yet implemented", so following that advice broke dictation entirely. A shared test helper now asserts no warning recommends them.

Tested on Hyprland across all three paths: streaming backend warns and no-ops, batch backend returns clean punctuated text tagged `deepgram+llm`, and with the endpoint broken the raw transcript is still typed and tagged plain.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)