### PR TITLE
feat(llm): strip fences, guard terminal multi-line, and stop preamble

### DIFF
--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -75,7 +75,14 @@ Clear all history instead of showing it.
 .TP
 .B command
 Command mode: select text, speak an instruction, and the LLM rewrites it
-in place.
+in place. Requires a selection. To write text where there is none, configure
+an
+.B [[llm_commands]]
+entry with a generic \(lqtreat the following text as a request and output
+only what is asked\(rq instruction \(em that path never reads the selection.
+See
+.I https://github.com/y0sif/whisrs/blob/main/docs/configuration.md
+for the recipe.
 .TP
 \fBllm\-command\fR \fINAME\fR
 Toggle a named custom LLM command (see
@@ -117,6 +124,37 @@ when the systemd user unit is loaded; otherwise prints guidance for
 manual restart. Does not require the daemon to be running \(em
 .B restart
 will start a stopped service.
+.SH LLM OUTPUT
+Applies to
+.B command
+and to every
+.B [[llm_commands]]
+entry \(em both type the model's reply at the cursor.
+.PP
+A reply wrapped entirely in a Markdown code fence is unwrapped before it is
+typed; a fence is never what you wanted at the cursor. A reply that contains
+several fenced blocks is prose about code, not a wrapper, and is left alone.
+Stripping has no opt-out, so an entry whose instruction asks for a fenced
+block cannot produce one.
+.PP
+A reply spanning several lines is typed normally \(em translating a paragraph
+or drafting an email is exactly what these commands are for. The one exception
+is a terminal: there a line break is an Enter that runs a command you have not
+read, so a multi-line reply aimed at a terminal is refused rather than typed.
+It is not lost \(em it is written to the history, where
+.B whisrs log
+recovers it. Ask for a one\-liner to get an injected result. The refusal also
+applies with
+.B [input] paste
+set, since bracketed paste is the foreground program's choice and cannot be
+relied on; and its notification fires even with
+.B [general] notify
+turned off, because nothing was typed.
+.PP
+Terminal detection needs
+.BR WindowTracker::get_focused_window_class ,
+which only Hyprland and Niri implement; elsewhere a terminal is treated as an
+ordinary target and multi-line replies are typed.
 .SH ENVIRONMENT
 .TP
 .B WHISRS_GROQ_API_KEY

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,12 +228,83 @@ response_format = "wav"     # audio format requested from the API
 # Modifiers: Super, Alt, Ctrl, Shift. At least one is required, so a bare
 #   "F13" is rejected; write "Shift+F13". The modifier set must match exactly,
 #   so "Ctrl+Alt+Ins" does not fire while Shift is also held.
+# Two bindings sharing a combo both fire on one press, so whisrs warns at
+#   startup when it finds a duplicate across [hotkeys] and [[llm_commands]].
 [hotkeys]
 toggle = "Super+Shift+W"
 cancel = "Super+Shift+D"
 command = "Super+Shift+G"
 speak = "Super+Shift+R"
 ```
+
+### Generate text with no selection
+
+`whisrs command` **rewrites a selection**: highlight some text, press the key,
+say what to do with it ("make this formal", "translate to German"). It reads
+the primary selection, falling back to a simulated Ctrl+C, and refuses with
+"no text selected" when it comes up empty.
+
+To **write new text** where there is nothing to select, use an `[[llm_commands]]`
+entry with a generic instruction. That path never reads the selection or the
+clipboard, so nothing needs to be highlighted first: press the key, say what you
+want, and the result is typed at the cursor.
+
+```toml
+[[llm_commands]]
+name = "ask"
+hotkey = "Super+Shift+B"
+instruction = "Treat the following text as a request and output only what is asked. Output the requested artifact itself, with no preamble, no explanation and no code fences."
+```
+
+Then press `Super+Shift+B`, say "the command to install steam on arch linux",
+press again (or stop talking), and `sudo pacman -S steam` is typed where your
+cursor is. Say "a polite email declining the meeting on Thursday" and you get
+the email. The instruction is what makes it generic, so one entry covers every
+ad-hoc request; a second entry with a narrower instruction ("Translate the
+following text into German. Return only the translation.") stays a dedicated
+command.
+
+It also works from a compositor keybind:
+`bind = $mainMod SHIFT, B, exec, whisrs llm-command ask` on Hyprland,
+`bindsym $mod+Shift+b exec whisrs llm-command ask` on Sway.
+
+### What happens to the LLM's reply
+
+The following applies to `whisrs command` and to every `[[llm_commands]]` entry,
+since both type the model's reply at the cursor.
+
+- **A wrapping code fence is removed.** If the whole reply is one fenced block,
+  the fence goes and the body is typed. A reply containing several fenced blocks
+  is prose about code, not a wrapper, and is left as it came.
+  There is no opt-out, and that is a real limitation: an `[[llm_commands]]` entry
+  whose instruction genuinely asks for a fenced block ("wrap this in a python
+  code fence") cannot produce one — the fence is stripped on the way to the
+  cursor, and no config key turns that off. If you need the fence characters
+  themselves, type them yourself around the result.
+- **Multi-line replies are typed normally**, except into a terminal. Translating
+  a paragraph or drafting an email is exactly what these commands are for, so
+  the line breaks are kept.
+- **A multi-line reply is refused when the focused window is a terminal.** There
+  a line break is an Enter, which would run a command before you have read it.
+  The text is not lost: it goes to the history, so `whisrs log` prints it and you
+  can copy it from there. Ask for a one-liner to get an injected result.
+  You are told when this happens: the "not typed" notification fires even with
+  `[general] notify = false`, because that setting means "don't narrate normal
+  operation", not "discard my dictation quietly".
+
+The refusal also applies with `[input] paste = true`, where the risk is lower
+but not gone. Pasting into a terminal sends Ctrl+Shift+V, and a terminal with
+bracketed paste enabled inserts multi-line text literally instead of running
+each line — but bracketed paste is the foreground program's choice, not the
+terminal's, and it is off inside many TUI programs and in some readline modes.
+whisrs cannot see which is the case from the window class alone, and refusing
+wrongly costs you one `whisrs log` lookup where injecting wrongly runs commands
+you never read, so it refuses either way.
+
+Terminal detection needs the compositor to report the focused window class,
+which today means Hyprland and Niri. On KDE, GNOME, Sway and X11 a terminal is
+treated as an ordinary target, so a multi-line reply is typed there. Add any
+class the built-in list misses to `[input] terminal_classes`.
 
 ## Environment variables
 

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, Result};
 use dialoguer::{Confirm, Editor, Input, Select};
 
 use crate::config::setup;
-use crate::{Config, RestartOutcome};
+use crate::{Config, HotkeyConfig, RestartOutcome};
 
 use setup::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
@@ -411,21 +411,48 @@ fn edit_hotkeys(config: &mut Config) -> Result<()> {
          `whisrs toggle` instead.{RESET}"
     );
 
+    // Prompt for every field, in struct order. A field left out of this list
+    // is silently destroyed: the editor rewrites the whole `[hotkeys]` table
+    // from this struct, and `any_hotkey_set` below drops the table entirely
+    // when the prompted fields all come back blank — taking the unprompted
+    // ones with it. That was live data loss for `speak`: editing hotkeys and
+    // clearing toggle/cancel/command deleted a configured read-aloud binding
+    // the editor never showed.
     let mut hotkeys = config.hotkeys.clone().unwrap_or_default();
     hotkeys.toggle = prompt_optional_string("Toggle hotkey", &hotkeys.toggle)?;
     hotkeys.cancel = prompt_optional_string("Cancel hotkey", &hotkeys.cancel)?;
     hotkeys.command = prompt_optional_string("Command-mode hotkey", &hotkeys.command)?;
+    hotkeys.speak = prompt_optional_string("Read-aloud hotkey", &hotkeys.speak)?;
 
     // Drop the whole section if every field is empty — keeps the TOML clean.
-    let any_set = hotkeys.toggle.is_some() || hotkeys.cancel.is_some() || hotkeys.command.is_some();
-    config.hotkeys = if any_set { Some(hotkeys) } else { None };
+    config.hotkeys = if any_hotkey_set(&hotkeys) {
+        Some(hotkeys)
+    } else {
+        None
+    };
     Ok(())
+}
+
+/// Whether any hotkey in the section is bound.
+///
+/// Must consider every field of [`HotkeyConfig`]: a field missed here reads as
+/// "the section is empty" and deletes the user's other bindings along with it.
+fn any_hotkey_set(hotkeys: &HotkeyConfig) -> bool {
+    let HotkeyConfig {
+        toggle,
+        cancel,
+        command,
+        speak,
+    } = hotkeys;
+    toggle.is_some() || cancel.is_some() || command.is_some() || speak.is_some()
 }
 
 fn prompt_optional_string(label: &str, current: &Option<String>) -> Result<Option<String>> {
     let default = current.clone().unwrap_or_default();
     let input: String = Input::new()
-        .with_prompt(format!("{label} (leave blank to unset)"))
+        // Enter keeps the shown default, so an existing value cannot be cleared
+        // by submitting an empty line. Type a space to unset one.
+        .with_prompt(format!("{label} (space to unset)"))
         .default(default)
         .allow_empty(true)
         .interact_text()
@@ -817,4 +844,76 @@ fn parse_csv_list(input: &str) -> Vec<String> {
         .filter(|s| !s.is_empty())
         .map(str::to_string)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every field name of `[hotkeys]`, taken from serde rather than a hand-
+    /// written list so a new field cannot be forgotten here too.
+    fn hotkey_field_names() -> Vec<String> {
+        let all_set = HotkeyConfig {
+            toggle: Some("a".into()),
+            cancel: Some("b".into()),
+            command: Some("c".into()),
+            speak: Some("d".into()),
+        };
+        let json = serde_json::to_value(&all_set).expect("HotkeyConfig serializes");
+        json.as_object()
+            .expect("HotkeyConfig is a struct")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// The editor rewrites the whole `[hotkeys]` table from the struct, so a
+    /// field it never prompts for is blanked on save. Assert the prompt list
+    /// covers every field — this is the half of the bug a value test cannot
+    /// see, since the prompting itself is interactive IO.
+    #[test]
+    fn edit_hotkeys_prompts_for_every_field() {
+        let source = include_str!("edit.rs");
+        let body = source
+            .split("fn edit_hotkeys(")
+            .nth(1)
+            .expect("edit.rs defines edit_hotkeys")
+            .split("\nfn ")
+            .next()
+            .expect("edit_hotkeys has a body");
+
+        for field in hotkey_field_names() {
+            assert!(
+                body.contains(&format!("hotkeys.{field} = prompt_optional_string")),
+                "edit_hotkeys never prompts for `{field}`, so editing hotkeys deletes it"
+            );
+        }
+    }
+
+    /// A section with nothing bound is dropped, keeping the TOML clean.
+    #[test]
+    fn an_empty_hotkey_section_is_dropped() {
+        assert!(!any_hotkey_set(&HotkeyConfig::default()));
+    }
+
+    /// Any single binding keeps the section. Before this was widened, a set
+    /// `speak` with the other three blank read as empty and the binding was
+    /// deleted on save.
+    #[test]
+    fn any_single_binding_keeps_the_section() {
+        for field in hotkey_field_names() {
+            let mut hotkeys = HotkeyConfig::default();
+            match field.as_str() {
+                "toggle" => hotkeys.toggle = Some("Super+Shift+D".into()),
+                "cancel" => hotkeys.cancel = Some("Super+Shift+Escape".into()),
+                "command" => hotkeys.command = Some("Super+Shift+C".into()),
+                "speak" => hotkeys.speak = Some("Super+Shift+R".into()),
+                other => panic!("unhandled hotkey field `{other}` — add it to this test"),
+            }
+            assert!(
+                any_hotkey_set(&hotkeys),
+                "a lone `{field}` binding was treated as an empty section and dropped"
+            );
+        }
+    }
 }

--- a/src/daemon/command_mode.rs
+++ b/src/daemon/command_mode.rs
@@ -12,13 +12,41 @@ use whisrs::state::{Action, StateMachine};
 use whisrs::{Config, Response, State};
 
 use crate::context::{CommandModeContext, DaemonContext, DaemonState, LlmCommandContext};
-use crate::injection::{clear_line_via_keyboard, inject_text, is_terminal_class};
+use crate::injection::{
+    clear_line_via_keyboard, inject_text, is_terminal_class, prepare_llm_injection, LlmInjection,
+};
 use crate::notify::{send_notification, truncate_preview};
 use crate::pipeline::{
     format_api_error, format_no_microphone_error, save_history_entry, transcribe_batch_audio,
     BatchOptions,
 };
 use crate::selection::{acquire_selected_text, capture_selection};
+
+/// History `backend` tag for a command-mode result, alongside the `llm:<name>`
+/// tags the `[[llm_commands]]` path writes.
+///
+/// Command mode does not otherwise log — the rewritten text lands on screen,
+/// and the original is still there to compare against. It logs on exactly one
+/// path: a multi-line result refused at a terminal, where the history entry is
+/// the only surviving copy and what `whisrs log` recovers.
+const COMMAND_MODE_HISTORY_BACKEND: &str = "command";
+
+/// The toast for a multi-line reply refused at a terminal. `label` names the
+/// `[[llm_commands]]` entry; `None` is command mode, which has no name.
+///
+/// Names `whisrs log` on purpose: nothing was typed, so the history entry
+/// written alongside this toast is the only surviving copy of the text, and a
+/// message that does not say where it went is a message that loses it.
+fn refused_multi_line_message(label: Option<&str>) -> String {
+    let subject = match label {
+        Some(name) => format!("'{name}': result"),
+        None => "Result".to_string(),
+    };
+    format!(
+        "{subject} spans multiple lines and the target is a terminal — not typed. \
+         Recover it with 'whisrs log'."
+    )
+}
 
 /// Claim a command-session context (command mode or llm-command) when audio
 /// collection ends, moving the state machine Recording → Transcribing.
@@ -58,16 +86,20 @@ fn claim_session<T>(state_machine: &mut StateMachine, ctx: &mut Option<T>) -> Op
 /// [`claim_session`], then — only after the claim succeeded — take the
 /// neighbor state that belongs to this recording (the capture handle, in
 /// case a stop path didn't already drop it, e.g. the input device vanished
-/// and the channel closed on its own).
+/// and the channel closed on its own; and the start time, which the history
+/// entry a refused multi-line result falls back to needs).
 ///
 /// The gating is the point: a stale background task can reach this after
 /// `handle_cancel` discarded its session AND a new session has already
 /// started. Taking `audio_capture` before knowing the claim succeeded would
 /// strip the new session's live capture. On bail this mutates nothing.
-fn claim_command_mode_session(ds: &mut DaemonState) -> Option<CommandModeContext> {
+fn claim_command_mode_session(
+    ds: &mut DaemonState,
+) -> Option<(CommandModeContext, Option<std::time::Instant>)> {
     let ctx = claim_session(&mut ds.state_machine, &mut ds.command_mode)?;
     ds.audio_capture.take(); // ensure capture is dropped
-    Some(ctx)
+    let started_at = ds.recording_started_at.take();
+    Some((ctx, started_at))
 }
 
 /// The claim block of [`llm_command_background`]: claim the session via
@@ -160,10 +192,27 @@ async fn command_mode_start(
     // is later injected through the same wrapper dictation uses: typed by
     // default, pasted when `[input] paste` is set. Either way it replaces the
     // active selection in GUI apps and lands at the prompt cursor in terminals.
+    //
+    // Command mode requires a selection: every [`CaptureError`] variant aborts
+    // here, including both "nothing came back" ones. It does not fall back to
+    // writing text from scratch when the capture comes up empty. A fallback
+    // was tried and dropped: the two empty-shaped variants are
+    // indistinguishable from the user's point of view but not to act on
+    // (`ClipboardUnchanged` also fires when the user copied their live
+    // selection by hand), so a fallback either refuses the ambiguous case —
+    // and then almost never fires, since any clipboard content makes it
+    // ambiguous — or types over text the user is still looking at. Writing
+    // text with no selection is what an `[[llm_commands]]` entry with a
+    // generic "treat this as a request" instruction does (issue #91); it never
+    // captures a selection in the first place, so the question never comes up.
     info!("command mode: getting selected text");
     let selected_text = match capture_selection(&context).await {
         Ok(text) => text,
-        Err(message) => return Response::Error { message },
+        Err(error) => {
+            return Response::Error {
+                message: error.to_string(),
+            }
+        }
     };
 
     info!(
@@ -265,12 +314,12 @@ async fn command_mode_background(
     // claim, so a bail cannot strip state from a session that started after
     // the cancel. The lock is released before the slow transcribe/LLM
     // awaits in the inner fn.
-    let cmd_ctx = {
+    let claimed = {
         let mut ds = daemon_state.lock().await;
         claim_command_mode_session(&mut ds)
     };
 
-    let Some(cmd_ctx) = cmd_ctx else {
+    let Some((cmd_ctx, recording_started_at)) = claimed else {
         // Cancelled: `handle_cancel` already moved the machine to Idle (its
         // dispatcher broadcasts the state and it resets the overlay level),
         // so there is nothing to finalize — the recording is discarded.
@@ -278,7 +327,9 @@ async fn command_mode_background(
         return;
     };
 
-    if let Err(e) = command_mode_background_inner(&all_samples, cmd_ctx, &context).await {
+    if let Err(e) =
+        command_mode_background_inner(&all_samples, cmd_ctx, recording_started_at, &context).await
+    {
         let friendly = format_api_error(&e);
         error!("command mode: {e:#}");
         if context.notify_error() {
@@ -310,6 +361,7 @@ async fn command_mode_background(
 async fn command_mode_background_inner(
     all_samples: &[i16],
     cmd_ctx: CommandModeContext,
+    recording_started_at: Option<std::time::Instant>,
     context: &DaemonContext,
 ) -> Result<()> {
     if context.config.general.audio_feedback {
@@ -332,8 +384,65 @@ async fn command_mode_background_inner(
     info!("command mode: instruction = {:?}", instruction);
 
     // Send to LLM.
-    let result =
-        llm::rewrite_text(&cmd_ctx.llm_config, &cmd_ctx.selected_text, &instruction).await?;
+    let raw = llm::rewrite_text(&cmd_ctx.llm_config, &cmd_ctx.selected_text, &instruction).await?;
+
+    // Resolve the target before deciding what to do with the reply: the
+    // multi-line refusal below is conditional on it, and so is the paste combo
+    // further down.
+    //
+    // `is_terminal` can only ever be true where
+    // `WindowTracker::get_focused_window_class()` is actually implemented,
+    // which is Hyprland (`src/window/hyprland.rs:59`) and Niri
+    // (`src/window/niri.rs:79`). `src/window/mod.rs:23` defaults it to `None`,
+    // so on KWin, GNOME, Sway and X11 it stays false and terminals there fall
+    // back to plain injection at the cursor (and to plain Ctrl+V on the paste
+    // branch). Tracked in issues #70 and #71; not fixed here. The practical
+    // consequence for the gate is that on those compositors a multi-line reply
+    // is typed into a terminal rather than refused — the same exposure the
+    // line-clear already has.
+    let is_terminal = context
+        .window_tracker
+        .get_focused_window_class()
+        .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
+        .unwrap_or(false);
+
+    // Clean the reply and decide whether it may be typed here (shared with the
+    // `[[llm_commands]]` path — see `prepare_llm_injection`).
+    let result = match prepare_llm_injection(&raw, is_terminal) {
+        LlmInjection::Inject(text) => text,
+        LlmInjection::Empty => {
+            warn!("command mode: LLM returned no usable text");
+            if context.notify_error() {
+                send_notification("whisrs", "Command mode: LLM returned empty text");
+            }
+            return Ok(());
+        }
+        LlmInjection::RefusedMultiLine(text) => {
+            warn!(
+                "command mode: refusing to inject {} chars of multi-line text into a terminal",
+                text.len()
+            );
+            save_history_entry(
+                &text,
+                COMMAND_MODE_HISTORY_BACKEND,
+                &context.config.general.language,
+                recording_started_at
+                    .map(|t| t.elapsed().as_secs_f64())
+                    .unwrap_or(0.0),
+            );
+            // Fired UNCONDITIONALLY — deliberately not behind
+            // `notify_error()`, unlike every other toast in this file. The
+            // others report progress or a failure; this one is different in
+            // kind, because it *withholds text the user would otherwise have
+            // received*, and the history entry just written is the only
+            // surviving copy. `notify = false` means "do not narrate normal
+            // operation", not "silently discard my work": gated, this outcome
+            // is a `warn!` in the journal that nobody reads, and from the
+            // user's chair the dictation simply vanished.
+            send_notification("whisrs", &refused_multi_line_message(None));
+            return Ok(());
+        }
+    };
 
     // Inject the result at the cursor through the same policy wrapper the
     // dictation path uses. By default that means typing keystrokes through
@@ -348,12 +457,8 @@ async fn command_mode_background_inner(
     // same reason it does for dictation: on compositors without the Wayland
     // virtual-keyboard protocol (e.g. KWin) uinput keycodes are decoded
     // through the target window's active XKB layout and can come out garbled,
-    // and the clipboard is layout-independent. `is_terminal` only picks
-    // Ctrl+Shift+V over Ctrl+V there; nothing else keys off it. It can only
-    // ever be true under Hyprland and Niri: `get_focused_window_class()`
-    // defaults to `None` for every other tracker (KWin, GNOME, Sway, X11),
-    // so terminals get plain Ctrl+V there. Same gap as the dictation path
-    // above; tracked in issues #70 and #71.
+    // and the clipboard is layout-independent. On that branch `is_terminal`
+    // only picks Ctrl+Shift+V over Ctrl+V.
     //
     // GUI apps: typing (or pasting) while text is selected replaces the
     // selection. That is text-widget behavior in GTK, Qt and Electron, and it
@@ -365,24 +470,11 @@ async fn command_mode_background_inner(
     // inject, so the result replaces the highlighted command instead of being
     // tacked onto it. The clear is best-effort: if it fails we still inject,
     // because appending the LLM result beats losing it.
-    //
-    // `is_terminal` can only ever be true where
-    // `WindowTracker::get_focused_window_class()` is actually implemented,
-    // which is Hyprland (`src/window/hyprland.rs:59`) and Niri
-    // (`src/window/niri.rs:79`). `src/window/mod.rs:23` defaults it to `None`,
-    // so on KWin, GNOME, Sway and X11 it stays false and terminals there fall
-    // back to plain injection at the cursor (and to plain Ctrl+V on the paste
-    // branch). Tracked in issues #70 and #71; not fixed here.
     info!("command mode: injecting {} chars", result.len());
     let text_clone = result.clone();
     let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
     let injector_backend = context.config.input.backend;
     let paste = context.config.input.paste;
-    let is_terminal = context
-        .window_tracker
-        .get_focused_window_class()
-        .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
-        .unwrap_or(false);
     match tokio::task::spawn_blocking(move || {
         if is_terminal {
             if let Err(e) = clear_line_via_keyboard(key_delay, injector_backend) {
@@ -768,20 +860,11 @@ async fn llm_command_background_inner(
         text.len()
     );
 
-    let result = llm::rewrite_text(&cmd_ctx.llm_config, &text, &cmd_ctx.instruction).await?;
+    let raw = llm::rewrite_text(&cmd_ctx.llm_config, &text, &cmd_ctx.instruction).await?;
 
-    if result.is_empty() {
-        if context.notify_error() {
-            send_notification(
-                "whisrs",
-                &format!("'{}': LLM returned empty text", cmd_ctx.name),
-            );
-        }
-        return Ok(());
-    }
-
-    // Restore window focus, then inject the result at the cursor — keystrokes,
-    // or clipboard paste when `[input] paste = true` (layout-independent).
+    // Restore window focus before anything else looks at what is focused: the
+    // gate below and the paste combo both key off the target window, and the
+    // focus may have moved during the recording.
     if let Some(wid) = &window_id {
         if let Err(e) = context.window_tracker.focus_window(wid) {
             warn!("failed to restore window focus: {e}");
@@ -790,19 +873,64 @@ async fn llm_command_background_inner(
         }
     }
 
+    // Resolved unconditionally, not just on the paste branch: the multi-line
+    // gate needs it too. Same #70/#71 caveat as command mode — only Hyprland
+    // and Niri implement `get_focused_window_class()`, so elsewhere this stays
+    // false and a terminal there is treated as an ordinary target.
+    let is_terminal = context
+        .window_tracker
+        .get_focused_window_class()
+        .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
+        .unwrap_or(false);
+
+    let duration_secs = recording_started_at
+        .map(|t| t.elapsed().as_secs_f64())
+        .unwrap_or(0.0);
+    let history_backend = format!("llm:{}", cmd_ctx.name);
+
+    // Clean the reply and decide whether it may be typed here — the same gate
+    // command mode uses. Multi-line output is normal for these commands
+    // (translate a paragraph, draft an email) and is injected as-is; it is only
+    // refused when the target is a terminal, where a line break is an Enter.
+    let result = match prepare_llm_injection(&raw, is_terminal) {
+        LlmInjection::Inject(text) => text,
+        LlmInjection::Empty => {
+            if context.notify_error() {
+                send_notification(
+                    "whisrs",
+                    &format!("'{}': LLM returned empty text", cmd_ctx.name),
+                );
+            }
+            return Ok(());
+        }
+        LlmInjection::RefusedMultiLine(text) => {
+            warn!(
+                "llm-command '{}': refusing to inject {} chars of multi-line text into a terminal",
+                cmd_ctx.name,
+                text.len()
+            );
+            save_history_entry(
+                &text,
+                &history_backend,
+                &context.config.general.language,
+                duration_secs,
+            );
+            // Fired UNCONDITIONALLY — see the matching arm in
+            // `command_mode_background_inner` for why this one toast bypasses
+            // the notify gate: it withholds text the user would otherwise
+            // have received, and `notify = false` means "do not narrate
+            // normal operation", not "silently discard my work".
+            send_notification("whisrs", &refused_multi_line_message(Some(&cmd_ctx.name)));
+            return Ok(());
+        }
+    };
+
+    // Inject at the cursor — keystrokes, or clipboard paste when
+    // `[input] paste = true` (layout-independent).
     let result_clone = result.clone();
     let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
     let injector_backend = context.config.input.backend;
     let paste = context.config.input.paste;
-    let is_terminal = if paste {
-        context
-            .window_tracker
-            .get_focused_window_class()
-            .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
-            .unwrap_or(false)
-    } else {
-        false
-    };
     match tokio::task::spawn_blocking(move || {
         inject_text(
             &result_clone,
@@ -825,12 +953,9 @@ async fn llm_command_background_inner(
         ),
     }
 
-    let duration_secs = recording_started_at
-        .map(|t| t.elapsed().as_secs_f64())
-        .unwrap_or(0.0);
     save_history_entry(
         &result,
-        &format!("llm:{}", cmd_ctx.name),
+        &history_backend,
         &context.config.general.language,
         duration_secs,
     );
@@ -849,6 +974,7 @@ async fn llm_command_background_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::selection::CaptureError;
 
     fn recording_machine() -> StateMachine {
         let mut sm = StateMachine::new();
@@ -1014,6 +1140,151 @@ mod tests {
         assert!(ds.llm_command.is_none());
         assert!(ds.recording_window_id.is_none());
         assert!(ds.recording_started_at.is_none());
+    }
+
+    /// The success half of the command-mode claim helper: an uncancelled stop
+    /// claims the context (consuming the slot), hands back this session's
+    /// start time — the history entry a terminal-refused multi-line result
+    /// falls back to needs the duration — clears that field, and enters
+    /// Transcribing.
+    #[test]
+    fn command_mode_claim_takes_own_session_state_on_success() {
+        let mut ds = DaemonState::new();
+        ds.state_machine.transition(Action::Toggle).unwrap();
+        ds.command_mode = Some(CommandModeContext {
+            selected_text: "selected".to_string(),
+            llm_config: Default::default(),
+        });
+        ds.recording_started_at = Some(std::time::Instant::now());
+
+        let (ctx, started_at) =
+            claim_command_mode_session(&mut ds).expect("live session must be claimed");
+
+        assert_eq!(ctx.selected_text, "selected");
+        assert!(started_at.is_some());
+        assert_eq!(ds.state_machine.state(), State::Transcribing);
+        assert!(ds.command_mode.is_none());
+        assert!(ds.recording_started_at.is_none());
+    }
+
+    /// Command mode *requires* a selection: every [`CaptureError`] variant —
+    /// including the two whose wording says "no text selected" — aborts the
+    /// session. `command_mode_start` renders the variant's `Display` into
+    /// `Response::Error` with no branching, which is what this pins: no
+    /// variant may be silently reinterpreted as "proceed with an empty
+    /// selection" (issue #91's rejected fallback).
+    #[test]
+    fn every_capture_error_aborts_command_mode_with_its_own_message() {
+        let cases = [
+            (
+                CaptureError::NothingSelected,
+                "no text selected — select some text first",
+            ),
+            (
+                CaptureError::ClipboardUnchanged,
+                "no text selected — select some text first",
+            ),
+            (
+                CaptureError::CopyFailed("uinput permission denied".to_string()),
+                "failed to copy selection: uinput permission denied",
+            ),
+            (
+                CaptureError::CopyTaskPanicked("task 12 panicked".to_string()),
+                "copy task panicked: task 12 panicked",
+            ),
+            (
+                CaptureError::ClipboardReadFailed("connection refused".to_string()),
+                "failed to read clipboard: connection refused",
+            ),
+        ];
+        for (error, expected) in cases {
+            // The exact expression `command_mode_start` evaluates on the error
+            // arm, byte-for-byte what the CLI prints and the toast shows.
+            let response = Response::Error {
+                message: error.to_string(),
+            };
+            let Response::Error { message } = response else {
+                panic!("capture failures must abort command mode");
+            };
+            assert_eq!(message, expected, "{error:?}");
+        }
+    }
+
+    /// The refusal message must name `whisrs log`, in both flavors: it is the
+    /// only place the text still exists, so a message that omits it turns a
+    /// recoverable result into a lost one.
+    #[test]
+    fn the_refusal_message_names_the_recovery_path() {
+        for label in [None, Some("german")] {
+            let message = refused_multi_line_message(label);
+            assert!(
+                message.contains("whisrs log"),
+                "{message:?} does not tell the user how to recover the text"
+            );
+            assert!(
+                message.contains("not typed"),
+                "{message:?} does not say the text was withheld"
+            );
+        }
+        assert!(refused_multi_line_message(Some("german")).starts_with("'german':"));
+    }
+
+    /// The refusal toast must never sit behind the notify gate.
+    ///
+    /// There is no runtime seam for this: `send_notification` spawns a D-Bus
+    /// thread, and reaching the arm needs a `DaemonContext` with a live window
+    /// tracker, transcription backend and audio device. What *is* testable is
+    /// the shape of the two call sites — both must notify, and neither may be
+    /// wrapped in `notify_error()` / `context.notify`. Gated, this outcome is a
+    /// `warn!` in the journal and nothing on screen, so a user with
+    /// notifications off just watches their dictation disappear.
+    #[test]
+    fn the_multi_line_refusal_notifies_unconditionally() {
+        // Everything before the test module — so the string literals in this
+        // very test cannot match themselves.
+        let production = include_str!("command_mode.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("the file has a production half");
+
+        let arms: Vec<String> = production
+            .split("LlmInjection::RefusedMultiLine(text) => {")
+            .skip(1)
+            .map(|rest| {
+                let arm = rest
+                    .split("return Ok(());")
+                    .next()
+                    .expect("the arm returns Ok");
+                // Comment lines are stripped: these arms explain *why* they
+                // bypass the notify gate, and naming it in prose must not read
+                // as calling it.
+                arm.lines()
+                    .filter(|line| !line.trim_start().starts_with("//"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .collect();
+        assert_eq!(
+            arms.len(),
+            2,
+            "command mode and llm-command each have exactly one refusal arm"
+        );
+
+        for arm in arms {
+            assert!(
+                arm.contains("send_notification("),
+                "a refusal arm that does not notify discards the result silently"
+            );
+            assert!(
+                !arm.contains("notify_error()"),
+                "the refusal toast must not be gated by notify_error() — \
+                 `notify = false` must not mean `discard my work silently`"
+            );
+            assert!(
+                !arm.contains("context.notify"),
+                "the refusal toast must not be gated by the notify flag at all"
+            );
+        }
     }
 
     /// A plain `whisrs toggle` on a command-mode / llm-command recording:

--- a/src/daemon/injection.rs
+++ b/src/daemon/injection.rs
@@ -3,9 +3,73 @@ use std::sync::{Mutex as StdMutex, OnceLock};
 use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
 
+use whisrs::llm;
 use whisrs::InjectorBackend;
 
 static KEYBOARD: OnceLock<StdMutex<Option<Box<dyn xkb_type::KeyInjector>>>> = OnceLock::new();
+
+/// What may be done with an LLM reply that is headed for the cursor, decided
+/// by [`prepare_llm_injection`].
+///
+/// Three-way rather than a `String`, because two of the outcomes must not
+/// reach the injector and the caller has to tell the user which one happened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LlmInjection {
+    /// Cleaned text, safe to inject at this target.
+    Inject(String),
+    /// Nothing usable came back: an empty reply, an all-whitespace one, or a
+    /// code fence with nothing in it.
+    Empty,
+    /// Multi-line text aimed at a terminal. Never injected — see
+    /// [`prepare_llm_injection`]. Carries the cleaned text so the caller can
+    /// put it in the history log instead of dropping it.
+    RefusedMultiLine(String),
+}
+
+/// Clean an LLM reply and decide whether it may be injected at the current
+/// target. Shared by `whisrs command` and `[[llm_commands]]`.
+///
+/// Two rules, and only one of them is absolute:
+///
+/// * **Cleaning is unconditional.** [`llm::clean_llm_output`] normalizes line
+///   endings and strips a code fence wrapping the whole reply, everywhere. A
+///   fenced reply is never what the user wanted typed.
+/// * **The multi-line refusal is conditional on the target.** A line break is
+///   only dangerous where it *submits*: at a shell prompt it is an Enter that
+///   runs a command the user has not read. Everywhere else a multi-line reply
+///   is the normal, wanted result — translating a paragraph, drafting an
+///   email, reformatting a list — so refusing it outright would break the
+///   feature it was meant to protect. Hence `is_terminal`, resolved by the
+///   caller from the focused window class.
+///
+/// Truncating to the first line was considered and rejected for the terminal
+/// case: `cd /tmp` out of `cd /tmp` + `rm -rf x` is a different, still
+/// destructive command. Refusing costs one retry and loses nothing — the text
+/// comes back in [`LlmInjection::RefusedMultiLine`] for the history log, where
+/// `whisrs log` recovers it.
+///
+/// **`[input] paste` is deliberately not a parameter.** The refusal fires the
+/// same way under `paste = true`, where the hazard is weaker: that path sends
+/// Ctrl+Shift+V, and a terminal with bracketed paste enabled inserts the whole
+/// multi-line text literally instead of running each line. Weaker is not
+/// absent. Bracketed paste is the *foreground program's* choice, not the
+/// terminal's — it is off inside plenty of TUI programs and in some readline
+/// modes — so from here, with only the window class to go on, we cannot know
+/// whether it is on at the moment the keystroke lands. The trade is asymmetric:
+/// refusing wrongly costs one `whisrs log` lookup, injecting wrongly runs
+/// commands the user never read. So the gate stays target-shaped, not
+/// injection-method-shaped, and this function keeps a signature that cannot
+/// express the weaker rule.
+pub(crate) fn prepare_llm_injection(raw: &str, is_terminal: bool) -> LlmInjection {
+    let cleaned = llm::clean_llm_output(raw);
+    if cleaned.is_empty() {
+        return LlmInjection::Empty;
+    }
+    if is_terminal && llm::contains_line_break(&cleaned) {
+        return LlmInjection::RefusedMultiLine(cleaned);
+    }
+    LlmInjection::Inject(cleaned)
+}
 
 /// Type text at the cursor using uinput (keyboard injection) or clipboard paste.
 pub(crate) fn type_text_at_cursor(
@@ -485,6 +549,119 @@ mod tests {
     /// `[input] terminal_classes` as the daemon hands it over.
     fn user(classes: &[&str]) -> Vec<String> {
         classes.iter().map(|c| c.to_string()).collect()
+    }
+
+    const TERMINAL: bool = true;
+    const NOT_A_TERMINAL: bool = false;
+
+    /// The reported defect, end to end: the model wraps a one-line command in
+    /// a fence, and it is unwrapped and injected at either target.
+    #[test]
+    fn a_fenced_one_liner_is_unwrapped_and_injected_anywhere() {
+        for target in [TERMINAL, NOT_A_TERMINAL] {
+            assert_eq!(
+                prepare_llm_injection("```bash\nsudo pacman -S steam\n```", target),
+                LlmInjection::Inject("sudo pacman -S steam".to_string()),
+                "is_terminal = {target}"
+            );
+        }
+    }
+
+    /// Cleaning does not depend on the target: padding and a wrapping fence go
+    /// in both directions. Only the multi-line verdict is conditional.
+    #[test]
+    fn cleaning_is_unconditional() {
+        for target in [TERMINAL, NOT_A_TERMINAL] {
+            assert_eq!(
+                prepare_llm_injection("  \n  Wo ist der Bahnhof?  \n", target),
+                LlmInjection::Inject("Wo ist der Bahnhof?".to_string())
+            );
+            assert_eq!(
+                prepare_llm_injection("```\nsudo pacman -S steam\n```\n", target),
+                LlmInjection::Inject("sudo pacman -S steam".to_string())
+            );
+        }
+    }
+
+    /// The hazard: a line break typed at a shell prompt is an Enter that runs
+    /// a command the user has not read. Refused, with the text handed back for
+    /// the history log rather than dropped.
+    #[test]
+    fn multi_line_output_is_refused_at_a_terminal() {
+        assert_eq!(
+            prepare_llm_injection("```sh\ncd /tmp\nrm -rf x\n```", TERMINAL),
+            LlmInjection::RefusedMultiLine("cd /tmp\nrm -rf x".to_string()),
+            "the refusal must carry the cleaned text, not drop it"
+        );
+    }
+
+    /// The correction that makes the gate shareable: refusing *all* multi-line
+    /// output would break the llm-command uses that produce it on purpose — a
+    /// translated paragraph, a drafted email, a reformatted list. Away from a
+    /// terminal there is nothing to submit, so it is injected normally.
+    #[test]
+    fn multi_line_output_is_injected_when_the_target_is_not_a_terminal() {
+        let email = "Hi Sam,\n\nThe kitchen tap is leaking.\n\nThanks,\nAlex";
+        assert_eq!(
+            prepare_llm_injection(email, NOT_A_TERMINAL),
+            LlmInjection::Inject(email.to_string())
+        );
+        assert_eq!(
+            prepare_llm_injection("```python\ndef f():\n    return 1\n```", NOT_A_TERMINAL),
+            LlmInjection::Inject("def f():\n    return 1".to_string()),
+            "the fence still goes; only the refusal is terminal-only"
+        );
+    }
+
+    /// CRLF and a bare CR are normalized before the verdict, so a `\r` can
+    /// never slip through to the keymap (which taps it as a real Enter). At a
+    /// terminal that means refused, not silently typed.
+    #[test]
+    fn carriage_returns_are_normalized_before_the_verdict() {
+        assert_eq!(
+            prepare_llm_injection("echo one\r\necho two", TERMINAL),
+            LlmInjection::RefusedMultiLine("echo one\necho two".to_string())
+        );
+        assert_eq!(
+            prepare_llm_injection("echo one\recho two", TERMINAL),
+            LlmInjection::RefusedMultiLine("echo one\necho two".to_string())
+        );
+        // A trailing CRLF is padding on a single-line answer, not a second line.
+        assert_eq!(
+            prepare_llm_injection("sudo pacman -S steam\r\n", TERMINAL),
+            LlmInjection::Inject("sudo pacman -S steam".to_string())
+        );
+    }
+
+    /// Content on the fence line is never dropped, so such a reply stays
+    /// multi-line and a terminal target refuses it — the user is told rather
+    /// than handed a different command from the one the model wrote.
+    #[test]
+    fn a_fence_line_carrying_content_is_refused_not_truncated() {
+        let LlmInjection::RefusedMultiLine(text) =
+            prepare_llm_injection("```bash echo hi\nrm -rf /tmp/x\n```", TERMINAL)
+        else {
+            panic!("a reply with content on the fence line is multi-line");
+        };
+        assert!(
+            text.contains("echo hi"),
+            "content on the fence line must survive, got {text:?}"
+        );
+    }
+
+    /// Nothing usable came back. Reported as its own outcome so the caller
+    /// toasts instead of injecting nothing and logging an empty entry.
+    #[test]
+    fn an_unusable_reply_is_reported_as_empty() {
+        for reply in ["", "   ", "\n\t\n", "\r\n", "```\n```", "```bash\n\n```"] {
+            for target in [TERMINAL, NOT_A_TERMINAL] {
+                assert_eq!(
+                    prepare_llm_injection(reply, target),
+                    LlmInjection::Empty,
+                    "{reply:?} at is_terminal = {target}"
+                );
+            }
+        }
     }
 
     /// Real-world strings, in the casing a compositor hands them to us: bare

--- a/src/daemon/selection.rs
+++ b/src/daemon/selection.rs
@@ -15,6 +15,53 @@ const COPY_SETTLE_DELAY: Duration = Duration::from_millis(250);
 /// the focused app time to service the copy.
 const COPY_READ_DELAY: Duration = Duration::from_millis(100);
 
+/// Why [`capture_selection`] came back with no text.
+///
+/// Typed rather than stringly, because "nothing came back" is not one fact.
+/// [`NothingSelected`] is a statement about the user (they had nothing
+/// highlighted); [`ClipboardUnchanged`] is a statement about the *capture* (it
+/// could not tell whether they did) — the copy handed back exactly the bytes
+/// the clipboard already held, which happens both when nothing was selected
+/// and when the user selected text and pressed Ctrl+C before invoking whisrs.
+///
+/// **No caller branches on the variant today** — read-aloud and command mode
+/// abort on every one of them, so the type is currently a better-typed way of
+/// carrying the same message. It is worth keeping anyway: the distinction is
+/// the precondition any caller would need before proceeding on "the user
+/// selected nothing". Proceeding means typing at the cursor, typing while a
+/// real selection is live *replaces* it, and only [`NothingSelected`] rules
+/// that out. Collapsing the two would hand such a caller the ambiguous case
+/// with no way to tell, which is the destructive direction.
+///
+/// The `Display` strings are byte-identical to the `String` errors
+/// [`capture_selection`] returned before it was typed, so read-aloud's error
+/// toast and `Response::Error` message are unchanged for every variant.
+///
+/// [`NothingSelected`]: CaptureError::NothingSelected
+/// [`ClipboardUnchanged`]: CaptureError::ClipboardUnchanged
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum CaptureError {
+    /// The clipboard was empty after the copy: nothing was selected, full
+    /// stop. The only variant a caller could safely read as "the user
+    /// highlighted nothing" — see the type-level doc.
+    #[error("no text selected — select some text first")]
+    NothingSelected,
+    /// The copy returned the bytes already on the clipboard. Ambiguous: no
+    /// selection *or* a selection the user had just copied. Never treated as
+    /// an empty selection — see the type-level doc.
+    #[error("no text selected — select some text first")]
+    ClipboardUnchanged,
+    /// The simulated Ctrl+C could not be sent (no uinput permission, ...).
+    #[error("failed to copy selection: {0}")]
+    CopyFailed(String),
+    /// The blocking copy task panicked.
+    #[error("copy task panicked: {0}")]
+    CopyTaskPanicked(String),
+    /// The clipboard could not be read back after the copy.
+    #[error("failed to read clipboard: {0}")]
+    ClipboardReadFailed(String),
+}
+
 /// Simulate a key combo (e.g. Ctrl+C, Ctrl+V) via a temporary uinput device.
 fn simulate_key_combo(modifier: evdev::Key, key: evdev::Key) -> anyhow::Result<()> {
     use evdev::{AttributeSet, EventType, InputEvent, Key};
@@ -143,7 +190,11 @@ fn instruction_from_capture(text: &str) -> Option<String> {
 /// needs no key simulation, so a non-empty primary selection is returned
 /// directly. This also avoids the clipboard-equality heuristic below — which
 /// only makes sense in the copy-fallback path — wrongly rejecting a selection
-/// that happens to equal the current clipboard.
+/// that happens to equal the current clipboard. That heuristic's ambiguity is
+/// why it reports [`CaptureError::ClipboardUnchanged`] rather than
+/// [`CaptureError::NothingSelected`]: only the latter is a statement about the
+/// user having highlighted nothing, and only the latter is safe for a caller
+/// to act on.
 ///
 /// When the primary selection is empty, fall back to a simulated Ctrl+C
 /// (Ctrl+Shift+C in terminals) and read the clipboard. A short settle delay
@@ -165,9 +216,11 @@ fn instruction_from_capture(text: &str) -> Option<String> {
 /// wasn't text, the fallback copy overwrites content that cannot be restored;
 /// a warning is logged before the copy fires (#80).
 ///
-/// Returns `Ok(text)` on success, or `Err(message)` describing why nothing was
-/// captured (caller surfaces this as a `Response::Error` + notification).
-pub(crate) async fn capture_selection(context: &DaemonContext) -> Result<String, String> {
+/// Returns `Ok(text)` on success, or a [`CaptureError`] saying why nothing was
+/// captured. Every caller today treats all variants alike, surfacing the
+/// `Display` as a `Response::Error` + notification; the variants exist for the
+/// distinction documented on [`CaptureError`], not for a live branch.
+pub(crate) async fn capture_selection(context: &DaemonContext) -> Result<String, CaptureError> {
     let clipboard = xkb_type::default_clipboard();
 
     // The terminal check is resolved lazily, inside the copy closure, so the
@@ -198,7 +251,7 @@ async fn capture_selection_impl<F>(
     copy: F,
     settle_delay: Duration,
     read_delay: Duration,
-) -> Result<String, String>
+) -> Result<String, CaptureError>
 where
     F: FnOnce() -> anyhow::Result<()> + Send + 'static,
 {
@@ -227,14 +280,14 @@ where
 
     match tokio::task::spawn_blocking(copy).await {
         Ok(Ok(())) => {}
-        Ok(Err(e)) => return Err(format!("failed to copy selection: {e}")),
-        Err(e) => return Err(format!("copy task panicked: {e}")),
+        Ok(Err(e)) => return Err(CaptureError::CopyFailed(e.to_string())),
+        Err(e) => return Err(CaptureError::CopyTaskPanicked(e.to_string())),
     }
 
     tokio::time::sleep(read_delay).await;
     let copied = clipboard
         .get_text()
-        .map_err(|e| format!("failed to read clipboard: {e}"))?;
+        .map_err(|e| CaptureError::ClipboardReadFailed(e.to_string()))?;
 
     // The copy clobbered the user's clipboard with the selection; put the
     // original back now that we've read it (see doc comment above). Skipped
@@ -263,10 +316,19 @@ where
         }
     }
 
-    // With no primary selection, an unchanged clipboard means the copy captured
-    // nothing (nothing selected, or the held hotkey garbled Ctrl+C).
-    if copied.is_empty() || saved_clipboard.as_deref() == Some(copied.as_str()) {
-        return Err("no text selected — select some text first".to_string());
+    // With no primary selection, nothing on the clipboard after the copy means
+    // the copy captured nothing — there was nothing to capture. Unambiguous.
+    if copied.is_empty() {
+        return Err(CaptureError::NothingSelected);
+    }
+
+    // An *unchanged* clipboard is a weaker signal wearing the same clothes:
+    // usually the copy was a no-op (nothing selected, or the held hotkey
+    // garbled Ctrl+C), but it reads identically when the user highlighted text
+    // and pressed Ctrl+C themselves a moment earlier. Reported as its own
+    // variant so callers can refuse to guess; the message is unchanged.
+    if saved_clipboard.as_deref() == Some(copied.as_str()) {
+        return Err(CaptureError::ClipboardUnchanged);
     }
 
     Ok(copied)
@@ -407,9 +469,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unchanged_clipboard_means_no_selection_and_no_restore() {
-        // The copy captured nothing: the clipboard still holds the original,
-        // so there is nothing to undo and no selection to return.
+    async fn unchanged_clipboard_is_reported_as_ambiguous_not_empty() {
+        // The copy returned what the clipboard already held. Usually that
+        // means nothing was selected — but it is not knowable from here, so
+        // it is `ClipboardUnchanged`, never `NothingSelected`. Nothing is
+        // written back either: there is nothing to undo.
         let clipboard = ScriptedClipboard::new("", &[Some("original"), Some("original")]);
         let fired = Arc::new(AtomicBool::new(false));
 
@@ -421,11 +485,58 @@ mod tests {
         )
         .await;
 
-        assert_eq!(
-            result,
-            Err("no text selected — select some text first".to_string())
-        );
+        assert_eq!(result, Err(CaptureError::ClipboardUnchanged));
         assert!(clipboard.writes().is_empty());
+    }
+
+    #[tokio::test]
+    async fn an_empty_clipboard_after_the_copy_is_nothing_selected() {
+        // The unambiguous case: nothing on the clipboard before, nothing
+        // after. This is the only variant a caller could read as "the user
+        // selected nothing" and act on.
+        let clipboard = ScriptedClipboard::new("", &[Some(""), Some("")]);
+        let fired = Arc::new(AtomicBool::new(false));
+
+        let result = capture_selection_impl(
+            &clipboard,
+            tracking_copy(Arc::clone(&fired)),
+            Duration::ZERO,
+            Duration::ZERO,
+        )
+        .await;
+
+        assert_eq!(result, Err(CaptureError::NothingSelected));
+        assert!(clipboard.writes().is_empty());
+    }
+
+    /// The destructive sequence from the #91 review: the user highlights
+    /// text, presses Ctrl+C out of habit, then fires the command hotkey. The
+    /// app doesn't publish a primary selection, so the fallback copy runs and
+    /// returns bytes identical to the clipboard the user just filled. The
+    /// selection is real and still live, so this must not be reported as
+    /// `NothingSelected`: that variant is the one a caller may act on by
+    /// typing at the cursor, and typing replaces a live selection.
+    #[tokio::test]
+    async fn ctrl_c_before_the_hotkey_is_never_reported_as_nothing_selected() {
+        let clipboard = ScriptedClipboard::new(
+            "",
+            &[
+                Some("the user's live selection"),
+                Some("the user's live selection"),
+            ],
+        );
+        let fired = Arc::new(AtomicBool::new(false));
+
+        let result = capture_selection_impl(
+            &clipboard,
+            tracking_copy(Arc::clone(&fired)),
+            Duration::ZERO,
+            Duration::ZERO,
+        )
+        .await;
+
+        assert_eq!(result, Err(CaptureError::ClipboardUnchanged));
+        assert_ne!(result, Err(CaptureError::NothingSelected));
     }
 
     #[tokio::test]
@@ -464,9 +575,61 @@ mod tests {
 
         assert_eq!(
             result,
-            Err("failed to copy selection: uinput unavailable".to_string())
+            Err(CaptureError::CopyFailed("uinput unavailable".to_string()))
         );
         assert!(clipboard.writes().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_clipboard_read_failure_after_the_copy_is_infrastructure() {
+        // Non-text (or unreadable) clipboard *after* the copy: the selection
+        // may well have been real, so this must never look like an empty
+        // selection to a caller.
+        let clipboard = ScriptedClipboard::new("", &[Some("original"), None]);
+        let fired = Arc::new(AtomicBool::new(false));
+
+        let result = capture_selection_impl(
+            &clipboard,
+            tracking_copy(Arc::clone(&fired)),
+            Duration::ZERO,
+            Duration::ZERO,
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Err(CaptureError::ClipboardReadFailed(
+                "clipboard holds non-text content".to_string()
+            ))
+        );
+    }
+
+    /// The user-visible half of the typed error. Read-aloud renders these
+    /// straight into its toast and `Response::Error`, so every variant's
+    /// wording is pinned byte-for-byte against what the untyped `String`
+    /// errors said before — the typing is invisible to the user.
+    #[test]
+    fn capture_error_messages_are_byte_identical_to_the_untyped_strings() {
+        assert_eq!(
+            CaptureError::NothingSelected.to_string(),
+            "no text selected — select some text first"
+        );
+        assert_eq!(
+            CaptureError::ClipboardUnchanged.to_string(),
+            "no text selected — select some text first"
+        );
+        assert_eq!(
+            CaptureError::CopyFailed("uinput unavailable".to_string()).to_string(),
+            "failed to copy selection: uinput unavailable"
+        );
+        assert_eq!(
+            CaptureError::CopyTaskPanicked("task 12 panicked".to_string()).to_string(),
+            "copy task panicked: task 12 panicked"
+        );
+        assert_eq!(
+            CaptureError::ClipboardReadFailed("connection refused".to_string()).to_string(),
+            "failed to read clipboard: connection refused"
+        );
     }
 
     #[test]

--- a/src/daemon/speak.rs
+++ b/src/daemon/speak.rs
@@ -81,12 +81,22 @@ pub(crate) async fn handle_speak(
         }
     };
 
-    // (c) Capture the selection. On failure (incl. empty), surface an error
-    // and — since this is hotkey-triggered — notify so the user sees why.
+    // (c) Capture the selection. On failure, surface an error and — since this
+    // is hotkey-triggered — notify so the user sees why.
+    //
+    // Every `CaptureError` variant is fatal here, deliberately: read-aloud has
+    // nothing to say without text. That includes both "nothing was selected"
+    // variants — `NothingSelected` (the clipboard came back empty) and
+    // `ClipboardUnchanged` (the capture could not tell). Only a caller that
+    // would proceed on an empty selection needs to tell them apart, and
+    // read-aloud never proceeds, so it just renders the variant's `Display`,
+    // whose wording is byte-identical across all of them and unchanged from
+    // before the error was typed.
     info!("speak: getting selected text");
     let selected_text = match capture_selection(&context).await {
         Ok(text) => text,
-        Err(message) => {
+        Err(error) => {
+            let message = error.to_string();
             if context.notify_error() {
                 send_notification("whisrs", &format!("Read-aloud: {message}"));
             }

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -40,98 +40,7 @@ pub async fn start_hotkey_listener(
     llm_commands: &[LlmCommandConfig],
     cmd_tx: mpsc::Sender<Command>,
 ) {
-    let mut actions = Vec::new();
-
-    if let Some(ref s) = config.toggle {
-        match parse_hotkey(s) {
-            Ok(binding) => {
-                info!("hotkey: toggle = {s}");
-                actions.push(HotkeyAction {
-                    binding,
-                    command: Command::Toggle { language: None },
-                });
-            }
-            Err(e) => warn!("invalid toggle hotkey '{s}': {e}"),
-        }
-    }
-
-    if let Some(ref s) = config.cancel {
-        match parse_hotkey(s) {
-            Ok(binding) => {
-                info!("hotkey: cancel = {s}");
-                actions.push(HotkeyAction {
-                    binding,
-                    command: Command::Cancel,
-                });
-            }
-            Err(e) => warn!("invalid cancel hotkey '{s}': {e}"),
-        }
-    }
-
-    if let Some(ref s) = config.command {
-        match parse_hotkey(s) {
-            Ok(binding) => {
-                info!("hotkey: command = {s}");
-                actions.push(HotkeyAction {
-                    binding,
-                    command: Command::CommandMode,
-                });
-            }
-            Err(e) => warn!("invalid command hotkey '{s}': {e}"),
-        }
-    }
-
-    if let Some(ref s) = config.speak {
-        match parse_hotkey(s) {
-            Ok(binding) => {
-                info!("hotkey: speak = {s}");
-                actions.push(HotkeyAction {
-                    binding,
-                    command: Command::Speak,
-                });
-            }
-            Err(e) => warn!("invalid speak hotkey '{s}': {e}"),
-        }
-    }
-
-    for entry in llm_commands {
-        match parse_hotkey(&entry.hotkey) {
-            Ok(binding) => {
-                info!("hotkey: llm-command '{}' = {}", entry.name, entry.hotkey);
-                actions.push(HotkeyAction {
-                    binding,
-                    command: Command::LlmCommand {
-                        name: entry.name.clone(),
-                    },
-                });
-            }
-            Err(e) => warn!(
-                "invalid hotkey '{}' for llm-command '{}': {e}",
-                entry.hotkey, entry.name
-            ),
-        }
-
-        if let Some(set_hotkey) = &entry.set_hotkey {
-            match parse_hotkey(set_hotkey) {
-                Ok(binding) => {
-                    info!(
-                        "hotkey: llm-command '{}' set-instruction = {}",
-                        entry.name, set_hotkey
-                    );
-                    actions.push(HotkeyAction {
-                        binding,
-                        command: Command::SetLlmInstruction {
-                            name: entry.name.clone(),
-                        },
-                    });
-                }
-                Err(e) => warn!(
-                    "invalid set_hotkey '{}' for llm-command '{}': {e}",
-                    set_hotkey, entry.name
-                ),
-            }
-        }
-    }
+    let actions = build_actions(config, llm_commands);
 
     if actions.is_empty() {
         debug!("no hotkeys configured");
@@ -204,6 +113,79 @@ pub async fn start_hotkey_listener(
             }
         });
     }
+}
+
+/// Build the dispatch table: every set `[hotkeys]` field, plus every
+/// `[[llm_commands]]` entry's `hotkey` and optional `set_hotkey`. Invalid
+/// specs are warned about and skipped, so one bad combo never disables the
+/// rest.
+///
+/// Split out of [`start_hotkey_listener`] — which needs real input devices and
+/// so cannot be unit-tested — because the failure this guards against is
+/// silent: a field added to [`HotkeyConfig`] but not listed here parses fine,
+/// validates fine, shows up in the config editor, and simply never fires.
+/// `every_fixed_hotkey_field_is_dispatched` below fails when that happens.
+fn build_actions(config: &HotkeyConfig, llm_commands: &[LlmCommandConfig]) -> Vec<HotkeyAction> {
+    let mut actions = Vec::new();
+
+    // Every field of `HotkeyConfig` must appear in this table.
+    let fixed = [
+        ("toggle", &config.toggle, Command::Toggle { language: None }),
+        ("cancel", &config.cancel, Command::Cancel),
+        ("command", &config.command, Command::CommandMode),
+        ("speak", &config.speak, Command::Speak),
+    ];
+    for (label, spec, command) in fixed {
+        let Some(spec) = spec else { continue };
+        match parse_hotkey(spec) {
+            Ok(binding) => {
+                info!("hotkey: {label} = {spec}");
+                actions.push(HotkeyAction { binding, command });
+            }
+            Err(e) => warn!("invalid {label} hotkey '{spec}': {e}"),
+        }
+    }
+
+    for entry in llm_commands {
+        match parse_hotkey(&entry.hotkey) {
+            Ok(binding) => {
+                info!("hotkey: llm-command '{}' = {}", entry.name, entry.hotkey);
+                actions.push(HotkeyAction {
+                    binding,
+                    command: Command::LlmCommand {
+                        name: entry.name.clone(),
+                    },
+                });
+            }
+            Err(e) => warn!(
+                "invalid hotkey '{}' for llm-command '{}': {e}",
+                entry.hotkey, entry.name
+            ),
+        }
+
+        if let Some(set_hotkey) = &entry.set_hotkey {
+            match parse_hotkey(set_hotkey) {
+                Ok(binding) => {
+                    info!(
+                        "hotkey: llm-command '{}' set-instruction = {}",
+                        entry.name, set_hotkey
+                    );
+                    actions.push(HotkeyAction {
+                        binding,
+                        command: Command::SetLlmInstruction {
+                            name: entry.name.clone(),
+                        },
+                    });
+                }
+                Err(e) => warn!(
+                    "invalid set_hotkey '{}' for llm-command '{}': {e}",
+                    set_hotkey, entry.name
+                ),
+            }
+        }
+    }
+
+    actions
 }
 
 /// Enumerate all keyboard input devices.
@@ -363,5 +345,85 @@ mod tests {
     fn right_hand_modifiers_are_equivalent() {
         let held: HashSet<Key> = HashSet::from([Key::KEY_RIGHTCTRL, Key::KEY_PAGEUP]);
         assert!(modifiers_held(&held, &[Key::KEY_LEFTCTRL]));
+    }
+
+    fn all_hotkeys_set() -> HotkeyConfig {
+        HotkeyConfig {
+            toggle: Some("Super+Shift+W".to_string()),
+            cancel: Some("Super+Shift+D".to_string()),
+            command: Some("Super+Shift+G".to_string()),
+            speak: Some("Super+Shift+R".to_string()),
+        }
+    }
+
+    /// Every field of [`HotkeyConfig`] must be wired to a command in
+    /// [`build_actions`]. Derived from serde rather than a hand-written count,
+    /// so a fifth field added to the struct fails here instead of shipping as
+    /// a binding that parses, validates, and silently never fires.
+    #[test]
+    fn every_fixed_hotkey_field_is_dispatched() {
+        let config = all_hotkeys_set();
+        let fields = toml::Value::try_from(&config)
+            .expect("HotkeyConfig serializes")
+            .as_table()
+            .expect("as a table")
+            .len();
+
+        let actions = build_actions(&config, &[]);
+        assert_eq!(
+            actions.len(),
+            fields,
+            "every set [hotkeys] field must produce a listener action — a new field \
+             needs a line in build_actions' `fixed` table"
+        );
+    }
+
+    /// Each field is wired to its own command — a mis-ordered `fixed` table
+    /// would silently send one key's press through another's handler.
+    #[test]
+    fn each_field_dispatches_its_own_command() {
+        let actions = build_actions(&all_hotkeys_set(), &[]);
+        for expected in [
+            Command::Toggle { language: None },
+            Command::Cancel,
+            Command::CommandMode,
+            Command::Speak,
+        ] {
+            assert_eq!(
+                actions
+                    .iter()
+                    .filter(
+                        |a| std::mem::discriminant(&a.command) == std::mem::discriminant(&expected)
+                    )
+                    .count(),
+                1,
+                "{expected:?} must be dispatched exactly once"
+            );
+        }
+    }
+
+    /// An unset binding registers nothing.
+    #[test]
+    fn an_unset_binding_registers_nothing() {
+        let config = HotkeyConfig {
+            command: Some("Super+Shift+G".to_string()),
+            ..Default::default()
+        };
+        let actions = build_actions(&config, &[]);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(actions[0].command, Command::CommandMode));
+    }
+
+    /// One invalid spec must not take the others down with it.
+    #[test]
+    fn an_invalid_binding_is_skipped_not_fatal() {
+        let config = HotkeyConfig {
+            toggle: Some("Super+Shift+W".to_string()),
+            speak: Some("NotAKey".to_string()),
+            ..Default::default()
+        };
+        let actions = build_actions(&config, &[]);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(actions[0].command, Command::Toggle { .. }));
     }
 }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,4 +1,4 @@
-//! LLM integration for command mode.
+//! LLM integration for command mode and `[[llm_commands]]`.
 //!
 //! Sends selected text + a voice instruction to an LLM chat API and returns
 //! the rewritten text. Supports any OpenAI-compatible `/chat/completions`
@@ -7,10 +7,25 @@
 //! `http://localhost:1234/v1/chat/completions` for LM Studio) and set
 //! `model` to whatever the server has loaded; local servers don't validate
 //! `api_key`, so any placeholder string works.
+//!
+//! One entry point, [`rewrite_text`], shared by both callers: `whisrs command`
+//! applies a spoken instruction to the text the user selected, and an
+//! `[[llm_commands]]` entry does the same with the roles swapped (dictated
+//! text + a preset instruction). A generic instruction — "treat the following
+//! text as a request and output only what is asked" — turns an entry into
+//! request-in / text-out generation, which is how issue #91's use case is
+//! served.
+//!
+//! Whatever comes back is typed at the user's cursor, so this module also owns
+//! the *text* side of making a reply safe to type: [`clean_llm_output`] strips
+//! the wrappers models add, and [`contains_line_break`] answers the one
+//! question the injection site needs in order to decide whether a reply may be
+//! sent to a terminal. The decision itself is not here — see
+//! `daemon/injection.rs`, which knows what is focused.
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Configuration for the LLM backend used in command mode.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,10 +97,33 @@ struct ChatRequest {
     temperature: f32,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct ChatMessage {
     role: String,
     content: String,
+}
+
+impl ChatMessage {
+    fn system(content: &str) -> Self {
+        Self {
+            role: "system".to_string(),
+            content: content.to_string(),
+        }
+    }
+
+    fn user(content: String) -> Self {
+        Self {
+            role: "user".to_string(),
+            content,
+        }
+    }
+
+    fn assistant(content: &str) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: content.to_string(),
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -103,60 +141,294 @@ struct ChatResponseMessage {
     content: String,
 }
 
-/// Send selected text and a voice instruction to the LLM, returning the rewritten text.
+/// System prompt shared by command mode and every `[[llm_commands]]` entry.
+///
+/// Whatever comes back is typed at the cursor, so a preamble ("Sure! Here's
+/// the command:"), a code fence, or wrapping quotes are not cosmetic — they
+/// are corrupt output. Saying so in prose is necessary but demonstrably not
+/// sufficient: this wording already forbade explanations, and gpt-4o-mini
+/// still answered "To install Steam on Arch Linux, you can use the following
+/// command: sudo pacman -S steam". [`REWRITE_EXAMPLES`] is the part that
+/// actually moves the model; the prose is kept short so it does not compete
+/// with the demonstrations.
+const REWRITE_SYSTEM_PROMPT: &str = "You are a text editing assistant. The user will give you some selected text and an instruction. \
+        Apply the instruction to the text and return ONLY the resulting text. \
+        Your reply is typed straight into whatever the user has focused, so it must contain the artifact and nothing else: \
+        no preamble, no explanation, no commentary, no surrounding quotes, no markdown formatting and no code fences.";
+
+/// One demonstration turn, in the same frame a real turn uses.
+struct RewriteExample {
+    /// Plays the role of the selection (command mode) or the dictated text
+    /// (`[[llm_commands]]`).
+    selected_text: &'static str,
+    instruction: &'static str,
+    /// The whole assistant reply. Bare artifact, no preamble.
+    reply: &'static str,
+}
+
+/// Few-shot turns prepended to every request.
+///
+/// The maintainer's report is the first one verbatim: asking for the Arch
+/// command to install Steam came back as a sentence with the command buried in
+/// it. Prose in the system prompt did not fix that, so the model is shown the
+/// shape instead of told it.
+///
+/// Chosen to span what a turn can produce, because a single shell-command
+/// example teaches "answer tersely" rather than "answer with only the
+/// artifact":
+///
+/// 1. a shell command — one line, no sentence around it;
+/// 2. a translation — the rewrite case, no "Translation:" label;
+/// 3. an email — **multi-line on purpose**, so terseness is not overgeneralized
+///    into "always answer in one line". Multi-line replies are legitimate and
+///    are injected normally everywhere except a terminal (see
+///    `daemon/injection.rs`).
+/// 4. a spelling fix on question-shaped input — the counterweight to 1 and 3.
+///
+/// The instruction on examples 1 and 3 is the generic "treat the following
+/// text as a request" wording from the documented generate recipe, so the
+/// examples double as the demonstration for that configuration. Left at that,
+/// two thirds of the set would demonstrate *request-fulfilment*, and a tuned
+/// `[[llm_commands]]` entry — "Fix the spelling. Return only the corrected
+/// text." — fed question-shaped dictation could have its question answered
+/// instead of its text corrected. Example 4 is the same question, under a
+/// transformation instruction, answered by transforming it: the instruction,
+/// not the shape of the text, decides which job is done. It is deliberately
+/// last, so it is the demonstration nearest the real request.
+const REWRITE_EXAMPLES: &[RewriteExample] = &[
+    RewriteExample {
+        selected_text: "what is the command to install steam on arch linux",
+        instruction: "Treat the following text as a request and output only what is asked.",
+        reply: "sudo pacman -S steam",
+    },
+    RewriteExample {
+        selected_text: "Where is the train station?",
+        instruction: "Translate the following text into German. Return only the translation.",
+        reply: "Wo ist der Bahnhof?",
+    },
+    RewriteExample {
+        selected_text: "write my landlord an email about the leaking kitchen tap and ask for a plumber this week",
+        instruction: "Treat the following text as a request and output only what is asked.",
+        reply: "Hi Sam,\n\nThe kitchen tap has started leaking and it is getting worse through the day. Could you arrange for a plumber to come round this week?\n\nThanks,\nAlex",
+    },
+    RewriteExample {
+        selected_text: "wht is teh comand to instal steam",
+        instruction: "Fix the spelling and grammar. Return only the corrected text.",
+        reply: "What is the command to install steam",
+    },
+];
+
+/// Frame a (text, instruction) pair as one user turn. Used for the real turn
+/// *and* for every example, so a demonstration is always shaped exactly like
+/// the request it is demonstrating.
+fn rewrite_user_message(selected_text: &str, instruction: &str) -> String {
+    format!("Selected text:\n{selected_text}\n\nInstruction: {instruction}")
+}
+
+/// The full messages array for a rewrite: system prompt, the [`REWRITE_EXAMPLES`]
+/// as alternating user/assistant turns, then the real request last.
+fn rewrite_messages(selected_text: &str, instruction: &str) -> Vec<ChatMessage> {
+    let mut messages = Vec::with_capacity(2 + REWRITE_EXAMPLES.len() * 2);
+    messages.push(ChatMessage::system(REWRITE_SYSTEM_PROMPT));
+    for example in REWRITE_EXAMPLES {
+        messages.push(ChatMessage::user(rewrite_user_message(
+            example.selected_text,
+            example.instruction,
+        )));
+        messages.push(ChatMessage::assistant(example.reply));
+    }
+    messages.push(ChatMessage::user(rewrite_user_message(
+        selected_text,
+        instruction,
+    )));
+    messages
+}
+
+/// Characters that would end a line if they were injected. `\r` and `\n` are
+/// the ones models actually emit; the rest are here because the injector's
+/// two paths fail differently and neither fails safely — an unmapped
+/// character falls through to a clipboard paste (plain Ctrl+V, which a
+/// terminal reads as readline's quoted-insert and which silently splices
+/// adjacent lines), while a mapped one is tapped as a real key.
+///
+/// `\r` is normalized away by [`clean_llm_output`] before this is consulted;
+/// it is listed for the property test that pins the set.
+const LINE_BREAKS: [char; 7] = [
+    '\n',       // line feed
+    '\r',       // carriage return — Return in the XKB keymap, i.e. a real Enter
+    '\u{000b}', // vertical tab
+    '\u{000c}', // form feed
+    '\u{0085}', // next line
+    '\u{2028}', // line separator
+    '\u{2029}', // paragraph separator
+];
+
+/// Post-process an LLM reply before it is injected at the cursor. Applied to
+/// **every** reply — command mode and `[[llm_commands]]` alike.
+///
+/// The prompt and the few-shot examples both tell the model not to fence or
+/// pad its answer; this is the belt to those suspenders, because the failure
+/// is expensive. A ```` ```bash ```` line is typed as if it were part of the
+/// command, and a trailing newline at a shell prompt submits a command the
+/// user has not read yet.
+///
+/// Line endings are normalized to `\n` first, so a CRLF reply cannot smuggle a
+/// `\r` past [`contains_line_break`] (the keymap maps `\r` to Return, so a
+/// surviving one is tapped as a real Enter mid-injection). Then a code fence
+/// wrapping the *entire* answer is stripped — always, with no opt-out — and
+/// the result is trimmed. A reply containing *several* fenced blocks is prose
+/// about code, not a wrapper, and is left exactly as it came.
+///
+/// "Always" has a cost worth naming: an `[[llm_commands]]` entry whose
+/// instruction genuinely asks for a fenced block ("wrap this in a python code
+/// fence") cannot produce one — the fence is removed on the way to the cursor.
+/// No config key buys it back. That is deliberate: the entries people actually
+/// write want the artifact, a stray fence is typed as literal characters into
+/// whatever is focused, and one config key per rare case is a worse trade than
+/// documenting the limitation (see `docs/configuration.md`).
+///
+/// Cleaning only. Whether the result may be injected *here, now* depends on
+/// what is focused, which this module cannot see: see
+/// `daemon/injection.rs::prepare_llm_injection`.
+pub fn clean_llm_output(text: &str) -> String {
+    let normalized = normalize_line_endings(text);
+    strip_wrapping_code_fence(&normalized).trim().to_string()
+}
+
+/// Whether `text` still holds a character that would end a line if injected.
+///
+/// The one fact the injection site needs from this module: at a shell prompt a
+/// line break is an Enter that runs a command the user has not read, so a
+/// multi-line reply aimed at a terminal is refused rather than typed. Nothing
+/// is wrong with a multi-line reply as such — a translated paragraph or a
+/// drafted email is exactly what an `[[llm_commands]]` entry is for — so the
+/// refusal is the injection site's call, conditional on the target, not this
+/// function's.
+///
+/// Expects [`clean_llm_output`] to have run first, which is what makes `\r`
+/// and `\r\n` collapse to the `\n` case.
+pub fn contains_line_break(text: &str) -> bool {
+    text.contains(LINE_BREAKS)
+}
+
+/// Normalize CRLF and bare CR to LF, so exactly one character has to be
+/// looked for downstream.
+fn normalize_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+/// Whether a fence's info string is a language tag (`bash`, `python`, `c++`,
+/// ``) rather than content.
+///
+/// A tag is one token: no whitespace. `` ```bash echo hi `` is not a tag —
+/// the model put part of its answer on the fence line, and stripping the
+/// fence would delete `echo hi` silently. Such a block is left fenced, which
+/// leaves a line break in it, which a terminal target then refuses to inject
+/// (see `daemon/injection.rs`): the user is told rather than handed a
+/// truncated command.
+fn is_fence_language_tag(info: &str) -> bool {
+    let info = info.trim();
+    info.is_empty()
+        || info
+            .chars()
+            .all(|c| c.is_alphanumeric() || matches!(c, '+' | '-' | '_' | '#' | '.'))
+}
+
+/// Strip a code fence that wraps the whole answer, returning `text` unchanged
+/// when the answer isn't a single fenced block.
+fn strip_wrapping_code_fence(text: &str) -> &str {
+    let trimmed = text.trim();
+    let Some(rest) = trimmed.strip_prefix("```") else {
+        return text;
+    };
+    // The opening fence's info string ("bash", "python", "") runs to the
+    // first newline.
+    let Some((info, body)) = rest.split_once('\n') else {
+        return text;
+    };
+    if info.contains("```") {
+        return text;
+    }
+    if !is_fence_language_tag(info) {
+        // Content on the fence line: stripping would drop it. Leave the reply
+        // whole and let the caller decide (see `is_fence_language_tag`).
+        warn!(
+            "llm: fenced reply carries content on the fence line ({:?}); \
+             leaving the fence in place rather than dropping it",
+            info.trim()
+        );
+        return text;
+    }
+    let Some(body) = body.trim_end().strip_suffix("```") else {
+        return text;
+    };
+    if body.contains("```") {
+        // More than one fenced block: not a single wrapper.
+        return text;
+    }
+    body
+}
+
+/// Send text and an instruction to the LLM, returning the raw reply.
+///
+/// Shared by `whisrs command` (selection + spoken instruction) and every
+/// `[[llm_commands]]` entry (dictated text + preset instruction). The reply is
+/// returned as it arrived; the caller runs it through [`clean_llm_output`] and
+/// the injection gate before anything is typed.
 pub async fn rewrite_text(
     config: &LlmConfig,
     selected_text: &str,
     instruction: &str,
 ) -> anyhow::Result<String> {
-    if config.api_key.is_empty() {
-        // Fall back to env vars.
-        let key = std::env::var("WHISRS_OPENAI_API_KEY")
-            .or_else(|_| std::env::var("WHISRS_GROQ_API_KEY"))
-            .unwrap_or_default();
-        if key.is_empty() {
-            anyhow::bail!(
-                "No LLM API key configured.\n\
-                 Add [llm] api_key to config.toml, or set WHISRS_OPENAI_API_KEY.\n\
-                 Run 'whisrs setup' to configure."
-            );
-        }
-        return rewrite_with_key(config, &key, selected_text, instruction).await;
-    }
-
-    rewrite_with_key(config, &config.api_key, selected_text, instruction).await
-}
-
-async fn rewrite_with_key(
-    config: &LlmConfig,
-    api_key: &str,
-    selected_text: &str,
-    instruction: &str,
-) -> anyhow::Result<String> {
+    let api_key = resolve_api_key(config)?;
     info!(
-        "command mode: sending to LLM (model={}, instruction={:?})",
+        "llm: sending to LLM (model={}, instruction={:?})",
         config.model, instruction
     );
     debug!("selected text: {:?}", selected_text);
 
-    let system_prompt = "You are a text editing assistant. The user will give you some selected text and a voice instruction. \
-        Apply the instruction to the text and return ONLY the modified text. \
-        Do not add explanations, markdown formatting, or quotes — just return the raw result text.";
+    chat_with_key(
+        config,
+        &api_key,
+        rewrite_messages(selected_text, instruction),
+    )
+    .await
+}
 
-    let user_message = format!("Selected text:\n{selected_text}\n\nInstruction: {instruction}");
+/// The configured key, or the env-var fallback when `[llm] api_key` is empty.
+fn resolve_api_key(config: &LlmConfig) -> anyhow::Result<String> {
+    if !config.api_key.is_empty() {
+        return Ok(config.api_key.clone());
+    }
+    // Fall back to env vars.
+    let key = std::env::var("WHISRS_OPENAI_API_KEY")
+        .or_else(|_| std::env::var("WHISRS_GROQ_API_KEY"))
+        .unwrap_or_default();
+    if key.is_empty() {
+        anyhow::bail!(
+            "No LLM API key configured.\n\
+             Add [llm] api_key to config.toml, or set WHISRS_OPENAI_API_KEY.\n\
+             Run 'whisrs setup' to configure."
+        );
+    }
+    Ok(key)
+}
 
+/// POST a prepared messages array to the configured `/chat/completions`
+/// endpoint.
+///
+/// `temperature` stays at 0.3: the preamble problem was a formatting habit,
+/// not sampling noise, and it is addressed by the few-shot turns. Lowering it
+/// further would also flatten the rewrite path's actual job (rephrasing,
+/// translating, drafting), which is not what needed fixing.
+async fn chat_with_key(
+    config: &LlmConfig,
+    api_key: &str,
+    messages: Vec<ChatMessage>,
+) -> anyhow::Result<String> {
     let request = ChatRequest {
         model: config.model.clone(),
-        messages: vec![
-            ChatMessage {
-                role: "system".to_string(),
-                content: system_prompt.to_string(),
-            },
-            ChatMessage {
-                role: "user".to_string(),
-                content: user_message,
-            },
-        ],
+        messages,
         temperature: 0.3,
     };
 
@@ -190,7 +462,7 @@ async fn rewrite_with_key(
         .map(|c| c.message.content.clone())
         .unwrap_or_default();
 
-    info!("command mode: LLM returned {} chars", result.len());
+    info!("llm: LLM returned {} chars", result.len());
     Ok(result)
 }
 
@@ -211,14 +483,8 @@ mod tests {
         let request = ChatRequest {
             model: "gpt-4o-mini".to_string(),
             messages: vec![
-                ChatMessage {
-                    role: "system".to_string(),
-                    content: "You are helpful.".to_string(),
-                },
-                ChatMessage {
-                    role: "user".to_string(),
-                    content: "Hello".to_string(),
-                },
+                ChatMessage::system("You are helpful."),
+                ChatMessage::user("Hello".to_string()),
             ],
             temperature: 0.3,
         };
@@ -226,6 +492,346 @@ mod tests {
         assert!(json.contains("gpt-4o-mini"));
         assert!(json.contains("system"));
         assert!(json.contains("Hello"));
+    }
+
+    /// The framing every turn shares. Both callers depend on it: command mode
+    /// puts the selection in `Selected text:` and `[[llm_commands]]` puts the
+    /// dictated text there.
+    #[test]
+    fn a_turn_frames_the_text_and_the_instruction() {
+        assert_eq!(
+            rewrite_user_message("hello world", "make it shout"),
+            "Selected text:\nhello world\n\nInstruction: make it shout"
+        );
+    }
+
+    /// System prompt, then the examples as alternating user/assistant turns,
+    /// then the real request last. Order is the whole mechanism: an example
+    /// after the request would be read as a continuation of it.
+    #[test]
+    fn the_messages_array_is_system_then_examples_then_the_request() {
+        let messages = rewrite_messages("hello world", "make it shout");
+
+        assert_eq!(messages.len(), 2 + REWRITE_EXAMPLES.len() * 2);
+        assert_eq!(messages[0], ChatMessage::system(REWRITE_SYSTEM_PROMPT));
+
+        for (i, example) in REWRITE_EXAMPLES.iter().enumerate() {
+            let user = &messages[1 + i * 2];
+            let assistant = &messages[2 + i * 2];
+            assert_eq!(
+                user,
+                &ChatMessage::user(rewrite_user_message(
+                    example.selected_text,
+                    example.instruction
+                )),
+                "example {i} must be framed exactly like a real request"
+            );
+            assert_eq!(assistant, &ChatMessage::assistant(example.reply));
+        }
+
+        let last = messages.last().expect("the request is the last turn");
+        assert_eq!(
+            last,
+            &ChatMessage::user(rewrite_user_message("hello world", "make it shout"))
+        );
+    }
+
+    /// The whole point of the examples: every demonstrated reply is the bare
+    /// artifact. A preamble, a label, wrapping quotes or a code fence in one
+    /// of these would teach the exact defect they exist to stop —
+    /// gpt-4o-mini answering "To install Steam on Arch Linux, you can use the
+    /// following command: sudo pacman -S steam".
+    #[test]
+    fn every_example_reply_is_the_bare_artifact() {
+        for example in REWRITE_EXAMPLES {
+            let reply = example.reply;
+            assert_eq!(reply.trim(), reply, "{reply:?} is padded");
+            assert!(!reply.contains("```"), "{reply:?} contains a code fence");
+            assert!(
+                !reply.starts_with('"') && !reply.starts_with('\''),
+                "{reply:?} is quoted"
+            );
+            for preamble in [
+                "Here is",
+                "Here's",
+                "Sure",
+                "Certainly",
+                "you can use",
+                "The translation",
+                "Translation:",
+                "Command:",
+            ] {
+                assert!(
+                    !reply.contains(preamble),
+                    "{reply:?} demonstrates a preamble ({preamble:?})"
+                );
+            }
+            // An example must survive its own cleaning unchanged, or it is
+            // demonstrating something the cleaner would have to undo.
+            assert_eq!(clean_llm_output(reply), reply, "{reply:?} is not clean");
+        }
+    }
+
+    /// The shapes a turn can take. A shell command alone teaches "answer
+    /// tersely"; the translation pins the rewrite case; the email keeps a
+    /// legitimate multi-line answer in the demonstration set so terseness is
+    /// not overgeneralized into "always one line"; and the spelling fix keeps
+    /// request-fulfilment from taking over the set (see below).
+    #[test]
+    fn the_examples_cover_a_command_a_translation_an_email_and_a_transformation() {
+        let replies: Vec<&str> = REWRITE_EXAMPLES.iter().map(|e| e.reply).collect();
+        assert!(
+            replies.contains(&"sudo pacman -S steam"),
+            "the reported failure must be demonstrated verbatim: {replies:?}"
+        );
+        assert!(
+            replies.contains(&"Wo ist der Bahnhof?"),
+            "a translation example is missing: {replies:?}"
+        );
+        assert!(
+            replies.iter().any(|r| contains_line_break(r)),
+            "no example demonstrates a legitimate multi-line reply: {replies:?}"
+        );
+    }
+
+    /// The instruction decides the job, not the shape of the text. Most of the
+    /// set is generic "treat this as a request" fulfilment, so at least one
+    /// example must show question-shaped input under a *transformation*
+    /// instruction being transformed rather than answered — otherwise a tuned
+    /// `[[llm_commands]]` entry ("Fix the spelling. Return only the corrected
+    /// text.") fed a dictated question can get the question answered.
+    #[test]
+    fn an_example_transforms_question_shaped_input_instead_of_answering_it() {
+        let example = REWRITE_EXAMPLES
+            .iter()
+            .find(|e| e.selected_text == "wht is teh comand to instal steam")
+            .expect("the question-shaped transformation example is missing");
+
+        assert_eq!(
+            example.instruction, "Fix the spelling and grammar. Return only the corrected text.",
+            "the instruction must be a transformation, not a request-fulfilment one"
+        );
+        assert_eq!(
+            example.reply, "What is the command to install steam",
+            "the reply must be the corrected text, not an answer to the question"
+        );
+        // The give-away that the question was answered instead of corrected:
+        // the answer to it is example 1's reply, which must not appear here.
+        assert!(
+            !example.reply.contains("pacman"),
+            "{:?} answers the question instead of transforming it",
+            example.reply
+        );
+    }
+
+    /// The prose half still has to forbid the wrappers outright — the examples
+    /// show the shape, the prompt names the rule.
+    #[test]
+    fn the_system_prompt_forbids_wrappers() {
+        for forbidden in [
+            "no preamble",
+            "no explanation",
+            "no commentary",
+            "no surrounding quotes",
+            "no markdown formatting and no code fences",
+        ] {
+            assert!(
+                REWRITE_SYSTEM_PROMPT.contains(forbidden),
+                "the system prompt must forbid {forbidden:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn clean_llm_output_leaves_a_bare_command_alone() {
+        assert_eq!(
+            clean_llm_output("sudo pacman -S steam"),
+            "sudo pacman -S steam"
+        );
+    }
+
+    /// A trailing newline typed at a shell prompt submits the command before
+    /// the user has read it.
+    #[test]
+    fn clean_llm_output_strips_trailing_and_leading_whitespace() {
+        assert_eq!(
+            clean_llm_output("\nsudo pacman -S steam\n"),
+            "sudo pacman -S steam"
+        );
+    }
+
+    #[test]
+    fn clean_llm_output_strips_a_wrapping_fence_with_a_language() {
+        assert_eq!(
+            clean_llm_output("```bash\nsudo pacman -S steam\n```"),
+            "sudo pacman -S steam"
+        );
+    }
+
+    #[test]
+    fn clean_llm_output_strips_a_bare_wrapping_fence() {
+        assert_eq!(
+            clean_llm_output("```\nsudo pacman -S steam\n```\n"),
+            "sudo pacman -S steam"
+        );
+    }
+
+    /// A fence wrapping the whole reply is stripped even when the body spans
+    /// several lines: a fenced reply is never what the user wants typed, and
+    /// where the body may then be injected is the injection site's call.
+    /// Internal newlines and indentation survive — only the wrapper goes.
+    #[test]
+    fn clean_llm_output_strips_the_fence_from_a_multi_line_block() {
+        assert_eq!(
+            clean_llm_output("```python\ndef f():\n    return 1\n```"),
+            "def f():\n    return 1"
+        );
+    }
+
+    /// Two fenced blocks is prose about code, not a wrapper — stripping the
+    /// outer pair would splice unrelated text together.
+    #[test]
+    fn clean_llm_output_leaves_multiple_fenced_blocks_alone() {
+        let text = "```sh\nfirst\n```\nthen run\n```sh\nsecond\n```";
+        assert_eq!(clean_llm_output(text), text);
+    }
+
+    /// Inline backticks are content, not a fence.
+    #[test]
+    fn clean_llm_output_leaves_inline_backticks_alone() {
+        assert_eq!(
+            clean_llm_output("run `pacman -S steam` as root"),
+            "run `pacman -S steam` as root"
+        );
+    }
+
+    /// A language tag is one token, so these fences are wrappers and the tag
+    /// carries no content worth keeping.
+    #[test]
+    fn a_language_tag_fence_is_still_stripped() {
+        for fence in ["```", "```bash", "```c++", "```python3", "```objective-c"] {
+            assert_eq!(
+                clean_llm_output(&format!("{fence}\nsudo pacman -S steam\n```")),
+                "sudo pacman -S steam",
+                "{fence:?} is a language tag, not content"
+            );
+        }
+    }
+
+    /// Content on the fence line is part of the answer, and a naive stripper
+    /// deletes it silently: `"```bash echo hi\nrm -rf /tmp/x\n```"` would come
+    /// back as `"rm -rf /tmp/x"`, a different command from the one the model
+    /// wrote. The fence is left in place instead, which keeps the reply
+    /// multi-line — and a multi-line reply aimed at a terminal is refused out
+    /// loud rather than truncated.
+    #[test]
+    fn a_fence_info_line_with_content_is_never_dropped() {
+        let cleaned = clean_llm_output("```bash echo hi\nrm -rf /tmp/x\n```");
+        assert!(
+            cleaned.contains("echo hi"),
+            "content on the fence line must survive cleaning, got {cleaned:?}"
+        );
+        assert!(contains_line_break(&cleaned));
+    }
+
+    /// An unterminated fence: nothing to strip, so the ```` ```bash ```` line
+    /// stays and a line break with it. Injecting this into a terminal types a
+    /// stray Enter after `sudo` — running a half-typed privileged command.
+    #[test]
+    fn an_unterminated_fence_stays_multi_line() {
+        let cleaned = clean_llm_output("```bash\nsudo rm -rf ~/data");
+        assert_eq!(cleaned, "```bash\nsudo rm -rf ~/data");
+        assert!(contains_line_break(&cleaned));
+    }
+
+    /// A fenced command followed by prose. The fence is not a wrapper, so
+    /// nothing is stripped and the whole reply — command, fence, explanation
+    /// — stays multi-line.
+    #[test]
+    fn a_fence_plus_prose_stays_multi_line() {
+        let reply = "```\nrm -rf ~/data\n```\nThis deletes your data.";
+        assert_eq!(clean_llm_output(reply), reply);
+        assert!(contains_line_break(reply));
+    }
+
+    /// CRLF is normalized before anything else looks at the text. `\r` is in
+    /// the XKB keymap (Return), so a surviving one is tapped as a real Enter
+    /// mid-injection.
+    #[test]
+    fn crlf_is_normalized_away() {
+        assert_eq!(
+            clean_llm_output("sudo pacman -S steam\r\n"),
+            "sudo pacman -S steam",
+            "a trailing CRLF is just padding on a single-line answer"
+        );
+
+        let cleaned = clean_llm_output("echo one\r\necho two");
+        assert_eq!(cleaned, "echo one\necho two");
+        assert!(!cleaned.contains('\r'), "no CR may survive cleaning");
+        assert!(contains_line_break(&cleaned));
+    }
+
+    /// A bare CR (old-Mac line ending, and what a model emits when it botches
+    /// a CRLF) is a line break too, and is the exact character the keymap
+    /// turns into Enter.
+    #[test]
+    fn a_bare_cr_is_normalized_to_a_line_feed() {
+        let cleaned = clean_llm_output("echo one\recho two");
+        assert_eq!(cleaned, "echo one\necho two");
+        assert!(!cleaned.contains('\r'));
+        assert!(contains_line_break(&cleaned));
+    }
+
+    /// Every character the gate treats as a line break is detected, including
+    /// the ones the keymap has no entry for — those fall through to a
+    /// clipboard paste, whose plain Ctrl+V a terminal reads as readline's
+    /// quoted-insert, silently splicing the lines together.
+    #[test]
+    fn every_line_break_character_is_detected() {
+        for break_char in LINE_BREAKS {
+            let cleaned = clean_llm_output(&format!("echo one{break_char}echo two"));
+            assert!(
+                contains_line_break(&cleaned),
+                "U+{:04X} must be seen as a line break",
+                break_char as u32
+            );
+        }
+    }
+
+    /// A single-line reply has no line break, however it arrived.
+    #[test]
+    fn a_single_line_reply_has_no_line_break() {
+        for reply in [
+            "sudo pacman -S steam",
+            "```bash\nsudo pacman -S steam\n```",
+            "  sudo pacman -S steam  \n",
+        ] {
+            let cleaned = clean_llm_output(reply);
+            assert_eq!(cleaned, "sudo pacman -S steam", "{reply:?}");
+            assert!(!contains_line_break(&cleaned));
+        }
+    }
+
+    /// Nothing usable: an empty reply, whitespace, and the fences models emit
+    /// when they have nothing to say. All clean to the empty string, which is
+    /// what the injection site refuses.
+    #[test]
+    fn nothing_usable_cleans_to_empty() {
+        for reply in [
+            "",
+            "   ",
+            "\n\t\n",
+            "\r\n",
+            "```\n```",
+            "```bash\n\n```",
+            "```\n\n```",
+        ] {
+            assert_eq!(
+                clean_llm_output(reply),
+                "",
+                "{reply:?} holds no usable text"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
#91 asked for command mode to generate text when nothing is selected. The first attempt made `whisrs command` tolerate an empty selection, which turned out to be unsafe: `capture_selection` returns the same error when nothing is selected and when the simulated copy returns the bytes already on the clipboard, so proceeding on it meant typing over a live selection. Fixing that left generation firing only when the clipboard happened to be empty too.

A separate `whisrs generate` command was built next and tested, and it made the redundancy obvious: an `[[llm_commands]]` entry with a generic instruction is already generate mode. You speak the request, it becomes the text, the result is typed at the cursor, no selection involved. That path shipped in #60. So no new command lands here, and the recipe is documented instead.

What testing that command did surface is that the LLM path needed hardening, and those fixes belong to every caller rather than one new one.

The reply is now cleaned before injection: CRLF and bare CR normalized, a code fence stripped when it wraps the entire reply, whitespace trimmed. A reply with two fenced blocks is prose about code and is left alone, and a fence info line carrying content is preserved rather than silently truncated into a different command. There is no opt-out, which the docs say plainly: an entry that genuinely wants a fenced block cannot get one.

Multi-line output is refused only when the focused window is a terminal, where a newline is an Enter that runs a line the user has not read. Anywhere else it is typed as before, because translating a paragraph or rewriting an email legitimately spans lines. The refused text is saved to history and the notification naming `whisrs log` fires unconditionally, deliberately ignoring `[general] notify`: that setting means do not narrate normal operation, not silently discard my work. The refusal also applies under `[input] paste`, where bracketed paste would insert the text literally, because bracketed paste is the foreground program's choice and cannot be relied on from here.

Four few-shot examples now precede every request, because the previous system prompt already forbade preamble in prose and the model ignored it. They cover a shell command, a translation, a deliberately multi-line email so terseness is not overgeneralized, and a transformation applied to question-shaped input so a tuned instruction like "fix the spelling" is not answered instead of applied.

Also replaces the string error from `capture_selection` with a typed one. No caller branches on the variants today; the distinction is kept because acting on the ambiguous case is what typed over a live selection.

Tested on Hyprland: an existing llm-command still translates cleanly, a generic request returns the bare command with no preamble, a multi-line reply is withheld in a terminal and typed normally in an editor, and the notification fires with notifications off.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)