### PR TITLE
feat(build): add optional vulkan, cuda, and hipblas GPU features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,11 @@ docs" in an untracked file changes nothing for users and shows up in no PR. Chec
 - `tray` — tray icon via `ksni`
 - `overlay` — recording overlay via `smithay-client-toolkit` + `wayland-client` + `tiny-skia`
 - `hooks` — recording-lifecycle hooks + MPRIS media pause via `zbus` (no new system dep; `overlay` already pulls `zbus`)
+- `vulkan` / `cuda` / `hipblas` — GPU backends for the bundled whisper.cpp, passed
+  through to `whisper-rs`. Each implies `local-whisper`. Off by default and never built
+  by CI or the release workflow, so they are source-build-only (`cargo install whisrs
+  --features vulkan`). Enabling one turns on whisper-rs's `_gpu`, which is what flips
+  `WhisperContextParameters::default().use_gpu` to true — there is no whisrs-side wiring.
 
 The **minimal** release build is `--no-default-features --features tray,overlay,hooks`:
 it drops only whisper.cpp. Keep `tray`, `overlay` and `hooks` in it (that omission was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3507,6 +3507,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
+ "libc",
  "whisper-rs-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,14 @@ local-whisper = ["dep:whisper-rs"]
 tray = ["dep:ksni"]
 overlay = ["dep:smithay-client-toolkit", "dep:wayland-client", "dep:tiny-skia", "dep:zbus"]
 hooks = ["dep:zbus"]
+# GPU backends for the bundled whisper.cpp. Opt-in at build time — the backend
+# has to be linked in, so there is no runtime switch — and CPU stays the default.
+# The `whisper-rs?/…` weak syntax applies the feature to whisper-rs without
+# itself enabling the optional dependency; `local-whisper` is what pulls it in,
+# so builds that never enable it stay free of whisper-rs.
+vulkan = ["local-whisper", "whisper-rs?/vulkan"]
+cuda = ["local-whisper", "whisper-rs?/cuda"]
+hipblas = ["local-whisper", "whisper-rs?/hipblas"]
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,59 @@ To **build from source** instead — including custom feature flag combos or uns
 
 After install, **press your hotkey** to start recording, **press again** to stop. Text appears at your cursor.
 
+### GPU acceleration (local whisper.cpp)
+
+The default build — and every prebuilt tarball — runs local whisper.cpp on the CPU. If you use the `local-whisper` backend, building with a GPU feature moves the model onto your GPU and cuts dictation latency from seconds to near-instant:
+
+```bash
+cargo install whisrs --features vulkan
+```
+
+| Feature | Backend | Hardware |
+|---|---|---|
+| `vulkan` | Vulkan | AMD, Intel, NVIDIA (cross-vendor; the safe default) |
+| `cuda` | CUDA | NVIDIA, needs the CUDA toolkit |
+| `hipblas` | ROCm/HIP | AMD, needs ROCm |
+
+These are compile-time features — the GPU backend has to be linked in, so there is no runtime switch. Each one implies `local-whisper`; the cloud backends are unaffected, and CPU stays the default.
+
+**Build-time system dependencies** (on top of the usual `alsa-lib`, `libxkbcommon`, `clang`, `cmake`). For `vulkan`:
+
+```bash
+# Arch Linux
+sudo pacman -S vulkan-headers vulkan-icd-loader shaderc
+
+# Debian/Ubuntu
+sudo apt install libvulkan-dev glslc
+
+# Fedora
+sudo dnf install vulkan-headers vulkan-loader-devel glslc
+```
+
+Your GPU driver package alone is **not** enough. The driver ships the runtime, not the development headers or the shader compiler, so a machine that runs Vulkan games fine will still fail the build with:
+
+```
+Could NOT find Vulkan (missing: Vulkan_INCLUDE_DIR)
+```
+
+Install the packages above and rebuild. `cuda` and `hipblas` likewise need their full toolkits (`cuda` / `rocm-hip-sdk`), not just the driver.
+
+**Verify it worked.** The binary should link against the Vulkan loader:
+
+```bash
+ldd ~/.cargo/bin/whisrsd | grep vulkan
+```
+
+No output means you got a CPU build. Then start the daemon in the foreground and watch whisper.cpp report the device it picked up:
+
+```bash
+RUST_LOG=debug whisrsd
+```
+
+A working Vulkan build names your GPU at load time (for example `ggml_vulkan: Found 1 Vulkan devices: Radeon RX 9070 XT (RADV GFX1201)`) and loads the model onto it.
+
+> **If you installed whisrs from a distro package or the tarball**, `cargo install` writes the new binaries to `~/.cargo/bin` and leaves the old ones in `/usr/local/bin` or `/usr/bin` untouched. Check that your systemd unit still points at the binary you just built — `systemctl --user cat whisrs.service` — and update `ExecStart` (or remove the stale copy) if it doesn't, otherwise you'll keep running the CPU build without noticing.
+
 <details>
 <summary><b>Other install methods (pre-built binary, AUR, Cargo, Nix, manual)</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ After install, **press your hotkey** to start recording, **press again** to stop
 
 ### GPU acceleration (local whisper.cpp)
 
-The default build — and every prebuilt tarball — runs local whisper.cpp on the CPU. If you use the `local-whisper` backend, building with a GPU feature moves the model onto your GPU and cuts dictation latency from seconds to near-instant:
+The default build — and every prebuilt tarball that ships whisper.cpp at all — runs it on the CPU. If you use the `local-whisper` backend, building with a GPU feature moves the model onto your GPU and cuts dictation latency from seconds to near-instant:
 
 ```bash
 cargo install whisrs --features vulkan
@@ -92,7 +92,7 @@ RUST_LOG=debug whisrsd
 
 A working Vulkan build names your GPU at load time (for example `ggml_vulkan: Found 1 Vulkan devices: Radeon RX 9070 XT (RADV GFX1201)`) and loads the model onto it.
 
-> **If you installed whisrs from a distro package or the tarball**, `cargo install` writes the new binaries to `~/.cargo/bin` and leaves the old ones in `/usr/local/bin` or `/usr/bin` untouched. Check that your systemd unit still points at the binary you just built — `systemctl --user cat whisrs.service` — and update `ExecStart` (or remove the stale copy) if it doesn't, otherwise you'll keep running the CPU build without noticing.
+> **If you installed whisrs from a distro package or the tarball**, `cargo install` writes the new binaries to `~/.cargo/bin` and leaves the old ones in `/usr/local/bin` or `/usr/bin` untouched. Check that your systemd unit still points at the binary you just built — `systemctl --user show whisrs.service -p ExecStart` — and point `ExecStart` at `~/.cargo/bin/whisrsd` if it doesn't, otherwise you'll keep running the CPU build without noticing. Don't just delete the old binary: `whisrs setup` writes an absolute `ExecStart`, so removing what it points at stops the daemon starting rather than moving it to the new build.
 
 <details>
 <summary><b>Other install methods (pre-built binary, AUR, Cargo, Nix, manual)</b></summary>


### PR DESCRIPTION
## Summary

Adds opt-in `vulkan`, `cuda`, and `hipblas` cargo features so users can build the bundled whisper.cpp with GPU acceleration via `cargo install whisrs --features vulkan`, without patching `Cargo.toml`.

This implements the approach you outlined in #48 - exposing whisper-rs's GPU backends as compile-time features rather than adding a new backend. CPU remains the default and nothing changes for existing users or cloud backends.

Motivation: `whisper-rs` is currently declared with no features, so every build (including the release tarballs) is CPU-only. The only workaround was editing `Cargo.toml` and building from a local path, which isn't documented anywhere.

## Changes

- **`Cargo.toml`** - three passthrough features in `[features]`:

  ```toml
  vulkan  = ["local-whisper", "whisper-rs?/vulkan"]
  cuda    = ["local-whisper", "whisper-rs?/cuda"]
  hipblas = ["local-whisper", "whisper-rs?/hipblas"]
  ```

  `default` is unchanged and `[dependencies.whisper-rs]` is untouched. The weak `whisper-rs?/…` syntax applies the feature without the feature itself acting as an enabler for the optional dependency - `local-whisper` is what pulls whisper-rs in, so a `--no-default-features` build stays free of it.

- **`Cargo.lock`** - one line. The `vulkan` feature enables `dep:libc` in whisper-rs, adding a `libc` edge. Without this, `cargo install whisrs --features vulkan --locked` fails with *"the lock file needs to be updated but --locked was passed"*. Happy to drop it if you'd rather regenerate it yourself.

- **`README.md`** - a "GPU acceleration" subsection under Installation covering the install command, the build-time system dependencies per distro, how to verify the backend is actually linked, and the stale-`ExecStart` trap.

No version bump, no refactoring, no changes to unrelated lines.

### On the README section

Two things in there came from hitting them personally, and are the reason the section isn't just a one-liner:

1. **The GPU driver package alone is not enough.** ggml-vulkan does `find_package(Vulkan COMPONENTS glslc REQUIRED)`, so you need the headers *and* a shader compiler. A machine that runs Vulkan games etc perfectly still fails the build with `Could NOT find Vulkan (missing: Vulkan_INCLUDE_DIR)`. On Arch that's `vulkan-headers vulkan-icd-loader shaderc`; Debian/Ubuntu and Fedora equivalents are listed too.
2. **`cargo install` writes to `~/.cargo/bin`** and leaves a distro-packaged or tarball-installed binary in `/usr/local/bin` alone, so the systemd unit can keep launching the old CPU build and the user sees no improvement and no error.

Trim it if it's more than you want in the README.

## Testing

Verified on a **Ryzen 7 9800X3D + Radeon RX 9070 XT (Navi 48, RADV) / CachyOS / niri 26.04**, daily-driving the `local-whisper` backend.

Real-world result: the model loads onto the GPU and dictation latency drops from seconds to effectively instant using a 1.5B parameter / 1080 MB model. 

Feature-graph and build verification:

| Command | Result |
|---|---|
| `cargo check --features vulkan` | passes; `libggml-vulkan.a` built and SPIR-V shaders generated |
| `cargo check --no-default-features --features vulkan` | passes |
| `cargo check --no-default-features` | passes; `cargo tree -i whisper-rs` reports no match, confirming whisper-rs is not pulled in |

Confirmed the build is genuinely accelerated rather than silently falling back to CPU:

```
$ ldd target/debug/whisrsd | grep -i vulkan
        libvulkan.so.1 => /usr/lib/libvulkan.so.1
```

and whisper.cpp reports the device at model load time on daemon startup.

**Caveat worth flagging:** I could only test `vulkan`. I don't have CUDA or ROCm toolchains available, so `cuda` and `hipblas` are verified by feature graph only. They resolve correctly and enable the right upstream features, but I have not compiled either one. They're one-line passthroughs to backends whisper.cpp supports upstream, so I'd expect them to be fine, but if you'd rather ship `vulkan` alone until someone can confirm the other two on real hardware, I'm completely happy to cut them from this PR.

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (302 + 106 + 1 tests, 0 failures)
- [x] Tested on at least one compositor (niri 26.04, CachyOS)

Refs #48
