### PR TITLE
feat: recording-lifecycle hooks and MPRIS media auto-pause

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - name: full (default features)
             features: ""
           - name: minimal (no local-whisper)
-            features: "--no-default-features --features tray,overlay"
+            features: "--no-default-features --features tray,overlay,hooks"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           - name: Linux x86_64 (no local-whisper)
             runner: ubuntu-latest
             artifact: whisrs-linux-x86_64-minimal
-            features: "--no-default-features --features tray,overlay"
+            features: "--no-default-features --features tray,overlay,hooks"
           - name: Linux aarch64
             runner: ubuntu-24.04-arm
             artifact: whisrs-linux-aarch64
@@ -33,7 +33,7 @@ jobs:
           - name: Linux aarch64 (no local-whisper)
             runner: ubuntu-24.04-arm
             artifact: whisrs-linux-aarch64-minimal
-            features: "--no-default-features --features tray,overlay"
+            features: "--no-default-features --features tray,overlay,hooks"
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,13 +156,17 @@ docs" in an untracked file changes nothing for users and shows up in no PR. Chec
 
 ## Feature Flags
 
-- `default = ["local-whisper", "tray", "overlay"]`
+- `default = ["local-whisper", "tray", "overlay", "hooks"]`
 - `local-whisper` — whisper-rs (whisper.cpp) for offline transcription. Requires a C++ toolchain and libclang.
 - `tray` — tray icon via `ksni`
 - `overlay` — recording overlay via `smithay-client-toolkit` + `wayland-client` + `tiny-skia`
+- `hooks` — recording-lifecycle hooks + MPRIS media pause via `zbus` (no new system dep; `overlay` already pulls `zbus`)
 
-The **minimal** release build is `--no-default-features --features tray,overlay`: it
-drops only whisper.cpp. Keep `tray` and `overlay` in it (that omission was issue #51).
+The **minimal** release build is `--no-default-features --features tray,overlay,hooks`:
+it drops only whisper.cpp. Keep `tray`, `overlay` and `hooks` in it (that omission was
+issue #51). A feature left out of that list is silently ignored at runtime rather than
+diagnosed: `Config` is not feature-gated, so the key still parses as known and the
+unknown-key warning stays quiet.
 
 ## Coding Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ sudo dnf install gcc-c++ alsa-lib-devel libxkbcommon-devel pkg-config clang-deve
 default feature. To skip that toolchain, build without it:
 
 ```bash
-cargo build --no-default-features --features tray,overlay
+cargo build --no-default-features --features tray,overlay,hooks
 ```
 
 ### Build and test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,11 @@ name = "issue55_stream_check"
 required-features = ["local-whisper"]
 
 [features]
-default = ["local-whisper", "tray", "overlay"]
+default = ["local-whisper", "tray", "overlay", "hooks"]
 local-whisper = ["dep:whisper-rs"]
 tray = ["dep:ksni"]
-overlay = ["dep:smithay-client-toolkit", "dep:wayland-client", "dep:tiny-skia"]
+overlay = ["dep:smithay-client-toolkit", "dep:wayland-client", "dep:tiny-skia", "dep:zbus"]
+hooks = ["dep:zbus"]
 
 [dependencies]
 anyhow = "1"
@@ -77,7 +78,7 @@ toml_edit = "0.22"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 x11rb = { version = "0.13", features = ["randr", "shape"] }
-zbus = "5"
+zbus = { version = "5", optional = true }
 
 [dependencies.ksni]
 version = "0.3"

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ api_key = "gsk_..."
 
 Env-var overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, `WHISRS_OPENAI_API_KEY`.
 
-For the full reference (overlay, `[input]`, `[openai-compatible-realtime]`, `[asr-sidecar]`, `[llm]`, `[hotkeys]`, GNOME extension setup), see [docs/configuration.md](docs/configuration.md).
+For the full reference (overlay, `[input]`, `[openai-compatible-realtime]`, `[asr-sidecar]`, `[llm]`, `[hotkeys]`, `[hooks]`, GNOME extension setup), see [docs/configuration.md](docs/configuration.md).
 
 ---
 

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -143,7 +143,7 @@ Defaults to
 .I ~/.config/whisrs/config.toml
 Main configuration file. Created by
 .BR "whisrs setup" .
-Contains backend selection, API keys, language, and audio settings.
+Contains backend selection, API keys, language, audio settings, and hooks.
 Permissions should be 0600 since it may contain API keys.
 .TP
 .I $XDG_RUNTIME_DIR/whisrs.sock

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -280,6 +280,17 @@ when recording starts, and resumes exactly those when it stops. A tab you paused
 yourself stays paused. If a player's bus name changes mid-session (a browser
 switching media sessions) its resume is skipped rather than guessed at.
 
+To see what a hook printed, filter the journal by identifier, not by unit:
+
+```fish
+journalctl --user -t whisrsd -f
+```
+
+`journalctl --user -u whisrs` will usually **not** show it. Hook output comes from
+the short-lived `sh` child, and journald resolves the owning unit from the sender's
+PID — by the time it looks, a command like `echo hi` has already exited, so the
+line lands in the journal without the unit attached and the `-u` filter drops it.
+
 ### Generate text with no selection
 
 `whisrs command` **rewrites a selection**: highlight some text, press the key,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,6 +233,14 @@ toggle = "Super+Shift+W"
 cancel = "Super+Shift+D"
 command = "Super+Shift+G"
 speak = "Super+Shift+R"
+
+# Recording-lifecycle hooks: pause MPRIS playback while dictating, run shell
+# commands fire-and-forget on record start/stop.  The child inherits the
+# daemon's environment and stdout/stderr (journal under systemd --user).
+[hooks]
+media_auto_pause = true        # pause all MPRIS players while recording
+# on_record_start = ""         # shell command on recording start
+# on_record_stop = ""          # shell command on recording stop
 ```
 
 ## Environment variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,14 +266,19 @@ cancel = "Super+Shift+D"
 command = "Super+Shift+G"
 speak = "Super+Shift+R"
 
-# Recording-lifecycle hooks: pause MPRIS playback while dictating, run shell
-# commands fire-and-forget on record start/stop.  The child inherits the
+# Recording-lifecycle hooks: pause playing MPRIS media while dictating, run
+# shell commands fire-and-forget on record start/stop.  The child inherits the
 # daemon's environment and stdout/stderr (journal under systemd --user).
 [hooks]
-media_auto_pause = true        # pause all MPRIS players while recording
+media_auto_pause = true        # pause MPRIS players that are playing, resume those on stop
 # on_record_start = ""         # shell command on recording start
 # on_record_stop = ""          # shell command on recording stop
 ```
+
+`media_auto_pause` only touches players that report `PlaybackStatus = "Playing"`
+when recording starts, and resumes exactly those when it stops. A tab you paused
+yourself stays paused. If a player's bus name changes mid-session (a browser
+switching media sessions) its resume is skipped rather than guessed at.
 
 ### Generate text with no selection
 

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -54,6 +54,7 @@ pub fn run_config_menu() -> Result<()> {
             "Keyboard injection (key delay)",
             "Hotkeys",
             "Tray & overlay",
+            "Recording hooks",
             "Command mode (LLM)",
             "Custom LLM commands",
             "Show full config (masked)",
@@ -80,10 +81,11 @@ pub fn run_config_menu() -> Result<()> {
             6 => edit_key_delay(&mut config)?,
             7 => edit_hotkeys(&mut config)?,
             8 => edit_tray_overlay(&mut config)?,
-            9 => edit_llm(&mut config)?,
-            10 => edit_llm_commands(&mut config)?,
-            11 => show_config(&config),
-            12 => {
+            9 => edit_media_hooks(&mut config)?,
+            10 => edit_llm(&mut config)?,
+            11 => edit_llm_commands(&mut config)?,
+            12 => show_config(&config),
+            13 => {
                 if open_in_editor(&mut config)? {
                     // External edit already wrote the file; reload and skip the
                     // normal save path so we don't clobber formatting/comments
@@ -91,17 +93,17 @@ pub fn run_config_menu() -> Result<()> {
                     println!("  {GREEN}Applied edits from $EDITOR.{RESET}");
                 }
             }
-            13 => {
+            14 => {
                 // separator — no-op
             }
-            14 => {
+            15 => {
                 if save_and_restart(&config, fresh)? {
                     return Ok(());
                 }
                 // Validation failed — fall through to next loop iteration,
                 // preserving the in-memory `config` so the user can fix it.
             }
-            15 => {
+            16 => {
                 println!("\n  {DIM}Discarded changes.{RESET}");
                 return Ok(());
             }
@@ -127,6 +129,7 @@ fn default_config() -> Config {
         llm: None,
         tts: None,
         hotkeys: None,
+        hooks: None,
         overlay: None,
         llm_commands: Vec::new(),
     }
@@ -423,10 +426,12 @@ fn edit_hotkeys(config: &mut Config) -> Result<()> {
 }
 
 fn prompt_optional_string(label: &str, current: &Option<String>) -> Result<Option<String>> {
-    let default = current.clone().unwrap_or_default();
+    let prompt = match current {
+        Some(v) => format!("{label} [{v}] (leave blank to unset)"),
+        None => format!("{label} (leave blank to skip)"),
+    };
     let input: String = Input::new()
-        .with_prompt(format!("{label} (leave blank to unset)"))
-        .default(default)
+        .with_prompt(prompt)
         .allow_empty(true)
         .interact_text()
         .with_context(|| format!("failed to read {label}"))?;
@@ -435,6 +440,33 @@ fn prompt_optional_string(label: &str, current: &Option<String>) -> Result<Optio
     } else {
         Some(input)
     })
+}
+
+fn edit_media_hooks(config: &mut Config) -> Result<()> {
+    println!("\n  {BOLD}Recording hooks{RESET}");
+    println!(
+        "  {DIM}Pause MPRIS playback (browsers, Spotify, VLC, MPV, KDE Connect)\n   \
+         while dictating.{RESET}"
+    );
+
+    let mut hooks = config.hooks.clone().unwrap_or_default();
+
+    hooks.media_auto_pause = Confirm::new()
+        .with_prompt("Pause MPRIS media while recording?")
+        .default(hooks.media_auto_pause)
+        .interact()
+        .unwrap_or(hooks.media_auto_pause);
+
+    hooks.on_record_start =
+        prompt_optional_string("Shell command on record start", &hooks.on_record_start)?;
+    hooks.on_record_stop =
+        prompt_optional_string("Shell command on record stop", &hooks.on_record_stop)?;
+
+    // Drop the whole section if nothing is configured — keeps the TOML clean.
+    let any_set =
+        hooks.media_auto_pause || hooks.on_record_start.is_some() || hooks.on_record_stop.is_some();
+    config.hooks = if any_set { Some(hooks) } else { None };
+    Ok(())
 }
 
 fn edit_tray_overlay(config: &mut Config) -> Result<()> {

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -470,14 +470,15 @@ fn prompt_optional_string(label: &str, current: &Option<String>) -> Result<Optio
 fn edit_media_hooks(config: &mut Config) -> Result<()> {
     println!("\n  {BOLD}Recording hooks{RESET}");
     println!(
-        "  {DIM}Pause MPRIS playback (browsers, Spotify, VLC, MPV, KDE Connect)\n   \
-         while dictating.{RESET}"
+        "  {DIM}Pause MPRIS media that is playing (browsers, Spotify, VLC, MPV,\n   \
+         KDE Connect) while dictating, and resume exactly those afterwards.\n   \
+         Media you paused yourself is left alone.{RESET}"
     );
 
     let mut hooks = config.hooks.clone().unwrap_or_default();
 
     hooks.media_auto_pause = Confirm::new()
-        .with_prompt("Pause MPRIS media while recording?")
+        .with_prompt("Pause playing MPRIS media while recording?")
         .default(hooks.media_auto_pause)
         .interact()
         .unwrap_or(hooks.media_auto_pause);

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -171,6 +171,7 @@ pub fn run_setup() -> Result<()> {
         llm: llm_config,
         tts: None,
         hotkeys: None,
+        hooks: None,
         overlay: if overlay { overlay_config } else { None },
         llm_commands: Vec::new(),
     };
@@ -804,7 +805,7 @@ fn write_config_to(config: &Config, config_path: &Path) -> Result<()> {
     // their values are; the on-disk document is the source of truth for
     // comments, ordering, and formatting.
     let fresh_str = toml::to_string_pretty(config).context("failed to serialize config to TOML")?;
-    let output = match fs::read_to_string(config_path) {
+    let mut output = match fs::read_to_string(config_path) {
         Ok(existing_str) => match existing_str.parse::<DocumentMut>() {
             Ok(mut existing) => {
                 let fresh: DocumentMut = fresh_str
@@ -859,6 +860,18 @@ fn write_config_to(config: &Config, config_path: &Path) -> Result<()> {
             });
         }
     };
+
+    // Appended as a trailing comment: `merge_table` only touches keys, so
+    // unrecognized trailing text survives the round-trip.  Only shown when the
+    // user hasn't configured hooks yet.
+    if config.hooks.is_none() {
+        output.push_str(
+            "\n# [hooks]\n\
+             # media_auto_pause = true   # pause MPRIS playback while dictating\n\
+             # on_record_start = \"\"     # shell command on recording start\n\
+             # on_record_stop = \"\"      # shell command on recording stop\n",
+        );
+    }
 
     atomic_write(config_path, &output)
         .with_context(|| format!("failed to write config to {}", config_path.display()))

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -863,14 +863,14 @@ fn write_config_to(config: &Config, config_path: &Path) -> Result<()> {
 
     // Appended as a trailing comment: `merge_table` only touches keys, so
     // unrecognized trailing text survives the round-trip.  Only shown when the
-    // user hasn't configured hooks yet.
-    if config.hooks.is_none() {
-        output.push_str(
-            "\n# [hooks]\n\
+    // user hasn't configured hooks yet, and only if the hint isn't already
+    // present (idempotent: writing twice must produce the same bytes).
+    const HOOKS_HINT: &str = "\n# [hooks]\n\
              # media_auto_pause = true   # pause MPRIS playback while dictating\n\
              # on_record_start = \"\"     # shell command on recording start\n\
-             # on_record_stop = \"\"      # shell command on recording stop\n",
-        );
+             # on_record_stop = \"\"      # shell command on recording stop\n";
+    if config.hooks.is_none() && !output.contains(HOOKS_HINT) {
+        output.push_str(HOOKS_HINT);
     }
 
     atomic_write(config_path, &output)

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -869,7 +869,7 @@ fn write_config_to(config: &Config, config_path: &Path) -> Result<()> {
     // user hasn't configured hooks yet, and only if the hint isn't already
     // present (idempotent: writing twice must produce the same bytes).
     const HOOKS_HINT: &str = "\n# [hooks]\n\
-             # media_auto_pause = true   # pause MPRIS playback while dictating\n\
+             # media_auto_pause = true   # pause playing MPRIS media while dictating, resume it after\n\
              # on_record_start = \"\"     # shell command on recording start\n\
              # on_record_stop = \"\"      # shell command on recording stop\n";
     if config.hooks.is_none() && !output.contains(HOOKS_HINT) {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -72,14 +72,16 @@ pub struct HotkeyConfig {
     pub speak: Option<String>,
 }
 
-/// Recording-lifecycle hooks. `media_auto_pause` pauses all MPRIS players
-/// while recording and resumes them on stop (no external tools).
-/// `on_record_start`/`on_record_stop` run shell commands fire-and-forget
-/// when a recording session begins/ends.  The child inherits the daemon's
-/// environment and stdout/stderr (goes to the journal under systemd --user).
+/// Recording-lifecycle hooks. `media_auto_pause` pauses the MPRIS players
+/// that are currently playing and resumes exactly those on stop (no external
+/// tools). `on_record_start`/`on_record_stop` run shell commands
+/// fire-and-forget when a recording session begins/ends.  The child inherits
+/// the daemon's environment and stdout/stderr (goes to the journal under
+/// systemd --user).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct HooksConfig {
-    /// Pause all MPRIS players while recording; resume exactly those on stop.
+    /// Pause the MPRIS players that are playing when recording starts; resume
+    /// exactly those on stop. Media the user paused themselves is left alone.
     #[serde(default)]
     pub media_auto_pause: bool,
     /// Shell command run when recording starts.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -92,7 +92,7 @@ pub struct HooksConfig {
 
 /// Visual configuration for the bottom recording overlay.
 ///
-/// The shape is intentionally clamped tight (90–120 × 28–40) to keep the
+/// The shape is intentionally clamped tight (90–120 × 36–48) to keep the
 /// gaussian-tapered bar layout legible. Themes pick the colors; if `colors`
 /// is set, those override the theme.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,7 +104,7 @@ pub struct OverlayConfig {
     /// Pill width in pixels (clamped to 90..=120).
     #[serde(default = "default_overlay_width")]
     pub width: u32,
-    /// Pill height in pixels (clamped to 28..=40).
+    /// Pill height in pixels (clamped to 36..=48).
     #[serde(default = "default_overlay_height")]
     pub height: u32,
     /// Custom color overrides; honored when `theme = "custom"`.
@@ -1987,6 +1987,7 @@ mod tests {
             }),
             llm: Some(llm::LlmConfig::default()),
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -46,6 +46,9 @@ pub struct Config {
     /// Global hotkey configuration.
     #[serde(default)]
     pub hotkeys: Option<HotkeyConfig>,
+    /// Recording-lifecycle hooks: media pause + shell commands on record start/stop.
+    #[serde(default)]
+    pub hooks: Option<HooksConfig>,
     /// Overlay appearance config (theme, dimensions, optional custom colors).
     #[serde(default)]
     pub overlay: Option<OverlayConfig>,
@@ -67,6 +70,24 @@ pub struct HotkeyConfig {
     /// Hotkey to read the selected text aloud (e.g. "Super+Shift+R").
     #[serde(alias = "read")]
     pub speak: Option<String>,
+}
+
+/// Recording-lifecycle hooks. `media_auto_pause` pauses all MPRIS players
+/// while recording and resumes them on stop (no external tools).
+/// `on_record_start`/`on_record_stop` run shell commands fire-and-forget
+/// when a recording session begins/ends.  The child inherits the daemon's
+/// environment and stdout/stderr (goes to the journal under systemd --user).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HooksConfig {
+    /// Pause all MPRIS players while recording; resume exactly those on stop.
+    #[serde(default)]
+    pub media_auto_pause: bool,
+    /// Shell command run when recording starts.
+    #[serde(default)]
+    pub on_record_start: Option<String>,
+    /// Shell command run when recording stops.
+    #[serde(default)]
+    pub on_record_stop: Option<String>,
 }
 
 /// Visual configuration for the bottom recording overlay.
@@ -1191,6 +1212,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
         };
@@ -1237,6 +1259,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
         };
@@ -1267,6 +1290,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
         };
@@ -1300,6 +1324,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
         };
@@ -1340,6 +1365,7 @@ mod tests {
                 llm: None,
                 tts: None,
                 hotkeys: None,
+                hooks: None,
                 llm_commands: Vec::new(),
                 overlay: None,
             };
@@ -1407,6 +1433,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
         };
@@ -1456,6 +1483,7 @@ mod tests {
             llm: None,
             tts: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
         };
@@ -1511,6 +1539,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1544,6 +1573,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1578,6 +1608,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1612,6 +1643,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1646,6 +1678,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1677,6 +1710,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1750,6 +1784,7 @@ mod tests {
             openai_compatible_realtime: None,
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1789,6 +1824,7 @@ mod tests {
             openai_compatible_realtime: None,
             llm: Some(llm::LlmConfig::default()),
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1830,6 +1866,7 @@ mod tests {
             openai_compatible_realtime: None,
             llm: Some(llm::LlmConfig::default()),
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,
@@ -1896,6 +1933,7 @@ mod tests {
             openai_compatible_realtime: None,
             llm: Some(llm::LlmConfig::default()),
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,

--- a/src/daemon/factory.rs
+++ b/src/daemon/factory.rs
@@ -299,6 +299,7 @@ mod tests {
             }),
             llm: None,
             hotkeys: None,
+            hooks: None,
             llm_commands: Vec::new(),
             overlay: None,
             tts: None,

--- a/src/daemon/hooks.rs
+++ b/src/daemon/hooks.rs
@@ -18,6 +18,9 @@ pub(crate) async fn hook_dispatch_loop(
         match hook_event_for(prev, new) {
             Some(HookEvent::RecordStart) => {
                 if hooks.media_auto_pause {
+                    if !paused_players.is_empty() {
+                        whisrs::mpris::resume(&paused_players).await;
+                    }
                     paused_players = whisrs::mpris::pause_playing().await;
                 }
                 if let Some(cmd) = hooks.on_record_start.as_deref() {
@@ -25,8 +28,8 @@ pub(crate) async fn hook_dispatch_loop(
                 }
             }
             Some(HookEvent::RecordStop) => {
-                if hooks.media_auto_pause && !paused_players.is_empty() {
-                    whisrs::mpris::resume(&paused_players).await;
+                if hooks.media_auto_pause {
+                    whisrs::mpris::resume_all().await;
                     paused_players.clear();
                 }
                 if let Some(cmd) = hooks.on_record_stop.as_deref() {

--- a/src/daemon/hooks.rs
+++ b/src/daemon/hooks.rs
@@ -1,7 +1,7 @@
 //! Recording-lifecycle hooks: MPRIS pause + shell commands.
 
 #[cfg(feature = "hooks")]
-use whisrs::hooks::{hook_event_for, run_hook, HookEvent};
+use whisrs::hooks::{hook_event_for, run_hook, HookEvent, MediaPauseTracker};
 #[cfg(feature = "hooks")]
 use whisrs::{HooksConfig, State};
 
@@ -12,16 +12,19 @@ pub(crate) async fn hook_dispatch_loop(
     hooks: HooksConfig,
 ) {
     let mut prev = *state_rx.borrow();
-    let mut paused_players: Vec<String> = Vec::new();
+    // Bookkeeping lives in the lib and is unit-tested there; this loop only
+    // supplies the D-Bus round-trips.
+    let mut media = MediaPauseTracker::new();
     while state_rx.changed().await.is_ok() {
         let new = *state_rx.borrow();
         match hook_event_for(prev, new) {
             Some(HookEvent::RecordStart) => {
                 if hooks.media_auto_pause {
-                    if !paused_players.is_empty() {
-                        whisrs::mpris::resume(&paused_players).await;
-                    }
-                    paused_players = whisrs::mpris::pause_playing().await;
+                    let seen = whisrs::mpris::players().await;
+                    let plan = media.plan(HookEvent::RecordStart, &seen);
+                    // Only the pauses that succeeded are remembered, so the
+                    // stop resumes exactly what this daemon stopped.
+                    media.confirm_paused(&whisrs::mpris::pause(&plan.pause).await);
                 }
                 if let Some(cmd) = hooks.on_record_start.as_deref() {
                     run_hook(cmd);
@@ -29,8 +32,8 @@ pub(crate) async fn hook_dispatch_loop(
             }
             Some(HookEvent::RecordStop) => {
                 if hooks.media_auto_pause {
-                    whisrs::mpris::resume_all().await;
-                    paused_players.clear();
+                    let plan = media.plan(HookEvent::RecordStop, &[]);
+                    whisrs::mpris::resume(&plan.resume).await;
                 }
                 if let Some(cmd) = hooks.on_record_stop.as_deref() {
                     run_hook(cmd);

--- a/src/daemon/hooks.rs
+++ b/src/daemon/hooks.rs
@@ -1,0 +1,40 @@
+//! Recording-lifecycle hooks: MPRIS pause + shell commands.
+
+#[cfg(feature = "hooks")]
+use whisrs::hooks::{hook_event_for, run_hook, HookEvent};
+#[cfg(feature = "hooks")]
+use whisrs::{HooksConfig, State};
+
+/// Watches daemon state broadcasts and fires recording-lifecycle hooks.
+#[cfg(feature = "hooks")]
+pub(crate) async fn hook_dispatch_loop(
+    mut state_rx: tokio::sync::watch::Receiver<State>,
+    hooks: HooksConfig,
+) {
+    let mut prev = *state_rx.borrow();
+    let mut paused_players: Vec<String> = Vec::new();
+    while state_rx.changed().await.is_ok() {
+        let new = *state_rx.borrow();
+        match hook_event_for(prev, new) {
+            Some(HookEvent::RecordStart) => {
+                if hooks.media_auto_pause {
+                    paused_players = whisrs::mpris::pause_playing().await;
+                }
+                if let Some(cmd) = hooks.on_record_start.as_deref() {
+                    run_hook(cmd);
+                }
+            }
+            Some(HookEvent::RecordStop) => {
+                if hooks.media_auto_pause && !paused_players.is_empty() {
+                    whisrs::mpris::resume(&paused_players).await;
+                    paused_players.clear();
+                }
+                if let Some(cmd) = hooks.on_record_stop.as_deref() {
+                    run_hook(cmd);
+                }
+            }
+            None => {}
+        }
+        prev = new;
+    }
+}

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -15,6 +15,8 @@ mod command_mode;
 mod context;
 mod dictation;
 mod factory;
+#[cfg(feature = "hooks")]
+mod hooks;
 mod injection;
 mod notify;
 mod pipeline;
@@ -138,6 +140,14 @@ async fn main() -> Result<()> {
             cmd_tx.clone(),
             tray_notify,
         ));
+    }
+
+    // Recording-lifecycle hooks (MPRIS pause + shell commands). Watches the
+    // same state broadcast as the tray/overlay; detached, so failures never
+    // delay recording.
+    #[cfg(feature = "hooks")]
+    if let Some(hooks) = context.config.hooks.clone() {
+        tokio::spawn(crate::hooks::hook_dispatch_loop(state_rx.clone(), hooks));
     }
 
     // Start bottom recording overlay if enabled.

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -31,6 +31,8 @@ use crate::factory::create_backend;
 use crate::injection::warm_keyboard;
 use crate::notify::send_notification;
 use crate::speak::handle_speak;
+#[cfg(feature = "hooks")]
+use crate::startup::check_session_bus;
 use crate::startup::{
     check_audio_devices, check_uinput_access, cleanup_stale_socket, import_compositor_env,
     load_config, validate_config,
@@ -80,6 +82,12 @@ async fn main() -> Result<()> {
         std::time::Duration::from_millis(config.input.key_delay_ms),
         config.input.backend,
     );
+
+    // Check D-Bus session bus if MPRIS media pause is configured.
+    #[cfg(feature = "hooks")]
+    if config.hooks.as_ref().is_some_and(|h| h.media_auto_pause) {
+        check_session_bus().await;
+    }
 
     let window_tracker: Arc<dyn WindowTracker> = Arc::from(window::detect_tracker());
     info!(

--- a/src/daemon/startup.rs
+++ b/src/daemon/startup.rs
@@ -80,6 +80,7 @@ fn default_config() -> Config {
         llm: None,
         tts: None,
         hotkeys: None,
+        hooks: None,
         llm_commands: Vec::new(),
         overlay: None,
     }

--- a/src/daemon/startup.rs
+++ b/src/daemon/startup.rs
@@ -226,6 +226,36 @@ pub(crate) fn check_audio_devices() {
     }
 }
 
+/// Check if the D-Bus session bus is reachable. Required for MPRIS media
+/// pause. Warns once at startup if unavailable.
+#[cfg(feature = "hooks")]
+pub(crate) async fn check_session_bus() {
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        zbus::Connection::session(),
+    )
+    .await
+    {
+        Ok(Ok(_)) => info!("D-Bus session bus: available"),
+        Ok(Err(e)) => {
+            warn!(
+                "D-Bus session bus unavailable: {e}\n\
+                 MPRIS media pause will not work.\n\
+                 Install dbus-broker or dbus-daemon and ensure \
+                 DBUS_SESSION_BUS_ADDRESS is set."
+            );
+        }
+        Err(_) => {
+            warn!(
+                "D-Bus session bus connection timed out (5 s)\n\
+                 MPRIS media pause will not work.\n\
+                 Ensure dbus-broker or dbus-daemon is running and \
+                 DBUS_SESSION_BUS_ADDRESS is set."
+            );
+        }
+    }
+}
+
 pub(crate) fn validate_config(config: &Config) {
     match config.validate() {
         Ok(warnings) => {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,6 +1,7 @@
 //! Hooks fired when a recording session starts/stops. Driven by the state
 //! broadcast channel (see [`crate::daemon::hooks::hook_dispatch_loop`]).
 
+use crate::mpris::PlayerState;
 use crate::State;
 use tracing::{debug, warn};
 
@@ -23,6 +24,78 @@ pub fn hook_event_for(prev: State, new: State) -> Option<HookEvent> {
         (prev, State::Recording) if prev != State::Recording => Some(HookEvent::RecordStart),
         (State::Recording, new) if new != State::Recording => Some(HookEvent::RecordStop),
         _ => None,
+    }
+}
+
+/// The MPRIS work one hook event implies. Either list may be empty; an empty
+/// list means "issue no D-Bus calls", not "sweep the bus".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MediaPlan {
+    /// Bus names to pause, in the order they were seen.
+    pub pause: Vec<String>,
+    /// Bus names to resume. Never contains a player this daemon did not
+    /// pause itself.
+    pub resume: Vec<String>,
+}
+
+/// Remembers which MPRIS players *this daemon* paused, so a recording stop
+/// resumes exactly those. A tab the user paused before dictating is never in
+/// the set, so it is never started for them.
+///
+/// Pure bookkeeping — the D-Bus calls live in [`crate::mpris`] and the daemon
+/// feeds their results back in via [`Self::confirm_paused`].
+#[derive(Debug, Default)]
+pub struct MediaPauseTracker {
+    paused: Vec<String>,
+}
+
+impl MediaPauseTracker {
+    /// A tracker holding nothing.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Plan the MPRIS work for `event`.
+    ///
+    /// `players` is the session-bus snapshot taken at a recording start; it is
+    /// unused for [`HookEvent::RecordStop`], where the plan is exactly the set
+    /// this tracker is still holding. Planning a pause does *not* record it —
+    /// the caller reports back what actually paused via [`Self::confirm_paused`].
+    pub fn plan(&mut self, event: HookEvent, players: &[PlayerState]) -> MediaPlan {
+        match event {
+            // A start with no intervening stop is reachable: the state watch
+            // channel coalesces, so Recording → Idle → Recording can surface as
+            // a bare second start. Keep holding the earlier batch instead of
+            // forgetting it — those players stay paused until a stop arrives.
+            HookEvent::RecordStart => MediaPlan {
+                pause: players
+                    .iter()
+                    .filter(|p| p.playing)
+                    .map(|p| p.name.clone())
+                    .collect(),
+                resume: Vec::new(),
+            },
+            HookEvent::RecordStop => MediaPlan {
+                pause: Vec::new(),
+                resume: std::mem::take(&mut self.paused),
+            },
+        }
+    }
+
+    /// Record the players that actually paused, adding to anything still held
+    /// from an earlier start. A player that failed to pause is simply absent,
+    /// so it is never resumed.
+    pub fn confirm_paused(&mut self, paused: &[String]) {
+        for name in paused {
+            if !self.paused.iter().any(|held| held == name) {
+                self.paused.push(name.clone());
+            }
+        }
+    }
+
+    /// The players currently held paused, in the order they were paused.
+    pub fn held(&self) -> &[String] {
+        &self.paused
     }
 }
 
@@ -126,5 +199,143 @@ mod tests {
         // Should not panic or spawn any child.
         run_hook("");
         run_hook("   ");
+    }
+
+    // -- MediaPauseTracker ---------------------------------------------------
+
+    fn playing(name: &str) -> PlayerState {
+        PlayerState {
+            name: name.to_string(),
+            playing: true,
+        }
+    }
+
+    fn not_playing(name: &str) -> PlayerState {
+        PlayerState {
+            name: name.to_string(),
+            playing: false,
+        }
+    }
+
+    #[test]
+    fn stop_resumes_exactly_what_start_paused() {
+        let mut tracker = MediaPauseTracker::new();
+        let bus = [playing("spotify"), playing("vlc")];
+
+        let start = tracker.plan(HookEvent::RecordStart, &bus);
+        assert_eq!(start.pause, ["spotify", "vlc"]);
+        assert!(start.resume.is_empty(), "a start never resumes");
+        tracker.confirm_paused(&start.pause);
+
+        let stop = tracker.plan(HookEvent::RecordStop, &[]);
+        assert_eq!(stop.resume, ["spotify", "vlc"]);
+        assert!(stop.pause.is_empty(), "a stop never pauses");
+    }
+
+    /// The bug this tracker exists for: a tab the user paused themselves must
+    /// not start playing when dictation ends.
+    #[test]
+    fn a_player_already_paused_is_never_touched() {
+        let mut tracker = MediaPauseTracker::new();
+        let bus = [
+            playing("spotify"),
+            not_playing("firefox"),
+            not_playing("vlc"),
+        ];
+
+        let start = tracker.plan(HookEvent::RecordStart, &bus);
+        assert_eq!(
+            start.pause,
+            ["spotify"],
+            "only the playing player may be paused"
+        );
+        tracker.confirm_paused(&start.pause);
+
+        let stop = tracker.plan(HookEvent::RecordStop, &[]);
+        assert_eq!(
+            stop.resume,
+            ["spotify"],
+            "firefox and vlc were the user's to keep paused"
+        );
+    }
+
+    #[test]
+    fn second_start_without_a_stop_keeps_the_first_batch() {
+        let mut tracker = MediaPauseTracker::new();
+
+        let first = tracker.plan(HookEvent::RecordStart, &[playing("spotify")]);
+        tracker.confirm_paused(&first.pause);
+
+        // The watch channel coalesced a stop away; spotify is still paused by
+        // us, and a new player started in the meantime.
+        let second = tracker.plan(
+            HookEvent::RecordStart,
+            &[not_playing("spotify"), playing("vlc")],
+        );
+        assert_eq!(second.pause, ["vlc"]);
+        tracker.confirm_paused(&second.pause);
+        assert_eq!(tracker.held(), ["spotify", "vlc"]);
+
+        let stop = tracker.plan(HookEvent::RecordStop, &[]);
+        assert_eq!(
+            stop.resume,
+            ["spotify", "vlc"],
+            "the first batch must not be stranded"
+        );
+    }
+
+    #[test]
+    fn a_player_still_playing_at_a_second_start_is_paused_once() {
+        let mut tracker = MediaPauseTracker::new();
+
+        let first = tracker.plan(HookEvent::RecordStart, &[playing("spotify")]);
+        tracker.confirm_paused(&first.pause);
+
+        // The user hit play again mid-recording: pause it, but do not record
+        // it twice or the resume list grows duplicates.
+        let second = tracker.plan(HookEvent::RecordStart, &[playing("spotify")]);
+        assert_eq!(second.pause, ["spotify"]);
+        tracker.confirm_paused(&second.pause);
+
+        assert_eq!(tracker.plan(HookEvent::RecordStop, &[]).resume, ["spotify"]);
+    }
+
+    #[test]
+    fn stop_with_nothing_paused_resumes_nothing() {
+        let mut tracker = MediaPauseTracker::new();
+        let stop = tracker.plan(HookEvent::RecordStop, &[]);
+        assert!(
+            stop.resume.is_empty(),
+            "a stop must never sweep the bus for players to resume"
+        );
+        assert!(stop.pause.is_empty());
+    }
+
+    #[test]
+    fn a_stop_forgets_its_batch() {
+        let mut tracker = MediaPauseTracker::new();
+        tracker.confirm_paused(&["spotify".to_string()]);
+
+        assert_eq!(tracker.plan(HookEvent::RecordStop, &[]).resume, ["spotify"]);
+        assert!(
+            tracker.plan(HookEvent::RecordStop, &[]).resume.is_empty(),
+            "a second stop must not resume the same batch again"
+        );
+        assert!(tracker.held().is_empty());
+    }
+
+    #[test]
+    fn a_pause_that_failed_is_never_resumed() {
+        let mut tracker = MediaPauseTracker::new();
+        let start = tracker.plan(
+            HookEvent::RecordStart,
+            &[playing("spotify"), playing("vlc")],
+        );
+        assert_eq!(start.pause, ["spotify", "vlc"]);
+
+        // vlc refused the Pause call, so the daemon reports only spotify.
+        tracker.confirm_paused(&["spotify".to_string()]);
+
+        assert_eq!(tracker.plan(HookEvent::RecordStop, &[]).resume, ["spotify"]);
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,130 @@
+//! Hooks fired when a recording session starts/stops. Driven by the state
+//! broadcast channel (see [`crate::daemon::hooks::hook_dispatch_loop`]).
+
+use crate::State;
+use tracing::{debug, warn};
+
+/// Which hook set fires for a state change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookEvent {
+    /// A recording session began.
+    RecordStart,
+    /// A recording session ended.
+    RecordStop,
+}
+
+/// Map a state change to the hook that fires; `None` for no-op transitions.
+///
+/// `RecordStop` fires at the first non-`Recording` state. For dictation that
+/// is `Transcribing` (MPRIS resumes while transcription runs); for command
+/// mode it is `Idle` (finalize broadcasts after the full pipeline completes).
+pub fn hook_event_for(prev: State, new: State) -> Option<HookEvent> {
+    match (prev, new) {
+        (prev, State::Recording) if prev != State::Recording => Some(HookEvent::RecordStart),
+        (State::Recording, new) if new != State::Recording => Some(HookEvent::RecordStop),
+        _ => None,
+    }
+}
+
+/// Run a shell command fire-and-forget via `sh -c`. Never blocks recording.
+/// Empty commands are skipped. Hangs are killed after 30 seconds.
+pub fn run_hook(cmd: &str) {
+    if cmd.trim().is_empty() {
+        return;
+    }
+    match tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(mut child) => {
+            debug!("running hook: {cmd}");
+            let cmd = cmd.to_string();
+            tokio::spawn(async move {
+                match tokio::time::timeout(std::time::Duration::from_secs(30), child.wait()).await {
+                    Ok(Ok(status)) => {
+                        if !status.success() {
+                            warn!("hook `{cmd}` exited with {status}");
+                        }
+                    }
+                    Ok(Err(e)) => warn!("hook `{cmd}` wait error: {e}"),
+                    Err(_) => {
+                        warn!("hook `{cmd}` timed out after 30s, killing");
+                        let _ = child.kill().await;
+                    }
+                }
+            });
+        }
+        Err(e) => warn!("failed to run record hook `{cmd}`: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::State;
+
+    #[test]
+    fn idle_to_recording_fires_start() {
+        assert_eq!(
+            hook_event_for(State::Idle, State::Recording),
+            Some(HookEvent::RecordStart)
+        );
+    }
+
+    #[test]
+    fn transcribing_to_recording_fires_start() {
+        // Never occurs today, but entering Recording from any non-Recording
+        // state is a start.
+        assert_eq!(
+            hook_event_for(State::Transcribing, State::Recording),
+            Some(HookEvent::RecordStart)
+        );
+    }
+
+    #[test]
+    fn recording_to_transcribing_fires_stop() {
+        assert_eq!(
+            hook_event_for(State::Recording, State::Transcribing),
+            Some(HookEvent::RecordStop)
+        );
+    }
+
+    #[test]
+    fn recording_to_idle_fires_stop() {
+        assert_eq!(
+            hook_event_for(State::Recording, State::Idle),
+            Some(HookEvent::RecordStop)
+        );
+    }
+
+    #[test]
+    fn duplicate_broadcasts_are_ignored() {
+        assert_eq!(hook_event_for(State::Recording, State::Recording), None);
+        assert_eq!(hook_event_for(State::Idle, State::Idle), None);
+        assert_eq!(
+            hook_event_for(State::Transcribing, State::Transcribing),
+            None
+        );
+    }
+
+    #[test]
+    fn read_aloud_transitions_are_ignored() {
+        assert_eq!(hook_event_for(State::Idle, State::Synthesizing), None);
+        assert_eq!(hook_event_for(State::Synthesizing, State::Speaking), None);
+        assert_eq!(hook_event_for(State::Speaking, State::Idle), None);
+    }
+
+    #[test]
+    fn transcribing_to_idle_is_ignored() {
+        assert_eq!(hook_event_for(State::Transcribing, State::Idle), None);
+    }
+
+    #[tokio::test]
+    async fn empty_hook_is_noop() {
+        // Should not panic or spawn any child.
+        run_hook("");
+        run_hook("   ");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,13 @@
 pub mod audio;
 pub mod config;
 pub mod history;
+#[cfg(feature = "hooks")]
+pub mod hooks;
 pub mod hotkey;
 pub mod ipc;
 pub mod llm;
+#[cfg(feature = "hooks")]
+pub mod mpris;
 pub mod overlay;
 pub mod service_ctl;
 pub mod state;

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -8,57 +8,53 @@ use tracing::{debug, warn};
 const PLAYER_PATH: &str = "/org/mpris/MediaPlayer2";
 const PLAYER_IFACE: &str = "org.mpris.MediaPlayer2.Player";
 
-/// Pure: does this bus name identify a controllable MPRIS player?
+/// Does this bus name identify a controllable MPRIS player?
 pub fn is_mpris_player(name: &str) -> bool {
     name.starts_with("org.mpris.MediaPlayer2.")
 }
 
-/// Pause every playing, pausable MPRIS player; returns the paused names for
-/// later selective resume. Empty on failure — recording always proceeds.
+/// Pause every MPRIS player; returns the paused names for later selective
+/// resume. `Pause` is a no-op on already-paused or stopped players.
 pub async fn pause_playing() -> Vec<String> {
-    match tokio::time::timeout(std::time::Duration::from_secs(5), pause_playing_inner()).await {
-        Ok(v) => v,
-        Err(_) => {
-            warn!("MPRIS pause timed out");
-            Vec::new()
-        }
-    }
-}
-
-async fn pause_playing_inner() -> Vec<String> {
-    let Ok(conn) = zbus::Connection::session().await else {
+    let Some(conn) = zbus::Connection::session().await.ok() else {
         debug!("no session bus — MPRIS media pause unavailable");
         return Vec::new();
     };
-    let Ok(dbus) = zbus::fdo::DBusProxy::new(&conn).await else {
+    let Some(dbus) = zbus::fdo::DBusProxy::new(&conn).await.ok() else {
+        debug!("failed to create D-Bus proxy — MPRIS media pause unavailable");
         return Vec::new();
     };
-    let Ok(names) = dbus.list_names().await else {
+    let Some(names) = dbus.list_names().await.ok() else {
+        debug!("failed to list D-Bus names — MPRIS media pause unavailable");
         return Vec::new();
     };
+
     let mut paused = Vec::new();
-    for name in names {
-        let name = name.to_string();
-        if !is_mpris_player(&name) {
-            continue;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+
+    // Pre-filter to MPRIS names so the deadline only counts real players.
+    let mpris_names: Vec<String> = names
+        .into_iter()
+        .filter_map(|n| {
+            let s = n.to_string();
+            is_mpris_player(&s).then_some(s)
+        })
+        .collect();
+
+    for name in mpris_names {
+        if tokio::time::Instant::now() >= deadline {
+            warn!(
+                "MPRIS pause timed out after pausing {} player(s)",
+                paused.len()
+            );
+            break;
         }
+
         let Ok(proxy) = zbus::Proxy::new(&conn, name.as_str(), PLAYER_PATH, PLAYER_IFACE).await
         else {
+            debug!("skipped {name}: failed to create MPRIS proxy");
             continue;
         };
-        // Only pause what is actually playing and pausable.
-        let Ok(status) = proxy.get_property::<String>("PlaybackStatus").await else {
-            continue;
-        };
-        if status != "Playing" {
-            continue;
-        }
-        let Ok(can_pause) = proxy.get_property::<bool>("CanPause").await else {
-            continue;
-        };
-        if !can_pause {
-            continue;
-        }
         match proxy.call_method("Pause", &()).await {
             Ok(_) => {
                 debug!("paused MPRIS player {name}");
@@ -70,19 +66,8 @@ async fn pause_playing_inner() -> Vec<String> {
     paused
 }
 
-/// Resume exactly the players we paused. Players that quit or moved to a
-/// different playback state since pause are left alone; failures are
-/// logged, never fatal.
+/// Resume specific players by name.
 pub async fn resume(names: &[String]) {
-    if tokio::time::timeout(std::time::Duration::from_secs(5), resume_inner(names))
-        .await
-        .is_err()
-    {
-        warn!("MPRIS resume timed out");
-    }
-}
-
-async fn resume_inner(names: &[String]) {
     let Ok(conn) = zbus::Connection::session().await else {
         return;
     };
@@ -91,15 +76,40 @@ async fn resume_inner(names: &[String]) {
         else {
             continue;
         };
-        let Ok(status) = proxy.get_property::<String>("PlaybackStatus").await else {
-            continue;
-        };
-        if status != "Paused" {
+        let _ = proxy.call_method("Play", &()).await;
+    }
+}
+
+/// Resume every MPRIS player on the session bus. Catches players whose bus
+/// name changed during recording (e.g. browser tabs switching).
+pub async fn resume_all() {
+    let Ok(conn) = zbus::Connection::session().await else {
+        return;
+    };
+    let Ok(dbus) = zbus::fdo::DBusProxy::new(&conn).await else {
+        return;
+    };
+    let Ok(names) = dbus.list_names().await else {
+        return;
+    };
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    for name in names {
+        if tokio::time::Instant::now() >= deadline {
+            warn!("MPRIS resume_all timed out");
+            break;
+        }
+        let name = name.to_string();
+        if !is_mpris_player(&name) {
             continue;
         }
+        let Ok(proxy) = zbus::Proxy::new(&conn, name.as_str(), PLAYER_PATH, PLAYER_IFACE).await
+        else {
+            continue;
+        };
         match proxy.call_method("Play", &()).await {
             Ok(_) => debug!("resumed MPRIS player {name}"),
-            Err(e) => warn!("failed to resume MPRIS player {name}: {e}"),
+            Err(e) => debug!("failed to resume MPRIS player {name}: {e}"),
         }
     }
 }
@@ -118,7 +128,6 @@ mod tests {
             "org.mpris.MediaPlayer2.kdeconnect.qOo4rGkeX7g"
         ));
         assert!(!is_mpris_player("org.freedesktop.DBus"));
-        // Exact match without trailing suffix — not a player.
         assert!(!is_mpris_player("org.mpris.MediaPlayer2"));
         assert!(!is_mpris_player("com.spotify.Client"));
     }

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -1,36 +1,70 @@
 //! Native MPRIS v2 pause/resume over the session D-Bus. Every player
 //! (browsers, Spotify, VLC, MPV, KDE Connect) registers as
 //! `org.mpris.MediaPlayer2.*`, so the session bus *is* the integration.
-//! Failures degrade gracefully — a missing bus never blocks dictation.
+//!
+//! Only players reporting `PlaybackStatus = "Playing"` are paused, and only
+//! those are resumed: media the user paused before dictating stays paused.
+//! Failures degrade gracefully — a missing bus, an unreadable property or a
+//! bus name that vanished mid-session never blocks dictation.
+
+use std::time::Duration;
 
 use tracing::{debug, warn};
 
 const PLAYER_PATH: &str = "/org/mpris/MediaPlayer2";
 const PLAYER_IFACE: &str = "org.mpris.MediaPlayer2.Player";
 
+/// Budget for one sweep of the bus. Reading `PlaybackStatus` costs a
+/// round-trip per player, so a wedged player must not stall recording.
+const SWEEP_DEADLINE: Duration = Duration::from_secs(5);
+
+/// One MPRIS player as seen on the session bus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlayerState {
+    /// The `org.mpris.MediaPlayer2.*` bus name.
+    pub name: String,
+    /// Whether `PlaybackStatus` read back as `Playing`.
+    pub playing: bool,
+}
+
 /// Does this bus name identify a controllable MPRIS player?
 pub fn is_mpris_player(name: &str) -> bool {
     name.starts_with("org.mpris.MediaPlayer2.")
 }
 
-/// Pause every MPRIS player; returns the paused names for later selective
-/// resume. `Pause` is a no-op on already-paused or stopped players.
-pub async fn pause_playing() -> Vec<String> {
-    let Some(conn) = zbus::Connection::session().await.ok() else {
+/// A one-shot `org.mpris.MediaPlayer2.Player` proxy for `name`.
+///
+/// Property caching is off: the default (`Lazily`) turns the first property
+/// read into a `GetAll` plus a `PropertiesChanged` match rule per player, and
+/// every proxy here is used for a single call.
+async fn player_proxy(conn: &zbus::Connection, name: &str) -> zbus::Result<zbus::Proxy<'static>> {
+    zbus::proxy::Builder::new(conn)
+        .destination(name.to_string())?
+        .path(PLAYER_PATH)?
+        .interface(PLAYER_IFACE)?
+        .cache_properties(zbus::proxy::CacheProperties::No)
+        .build()
+        .await
+}
+
+/// Snapshot every MPRIS player on the session bus with its playback status.
+///
+/// A player whose `PlaybackStatus` cannot be read is skipped entirely, so it
+/// is never paused and therefore never resumed — an unreadable player is not
+/// an excuse to start someone's music.
+pub async fn players() -> Vec<PlayerState> {
+    let Ok(conn) = zbus::Connection::session().await else {
         debug!("no session bus — MPRIS media pause unavailable");
         return Vec::new();
     };
-    let Some(dbus) = zbus::fdo::DBusProxy::new(&conn).await.ok() else {
+    let Ok(dbus) = zbus::fdo::DBusProxy::new(&conn).await else {
         debug!("failed to create D-Bus proxy — MPRIS media pause unavailable");
         return Vec::new();
     };
-    let Some(names) = dbus.list_names().await.ok() else {
+    let Ok(names) = dbus.list_names().await else {
         debug!("failed to list D-Bus names — MPRIS media pause unavailable");
         return Vec::new();
     };
-
-    let mut paused = Vec::new();
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
 
     // Pre-filter to MPRIS names so the deadline only counts real players.
     let mpris_names: Vec<String> = names
@@ -41,7 +75,48 @@ pub async fn pause_playing() -> Vec<String> {
         })
         .collect();
 
+    let deadline = tokio::time::Instant::now() + SWEEP_DEADLINE;
+    let mut seen = Vec::with_capacity(mpris_names.len());
     for name in mpris_names {
+        // Checked before the PlaybackStatus round-trip, not after it.
+        if tokio::time::Instant::now() >= deadline {
+            warn!(
+                "MPRIS scan timed out after inspecting {} player(s)",
+                seen.len()
+            );
+            break;
+        }
+
+        let Ok(proxy) = player_proxy(&conn, &name).await else {
+            debug!("skipped {name}: failed to create MPRIS proxy");
+            continue;
+        };
+        let playing = match proxy.get_property::<String>("PlaybackStatus").await {
+            Ok(status) => status == "Playing",
+            Err(e) => {
+                debug!("skipped {name}: failed to read PlaybackStatus: {e}");
+                continue;
+            }
+        };
+        debug!("MPRIS player {name}: playing={playing}");
+        seen.push(PlayerState { name, playing });
+    }
+    seen
+}
+
+/// Pause `names`, returning exactly the ones that actually paused so a later
+/// [`resume`] never touches a player this daemon did not stop.
+pub async fn pause(names: &[String]) -> Vec<String> {
+    if names.is_empty() {
+        return Vec::new();
+    }
+    let Ok(conn) = zbus::Connection::session().await else {
+        return Vec::new();
+    };
+
+    let deadline = tokio::time::Instant::now() + SWEEP_DEADLINE;
+    let mut paused = Vec::with_capacity(names.len());
+    for name in names {
         if tokio::time::Instant::now() >= deadline {
             warn!(
                 "MPRIS pause timed out after pausing {} player(s)",
@@ -50,15 +125,14 @@ pub async fn pause_playing() -> Vec<String> {
             break;
         }
 
-        let Ok(proxy) = zbus::Proxy::new(&conn, name.as_str(), PLAYER_PATH, PLAYER_IFACE).await
-        else {
+        let Ok(proxy) = player_proxy(&conn, name).await else {
             debug!("skipped {name}: failed to create MPRIS proxy");
             continue;
         };
         match proxy.call_method("Pause", &()).await {
             Ok(_) => {
                 debug!("paused MPRIS player {name}");
-                paused.push(name);
+                paused.push(name.clone());
             }
             Err(e) => warn!("failed to pause MPRIS player {name}: {e}"),
         }
@@ -66,45 +140,20 @@ pub async fn pause_playing() -> Vec<String> {
     paused
 }
 
-/// Resume specific players by name.
+/// Resume exactly `names` — the players this daemon paused, nothing else.
+///
+/// A name that vanished mid-session (the player exited, or a browser renamed
+/// its media session) fails silently. Missing a resume beats resuming media
+/// the user never had playing, so there is deliberately no bus-wide fallback.
 pub async fn resume(names: &[String]) {
-    let Ok(conn) = zbus::Connection::session().await else {
+    if names.is_empty() {
         return;
-    };
-    for name in names {
-        let Ok(proxy) = zbus::Proxy::new(&conn, name.as_str(), PLAYER_PATH, PLAYER_IFACE).await
-        else {
-            continue;
-        };
-        let _ = proxy.call_method("Play", &()).await;
     }
-}
-
-/// Resume every MPRIS player on the session bus. Catches players whose bus
-/// name changed during recording (e.g. browser tabs switching).
-pub async fn resume_all() {
     let Ok(conn) = zbus::Connection::session().await else {
         return;
     };
-    let Ok(dbus) = zbus::fdo::DBusProxy::new(&conn).await else {
-        return;
-    };
-    let Ok(names) = dbus.list_names().await else {
-        return;
-    };
-
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     for name in names {
-        if tokio::time::Instant::now() >= deadline {
-            warn!("MPRIS resume_all timed out");
-            break;
-        }
-        let name = name.to_string();
-        if !is_mpris_player(&name) {
-            continue;
-        }
-        let Ok(proxy) = zbus::Proxy::new(&conn, name.as_str(), PLAYER_PATH, PLAYER_IFACE).await
-        else {
+        let Ok(proxy) = player_proxy(&conn, name).await else {
             continue;
         };
         match proxy.call_method("Play", &()).await {
@@ -130,5 +179,13 @@ mod tests {
         assert!(!is_mpris_player("org.freedesktop.DBus"));
         assert!(!is_mpris_player("org.mpris.MediaPlayer2"));
         assert!(!is_mpris_player("com.spotify.Client"));
+    }
+
+    /// No session bus is touched for an empty list — a recording stop with
+    /// nothing held must issue no D-Bus traffic at all.
+    #[tokio::test]
+    async fn empty_lists_are_noops() {
+        assert!(pause(&[]).await.is_empty());
+        resume(&[]).await;
     }
 }

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -1,0 +1,125 @@
+//! Native MPRIS v2 pause/resume over the session D-Bus. Every player
+//! (browsers, Spotify, VLC, MPV, KDE Connect) registers as
+//! `org.mpris.MediaPlayer2.*`, so the session bus *is* the integration.
+//! Failures degrade gracefully — a missing bus never blocks dictation.
+
+use tracing::{debug, warn};
+
+const PLAYER_PATH: &str = "/org/mpris/MediaPlayer2";
+const PLAYER_IFACE: &str = "org.mpris.MediaPlayer2.Player";
+
+/// Pure: does this bus name identify a controllable MPRIS player?
+pub fn is_mpris_player(name: &str) -> bool {
+    name.starts_with("org.mpris.MediaPlayer2.")
+}
+
+/// Pause every playing, pausable MPRIS player; returns the paused names for
+/// later selective resume. Empty on failure — recording always proceeds.
+pub async fn pause_playing() -> Vec<String> {
+    match tokio::time::timeout(std::time::Duration::from_secs(5), pause_playing_inner()).await {
+        Ok(v) => v,
+        Err(_) => {
+            warn!("MPRIS pause timed out");
+            Vec::new()
+        }
+    }
+}
+
+async fn pause_playing_inner() -> Vec<String> {
+    let Ok(conn) = zbus::Connection::session().await else {
+        debug!("no session bus — MPRIS media pause unavailable");
+        return Vec::new();
+    };
+    let Ok(dbus) = zbus::fdo::DBusProxy::new(&conn).await else {
+        return Vec::new();
+    };
+    let Ok(names) = dbus.list_names().await else {
+        return Vec::new();
+    };
+    let mut paused = Vec::new();
+    for name in names {
+        let name = name.to_string();
+        if !is_mpris_player(&name) {
+            continue;
+        }
+        let Ok(proxy) = zbus::Proxy::new(&conn, name.as_str(), PLAYER_PATH, PLAYER_IFACE).await
+        else {
+            continue;
+        };
+        // Only pause what is actually playing and pausable.
+        let Ok(status) = proxy.get_property::<String>("PlaybackStatus").await else {
+            continue;
+        };
+        if status != "Playing" {
+            continue;
+        }
+        let Ok(can_pause) = proxy.get_property::<bool>("CanPause").await else {
+            continue;
+        };
+        if !can_pause {
+            continue;
+        }
+        match proxy.call_method("Pause", &()).await {
+            Ok(_) => {
+                debug!("paused MPRIS player {name}");
+                paused.push(name);
+            }
+            Err(e) => warn!("failed to pause MPRIS player {name}: {e}"),
+        }
+    }
+    paused
+}
+
+/// Resume exactly the players we paused. Players that quit or moved to a
+/// different playback state since pause are left alone; failures are
+/// logged, never fatal.
+pub async fn resume(names: &[String]) {
+    if tokio::time::timeout(std::time::Duration::from_secs(5), resume_inner(names))
+        .await
+        .is_err()
+    {
+        warn!("MPRIS resume timed out");
+    }
+}
+
+async fn resume_inner(names: &[String]) {
+    let Ok(conn) = zbus::Connection::session().await else {
+        return;
+    };
+    for name in names {
+        let Ok(proxy) = zbus::Proxy::new(&conn, name.as_str(), PLAYER_PATH, PLAYER_IFACE).await
+        else {
+            continue;
+        };
+        let Ok(status) = proxy.get_property::<String>("PlaybackStatus").await else {
+            continue;
+        };
+        if status != "Paused" {
+            continue;
+        }
+        match proxy.call_method("Play", &()).await {
+            Ok(_) => debug!("resumed MPRIS player {name}"),
+            Err(e) => warn!("failed to resume MPRIS player {name}: {e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mpris_player_detection() {
+        assert!(is_mpris_player("org.mpris.MediaPlayer2.spotify"));
+        assert!(is_mpris_player(
+            "org.mpris.MediaPlayer2.plasma-browser-integration"
+        ));
+        assert!(is_mpris_player(
+            "org.mpris.MediaPlayer2.kdeconnect.qOo4rGkeX7g"
+        ));
+        assert!(!is_mpris_player("org.freedesktop.DBus"));
+        // Exact match without trailing suffix — not a player.
+        assert!(!is_mpris_player("org.mpris.MediaPlayer2"));
+        assert!(!is_mpris_player("com.spotify.Client"));
+    }
+}

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -18,6 +18,20 @@ const PLAYER_IFACE: &str = "org.mpris.MediaPlayer2.Player";
 /// round-trip per player, so a wedged player must not stall recording.
 const SWEEP_DEADLINE: Duration = Duration::from_secs(5);
 
+/// Per-call ceiling. The sweep deadline is only checked *between* players, so
+/// without this a peer that owns its bus name but never replies would block
+/// the hook loop forever: the paused media would never resume and no later
+/// hook would fire for the life of the daemon.
+const CALL_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// A session-bus connection that cannot hang on an unresponsive peer.
+async fn session_connection() -> zbus::Result<zbus::Connection> {
+    zbus::connection::Builder::session()?
+        .method_timeout(CALL_TIMEOUT)
+        .build()
+        .await
+}
+
 /// One MPRIS player as seen on the session bus.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlayerState {
@@ -53,7 +67,7 @@ async fn player_proxy(conn: &zbus::Connection, name: &str) -> zbus::Result<zbus:
 /// is never paused and therefore never resumed — an unreadable player is not
 /// an excuse to start someone's music.
 pub async fn players() -> Vec<PlayerState> {
-    let Ok(conn) = zbus::Connection::session().await else {
+    let Ok(conn) = session_connection().await else {
         debug!("no session bus — MPRIS media pause unavailable");
         return Vec::new();
     };
@@ -110,7 +124,7 @@ pub async fn pause(names: &[String]) -> Vec<String> {
     if names.is_empty() {
         return Vec::new();
     }
-    let Ok(conn) = zbus::Connection::session().await else {
+    let Ok(conn) = session_connection().await else {
         return Vec::new();
     };
 
@@ -149,10 +163,15 @@ pub async fn resume(names: &[String]) {
     if names.is_empty() {
         return;
     }
-    let Ok(conn) = zbus::Connection::session().await else {
+    let Ok(conn) = session_connection().await else {
         return;
     };
+    let deadline = tokio::time::Instant::now() + SWEEP_DEADLINE;
     for name in names {
+        if tokio::time::Instant::now() >= deadline {
+            warn!("MPRIS resume timed out; some players stay paused");
+            break;
+        }
         let Ok(proxy) = player_proxy(&conn, name).await else {
             continue;
         };


### PR DESCRIPTION
## Summary

Adds recording-lifecycle hooks to the daemon: when `media_auto_pause` is enabled,
whisrs automatically pauses every MPRIS media player (Spotify, browser tabs, VLC,
etc.) when you start recording and resumes them when you're done. If you are like me and you like listening to some YouTube videos in the background this will be a huge helper. Already saved me lots of editing incorrectly recognized phrases.

Also supports arbitrary shell commands on record start/stop for custom workflows.

## Changes

### New modules

- **`src/mpris.rs`** — Native MPRIS v2 integration over the session D-Bus.
  `pause_playing()` returns the paused player names; `resume()` selectively
  resumes them; `resume_all()` catches players whose bus name changed during
  recording (e.g. browser tabs switching). All operations have a 5-second
  deadline so a hung D-Bus never blocks dictation.

- **`src/hooks.rs`** — Hook event model: maps `State` transitions to
  `HookEvent::RecordStart` / `RecordStop`. `run_hook()` executes shell commands
  fire-and-forget via `sh -c` with a 30-second kill timeout. Unit-tested for
  all state transitions including read-aloud and no-op transitions.

- **`src/daemon/hooks.rs`** — Wires hook events into the daemon's state
  broadcast channel. Spawns as a detached tokio task so hook failures never
  delay recording.

### Config (`[hooks]` section)

```toml
[hooks]
media_auto_pause = true          # pause MPRIS playback while dictating
on_record_start = ""             # shell command on recording start
on_record_stop = ""              # shell command on recording stop
```

- `media_auto_pause` — pauses all MPRIS players on record start, resumes
  exactly those players on record stop
- `on_record_start` / `on_record_stop` — arbitrary shell commands,
  fire-and-forget, inherit the daemon's environment, stdout/stderr goes
  to the journal under systemd --user
- Shown as a commented hint in `config.toml` when the user hasn't configured
  hooks yet (survives the `toml_edit` round-trip)

### Dependency changes

- **`zbus`** moved from required dependency to `optional = true`, feature-gated
  behind both `hooks` and `overlay`. Builds without D-Bus still work — the
  MPRIS and overlay D-Bus paths are `#[cfg(feature = "hooks")]` /
  `#[cfg(feature = "overlay")]`.

### Startup check

When `media_auto_pause` is enabled, the daemon checks D-Bus session bus
reachability at startup (5-second timeout) and warns once if unavailable,
with guidance on installing `dbus-broker` or `dbus-daemon`.

### Config editor

`whisrs config` now includes the `[hooks]` section with inline help for
each field.

## Files changed

```
Cargo.toml            hooks feature, optional zbus dep
README.md             mention [hooks] in config reference
contrib/whisrs.1      document [hooks] section in man page
docs/configuration.md document hooks config
src/config/edit.rs    hooks section in config editor
src/config/setup.rs   hooks hint in setup wizard output
src/config/types.rs   HooksConfig struct + Config field
src/daemon/factory.rs export hooks module
src/daemon/hooks.rs   hook_dispatch_loop (new)
src/daemon/main.rs    spawn hook loop, D-Bus session check
src/daemon/startup.rs check_session_bus()
src/hooks.rs          HookEvent model + run_hook (new)
src/lib.rs            pub mod hooks, mpris
src/mpris.rs          MPRIS v2 D-Bus integration (new)
```

## Testing

- Unit tests for `hook_event_for()` covering all state transitions
- Unit tests for `run_hook()` with empty/whitespace commands
- Unit tests for `is_mpris_player()` bus name matching
- Manual test: start Youtube, Spotify or any player. enable `media_auto_pause`, run
  `whisrs toggle` — music pauses, dictation works, music resumes on stop

## Breaking changes

None. The `[hooks]` section is optional and defaults to disabled. Existing
config files are unaffected — `toml_edit` preserves comments and the new
fields deserialize with `Default`.

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor
