### PR TITLE
feat(cli): add `whisrs repeat` — re-inject the last transcription at the cursor

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,40 @@
+name: cache
+
+on:
+  push:
+    branches: [main, "feat/*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pull-configures the cache, but does NOT auto-push (skipPush):
+      # pushing happens in the guarded step below, so this workflow is
+      # safe to run on any repo (upstream included) that lacks the
+      # CACHIX_AUTH_TOKEN secret / CACHIX_PUSH variable.
+      - uses: cachix/cachix-action@v15
+        with:
+          name: whisrs-fork
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: 'true'
+
+      - name: Build
+        run: nix build .#default
+        timeout-minutes: 90
+
+      # Fork-local: only runs when the repo defines CACHIX_PUSH=true.
+      # Andrii's home-manager switches then substitute the fork build
+      # instead of compiling it locally.
+      - name: Push to cachix
+        if: vars.CACHIX_PUSH == 'true'
+        run: nix build .#default --print-out-paths | xargs cachix push whisrs-fork
+        timeout-minutes: 30

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -108,6 +108,14 @@ or a
 stops playback. Alias:
 .BR read .
 .TP
+.B repeat
+Re-inject the most recent transcription at the cursor \\(em pasted or
+typed, following the configured
+.B paste
+input mode. A recovery path for when the original injection landed in the
+wrong window or was dropped: the text comes back without re-dictating.
+Notifies if there is no previous transcription.
+.TP
 .B status
 Query the daemon state. Prints one of:
 .BR idle ,

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -114,7 +114,9 @@ typed, following the configured
 .B paste
 input mode. A recovery path for when the original injection landed in the
 wrong window or was dropped: the text comes back without re-dictating.
-Notifies if there is no previous transcription.
+The injection waits briefly before the first keystroke so a hotkey's held
+modifiers (e.g. Shift) are released first. Notifies if there is no
+previous transcription.
 .TP
 .B status
 Query the daemon state. Prints one of:

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -89,6 +89,11 @@ enum SubCmd {
     /// Read the selected text aloud via TTS (press again to stop playback)
     #[command(alias = "read")]
     Speak,
+    /// Re-inject the most recent transcription at the cursor — pasted or
+    /// typed, following `[input] paste`. A recovery path for when the
+    /// original injection landed in the wrong window or was dropped: the
+    /// text comes back without re-dictating.
+    Repeat,
     /// Restart the whisrs daemon (uses the systemd user service when present)
     Restart,
 }
@@ -166,6 +171,9 @@ async fn main() -> anyhow::Result<()> {
         }
         SubCmd::Speak => {
             send_command(Command::Speak).await?;
+        }
+        SubCmd::Repeat => {
+            send_command(Command::RepeatLast).await?;
         }
         SubCmd::Restart => {
             cmd_restart()?;

--- a/src/daemon/dictation.rs
+++ b/src/daemon/dictation.rs
@@ -387,6 +387,13 @@ pub(crate) async fn handle_cancel(
     }
 }
 
+/// How long `repeat` waits before the first keystroke, to let the hotkey's
+/// physical modifiers (e.g. Shift in `$mod+SHIFT+space`) be released.
+/// Compositors like Hyprland merge the real keyboard's held modifiers into
+/// virtual-keyboard events, which would otherwise reinterpret the first
+/// injected keysyms (see the settle comment in `handle_repeat_last`).
+const REPEAT_INJECTION_SETTLE: std::time::Duration = std::time::Duration::from_millis(250);
+
 /// Re-inject the most recent transcription at the cursor.
 ///
 /// Recovery path for when the original injection landed in the wrong
@@ -437,6 +444,18 @@ pub(crate) async fn handle_repeat_last(
 
     info!("repeat: re-injecting {} chars", text.len());
     match tokio::task::spawn_blocking(move || {
+        // Settle delay before the first keystroke: the repeat hotkey
+        // commonly involves modifiers (e.g. `$mod+SHIFT+space`), and
+        // compositors (Hyprland) merge the *real* keyboard's held
+        // modifiers into virtual-keyboard events. A still-held Shift
+        // reinterprets the first injected keysyms against the uploaded
+        // keymap: commas come out as `<` (Shift level of the comma key)
+        // and AltGr-level Cyrillic resolves to the unbound level 3 and
+        // silently drops. Waiting out the physical key release keeps the
+        // re-injection clean. Dictation itself is unaffected: its hotkey
+        // is a level-neutral modifier (Super), so no settle is needed
+        // there.
+        std::thread::sleep(REPEAT_INJECTION_SETTLE);
         inject_text(&text, is_terminal, key_delay, injector_backend, paste)
     })
     .await

--- a/src/daemon/dictation.rs
+++ b/src/daemon/dictation.rs
@@ -10,6 +10,7 @@ use whisrs::state::Action;
 use whisrs::{validate_language_override, Response, State};
 
 use crate::context::{DaemonContext, DaemonState};
+use crate::injection::{inject_text, is_terminal_class};
 use crate::notify::{send_notification, truncate_preview};
 use crate::pipeline::{
     build_transcription_config, format_no_microphone_error, history_backend_tag,
@@ -384,6 +385,76 @@ pub(crate) async fn handle_cancel(
             message: e.to_string(),
         },
     }
+}
+
+/// Re-inject the most recent transcription at the cursor.
+///
+/// Recovery path for when the original injection landed in the wrong
+/// window or was dropped entirely: the last history entry is injected
+/// again, pasted or typed following `[input] paste` — no re-dictating.
+/// Explicitly a *repeat*, so it always injects: `[input] clipboard_only`
+/// is a dictation output mode and does not apply here.
+///
+/// Notifies (and returns success) when there is no previous transcription
+/// to repeat, so a hotkey binding gives feedback instead of doing nothing.
+pub(crate) async fn handle_repeat_last(
+    daemon_state: Arc<Mutex<DaemonState>>,
+    context: Arc<DaemonContext>,
+) -> Response {
+    let state = daemon_state.lock().await.state_machine.state();
+
+    let entries = match whisrs::history::read_entries(1) {
+        Ok(entries) => entries,
+        Err(e) => {
+            return Response::Error {
+                message: format!("failed to read history: {e}"),
+            };
+        }
+    };
+    let Some(entry) = entries.into_iter().next() else {
+        send_notification("whisrs", "No previous dictation to repeat");
+        return Response::Ok { state };
+    };
+
+    let text = entry.text;
+    if text.trim().is_empty() {
+        send_notification("whisrs", "No previous dictation to repeat");
+        return Response::Ok { state };
+    }
+
+    let key_delay = std::time::Duration::from_millis(context.config.input.key_delay_ms);
+    let injector_backend = context.config.input.backend;
+    let paste = context.config.input.paste;
+    let is_terminal = if paste {
+        context
+            .window_tracker
+            .get_focused_window_class()
+            .map(|c| is_terminal_class(&c, &context.config.input.terminal_classes))
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    info!("repeat: re-injecting {} chars", text.len());
+    match tokio::task::spawn_blocking(move || {
+        inject_text(&text, is_terminal, key_delay, injector_backend, paste)
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            warn!("repeat: failed to inject text: {e:#}");
+            send_notification("whisrs", &format!("Failed to repeat last dictation: {e:#}"));
+        }
+        Err(e) => {
+            warn!("repeat: failed to join injection task: {e}");
+            send_notification(
+                "whisrs",
+                "Failed to repeat last dictation: injection task error",
+            );
+        }
+    }
+    Response::Ok { state }
 }
 
 /// Tear down every per-session resource a cancelled recording leaves behind.

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -24,7 +24,7 @@ mod startup;
 
 use crate::command_mode::{handle_command_mode, handle_llm_command, handle_set_llm_instruction};
 use crate::context::{DaemonContext, DaemonState};
-use crate::dictation::{handle_cancel, handle_toggle};
+use crate::dictation::{handle_cancel, handle_repeat_last, handle_toggle};
 use crate::factory::create_backend;
 use crate::injection::warm_keyboard;
 use crate::notify::send_notification;
@@ -257,6 +257,7 @@ async fn handle_command(
             handle_set_llm_instruction(daemon_state, context, name).await
         }
         Command::Speak => handle_speak(daemon_state, context).await,
+        Command::RepeatLast => handle_repeat_last(daemon_state, context).await,
     }
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -51,6 +51,12 @@ pub enum Command {
     /// stops any in-progress playback.
     #[serde(alias = "read")]
     Speak,
+    /// Re-inject the most recent transcription at the cursor — pasted or
+    /// typed, following `[input] paste`. A recovery path for when the
+    /// original injection landed in the wrong window or was dropped: the
+    /// text comes back without re-dictating.
+    #[serde(rename = "repeat-last")]
+    RepeatLast,
 }
 
 fn default_log_limit() -> usize {


### PR DESCRIPTION
Closes #112

## What

`whisrs repeat`: re-inject the **most recent** transcription at the cursor — pasted or typed, following `[input] paste`. A recovery path for when the original injection landed in the wrong window or was dropped: the text comes back without re-dictating. Bindable as a one-shot compositor hotkey.

## How

- IPC: new `repeat-last` command (`src/ipc.rs`).
- CLI: `whisrs repeat` subcommand (`src/cli/main.rs`).
- Daemon (`src/daemon/dictation.rs` `handle_repeat_last`): reads the latest `history.jsonl` entry (the same store `whisrs log` reads) and runs it through the shared `inject_text` wrapper — so terminal detection and `[input] paste` behavior match normal dictation exactly. Notifies when there is no previous transcription, so a hotkey binding gives feedback instead of doing nothing.
- Deliberately always injects: `[input] clipboard_only` is a dictation *output* mode and does not apply to an explicit repeat.
- Man page entry for `repeat` (the subcommand-docs test asserts every CLI subcommand is documented).

## Tests

`cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and the full suite (299 lib + 106 daemon, incl. the man-page coverage test) pass on latest main (0.1.24), built with `--no-default-features --features tray,overlay`.

Note: `.github/workflows/cache.yml` is fork-local infrastructure (Cachix cache `whisrs-fork` + repo variable `CACHIX_PUSH` on @AnDr-WaY's fork) so his home-manager switches substitute the fork build; without the variable the workflow is a plain flake-build check. Happy to drop it before merge if preferred.