### PR TITLE
feat(window): implement get_focused_window_class on Sway and X11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ unknown-key warning stays quiet.
 - Serde for all serialization: JSON for IPC, TOML for config
 - Length-prefixed JSON over Unix socket for IPC (4-byte big-endian length + JSON body)
 - All platform-specific behavior behind traits (`KeyInjector`, `WindowTracker`, `ClipboardBackend`)
-- **A trait method with a useful default is a trap. Prefer a required method, or check every implementor.** Case study: `WindowTracker::get_focused_window_class()` defaulted to `None` and only Hyprland and Niri overrode it, so `is_terminal` was silently false on KDE, GNOME, Sway and X11 until #71. The method is required now, Sway and X11 implement it, and KDE/GNOME return an explicit `None` (GNOME needs a shell extension, issue #72; KDE would need `org_kde_plasma_window_management`), so a new tracker cannot inherit the gap without a compile error.
+- **A trait method with a useful default is a trap. Prefer a required method, or check every implementor.** Case study: `WindowTracker::get_focused_window_class()` defaulted to `None` and only Hyprland and Niri overrode it, so `is_terminal` was silently false on KDE, GNOME, Sway and X11 until #71. The method is required now, Sway and X11 implement it, and KDE/GNOME return an explicit `None` (GNOME needs a shell extension, issue #72; KDE would need `org_kde_plasma_window_management`, issue #127), so a new tracker cannot inherit the gap without a compile error.
 - **Wire new features into both transcription paths.** A feature added only to `run_streaming_pipeline` silently no-ops for batch backends (`groq`, `openai`/`deepgram` REST, `asr-sidecar`). This shipped as a bug in #54.
 - Config structs derive both `Serialize` and `Deserialize` for read/write
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ unknown-key warning stays quiet.
 - Serde for all serialization: JSON for IPC, TOML for config
 - Length-prefixed JSON over Unix socket for IPC (4-byte big-endian length + JSON body)
 - All platform-specific behavior behind traits (`KeyInjector`, `WindowTracker`, `ClipboardBackend`)
-- **A trait method with a useful default is a trap. Prefer a required method, or check every implementor.** Case study: `WindowTracker::get_focused_window_class()` defaulted to `None` and only Hyprland and Niri overrode it, so `is_terminal` was silently false on KDE, GNOME, Sway and X11 until #71. The method is required now, Sway and X11 implement it, and KDE/GNOME return an explicit `None` (issue #72), so a new tracker cannot inherit the gap without a compile error.
+- **A trait method with a useful default is a trap. Prefer a required method, or check every implementor.** Case study: `WindowTracker::get_focused_window_class()` defaulted to `None` and only Hyprland and Niri overrode it, so `is_terminal` was silently false on KDE, GNOME, Sway and X11 until #71. The method is required now, Sway and X11 implement it, and KDE/GNOME return an explicit `None` (GNOME needs a shell extension, issue #72; KDE would need `org_kde_plasma_window_management`), so a new tracker cannot inherit the gap without a compile error.
 - **Wire new features into both transcription paths.** A feature added only to `run_streaming_pipeline` silently no-ops for batch backends (`groq`, `openai`/`deepgram` REST, `asr-sidecar`). This shipped as a bug in #54.
 - Config structs derive both `Serialize` and `Deserialize` for read/write
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ unknown-key warning stays quiet.
 - Serde for all serialization: JSON for IPC, TOML for config
 - Length-prefixed JSON over Unix socket for IPC (4-byte big-endian length + JSON body)
 - All platform-specific behavior behind traits (`KeyInjector`, `WindowTracker`, `ClipboardBackend`)
-- **A trait method with a useful default is a trap.** `WindowTracker::get_focused_window_class()` defaults to `None` and is overridden only by Hyprland and Niri, so `is_terminal` is silently false on KDE, GNOME, Sway and X11. Prefer a required method, or check every implementor.
+- **A trait method with a useful default is a trap. Prefer a required method, or check every implementor.** Case study: `WindowTracker::get_focused_window_class()` defaulted to `None` and only Hyprland and Niri overrode it, so `is_terminal` was silently false on KDE, GNOME, Sway and X11 until #71. The method is required now, Sway and X11 implement it, and KDE/GNOME return an explicit `None` (issue #72), so a new tracker cannot inherit the gap without a compile error.
 - **Wire new features into both transcription paths.** A feature added only to `run_streaming_pipeline` silently no-ops for batch backends (`groq`, `openai`/`deepgram` REST, `asr-sidecar`). This shipped as a bug in #54.
 - Config structs derive both `Serialize` and `Deserialize` for read/write
 

--- a/contrib/whisrs.1
+++ b/contrib/whisrs.1
@@ -153,8 +153,9 @@ turned off, because nothing was typed.
 .PP
 Terminal detection needs
 .BR WindowTracker::get_focused_window_class ,
-which only Hyprland and Niri implement; elsewhere a terminal is treated as an
-ordinary target and multi-line replies are typed.
+which Hyprland, Niri, Sway and X11 implement. On GNOME and KDE it reports
+nothing, so a terminal there is treated as an ordinary target and multi-line
+replies are typed.
 .SH ENVIRONMENT
 .TP
 .B WHISRS_GROQ_API_KEY

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,7 +153,8 @@ clipboard_only = false
 #   hyprctl activewindow | grep class
 #   niri msg focused-window
 #   swaymsg -t get_tree   (the focused node's app_id for Wayland apps,
-#                          window_properties.class for XWayland ones)
+#                          window_properties.class for XWayland ones, falling
+#                          back to window_properties.instance)
 #   xprop WM_CLASS        (then click the window; the SECOND string is the
 #                          class, and that is the one whisrs reports; when it
 #                          is empty, whisrs falls back to the first string)
@@ -164,7 +165,7 @@ clipboard_only = false
 # key has no effect on either.
 #
 # Sway and X11 started reporting a class in issue #71, so terminal detection
-# now fires on those sessions. Three behaviors change there:
+# now fires on those sessions. Four behaviors change there:
 #   * command mode clears the prompt line with Ctrl+A then Ctrl+K before
 #     injecting. That is right at a shell prompt and wrong inside a TUI; GNU
 #     screen takes Ctrl+A as its prefix, and many tmux users rebind theirs to
@@ -175,6 +176,8 @@ clipboard_only = false
 #     xterm and urxvt do not bind Ctrl+Shift+C. The primary selection is tried
 #     first and covers a highlighted selection, so this affects the fallback
 #     only.
+#   * with `paste = true`, injection sends Ctrl+Shift+V instead of Ctrl+V. This
+#     one is a fix, not a loss: Ctrl+V at a terminal is readline quoted-insert.
 terminal_classes = []
 
 [groq]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,8 +161,8 @@ clipboard_only = false
 #
 # A class is reported on Hyprland, Niri, Sway and X11. GNOME reports none
 # without a shell extension (issue #72), and KDE reports none because whisrs
-# does not speak the org_kde_plasma_window_management Wayland protocol, so this
-# key has no effect on either.
+# does not speak the org_kde_plasma_window_management Wayland protocol (issue
+# #127), so this key has no effect on either.
 #
 # Sway and X11 started reporting a class in issue #71, so terminal detection
 # now fires on those sessions. Four behaviors change there:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,8 +152,25 @@ clipboard_only = false
 # Read the class off your compositor:
 #   hyprctl activewindow | grep class
 #   niri msg focused-window
-# Hyprland and Niri are also the only window trackers that report a class
-# today, so this key has no effect on KDE, GNOME, Sway or X11 (issue #71).
+#   swaymsg -t get_tree   (the focused node's app_id for Wayland apps,
+#                          window_properties.class for XWayland ones)
+#   xprop WM_CLASS        (then click the window; the SECOND string is the
+#                          class, and that is the one whisrs reports)
+#
+# A class is reported on Hyprland, Niri, Sway and X11. KDE and GNOME report
+# none, so this key has no effect there (issue #72).
+#
+# Sway and X11 started reporting a class in issue #71, so terminal detection
+# now fires on those sessions. Three behaviors change there:
+#   * command mode clears the prompt line with Ctrl+A then Ctrl+K before
+#     injecting. That is right at a shell prompt and wrong inside a TUI; tmux
+#     binds Ctrl+A as its prefix by default.
+#   * a multi-line LLM reply is refused at a terminal and kept in `whisrs log`
+#     instead of being typed, including inside a terminal-hosted editor.
+#   * the selection copy fallback sends Ctrl+Shift+C instead of Ctrl+C. Stock
+#     xterm and urxvt do not bind Ctrl+Shift+C. The primary selection is tried
+#     first and covers a highlighted selection, so this affects the fallback
+#     only.
 terminal_classes = []
 
 [groq]
@@ -373,7 +390,7 @@ wrongly costs you one `whisrs log` lookup where injecting wrongly runs commands
 you never read, so it refuses either way.
 
 Terminal detection needs the compositor to report the focused window class,
-which today means Hyprland and Niri. On KDE, GNOME, Sway and X11 a terminal is
+which today means Hyprland, Niri, Sway and X11. On KDE and GNOME a terminal is
 treated as an ordinary target, so a multi-line reply is typed there. Add any
 class the built-in list misses to `[input] terminal_classes`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,16 +155,20 @@ clipboard_only = false
 #   swaymsg -t get_tree   (the focused node's app_id for Wayland apps,
 #                          window_properties.class for XWayland ones)
 #   xprop WM_CLASS        (then click the window; the SECOND string is the
-#                          class, and that is the one whisrs reports)
+#                          class, and that is the one whisrs reports; when it
+#                          is empty, whisrs falls back to the first string)
 #
-# A class is reported on Hyprland, Niri, Sway and X11. KDE and GNOME report
-# none, so this key has no effect there (issue #72).
+# A class is reported on Hyprland, Niri, Sway and X11. GNOME reports none
+# without a shell extension (issue #72), and KDE reports none because whisrs
+# does not speak the org_kde_plasma_window_management Wayland protocol, so this
+# key has no effect on either.
 #
 # Sway and X11 started reporting a class in issue #71, so terminal detection
 # now fires on those sessions. Three behaviors change there:
 #   * command mode clears the prompt line with Ctrl+A then Ctrl+K before
-#     injecting. That is right at a shell prompt and wrong inside a TUI; tmux
-#     binds Ctrl+A as its prefix by default.
+#     injecting. That is right at a shell prompt and wrong inside a TUI; GNU
+#     screen takes Ctrl+A as its prefix, and many tmux users rebind theirs to
+#     match.
 #   * a multi-line LLM reply is refused at a terminal and kept in `whisrs log`
 #     instead of being typed, including inside a terminal-hosted editor.
 #   * the selection copy fallback sends Ctrl+Shift+C instead of Ctrl+C. Stock

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -403,8 +403,9 @@ pub struct InputConfig {
     /// alone. Write the class exactly as the compositor reports it
     /// (`hyprctl activewindow`, `niri msg focused-window`, `swaymsg -t
     /// get_tree`, `xprop WM_CLASS`). Sway reports `app_id` for Wayland views
-    /// and `window_properties.class` for XWayland ones; on X11 the class is the
-    /// second of the two strings in `WM_CLASS`.
+    /// and `window_properties.class` for XWayland ones, falling back to
+    /// `window_properties.instance`; on X11 the class is the second of the two
+    /// strings in `WM_CLASS`, falling back to the first.
     #[serde(default)]
     pub terminal_classes: Vec<String>,
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -401,7 +401,10 @@ pub struct InputConfig {
     /// a generic name like `warp` matches a window whose class is exactly
     /// `warp`, and leaves `app.drey.Warp` (GNOME's Magic Wormhole client)
     /// alone. Write the class exactly as the compositor reports it
-    /// (`hyprctl activewindow`, `niri msg focused-window`).
+    /// (`hyprctl activewindow`, `niri msg focused-window`, `swaymsg -t
+    /// get_tree`, `xprop WM_CLASS`). Sway reports `app_id` for Wayland views
+    /// and `window_properties.class` for XWayland ones; on X11 the class is the
+    /// second of the two strings in `WM_CLASS`.
     #[serde(default)]
     pub terminal_classes: Vec<String>,
 }

--- a/src/daemon/command_mode.rs
+++ b/src/daemon/command_mode.rs
@@ -391,15 +391,13 @@ async fn command_mode_background_inner(
     // further down.
     //
     // `is_terminal` can only ever be true where
-    // `WindowTracker::get_focused_window_class()` is actually implemented,
-    // which is Hyprland (`src/window/hyprland.rs:59`) and Niri
-    // (`src/window/niri.rs:79`). `src/window/mod.rs:23` defaults it to `None`,
-    // so on KWin, GNOME, Sway and X11 it stays false and terminals there fall
-    // back to plain injection at the cursor (and to plain Ctrl+V on the paste
-    // branch). Tracked in issues #70 and #71; not fixed here. The practical
-    // consequence for the gate is that on those compositors a multi-line reply
-    // is typed into a terminal rather than refused — the same exposure the
-    // line-clear already has.
+    // `WindowTracker::get_focused_window_class()` is implemented, which is
+    // Hyprland, Niri, Sway and X11. It still returns `None` on KWin and GNOME
+    // (`src/window/dbus.rs`, issue #72), so there it stays false and terminals
+    // fall back to plain injection at the cursor (and to plain Ctrl+V on the
+    // paste branch). The practical consequence for the gate is that on those
+    // two desktops a multi-line reply is typed into a terminal rather than
+    // refused, the same exposure the line-clear already has.
     let is_terminal = context
         .window_tracker
         .get_focused_window_class()
@@ -888,9 +886,9 @@ async fn llm_command_background_inner(
     }
 
     // Resolved unconditionally, not just on the paste branch: the multi-line
-    // gate needs it too. Same #70/#71 caveat as command mode — only Hyprland
-    // and Niri implement `get_focused_window_class()`, so elsewhere this stays
-    // false and a terminal there is treated as an ordinary target.
+    // gate needs it too. Same caveat as command mode: `get_focused_window_class()`
+    // returns `None` on KWin and GNOME (issue #72), so this stays false there
+    // and a terminal is treated as an ordinary target.
     let is_terminal = context
         .window_tracker
         .get_focused_window_class()

--- a/src/daemon/command_mode.rs
+++ b/src/daemon/command_mode.rs
@@ -393,11 +393,13 @@ async fn command_mode_background_inner(
     // `is_terminal` can only ever be true where
     // `WindowTracker::get_focused_window_class()` is implemented, which is
     // Hyprland, Niri, Sway and X11. It still returns `None` on KWin and GNOME
-    // (`src/window/dbus.rs`, issue #72), so there it stays false and terminals
-    // fall back to plain injection at the cursor (and to plain Ctrl+V on the
-    // paste branch). The practical consequence for the gate is that on those
-    // two desktops a multi-line reply is typed into a terminal rather than
-    // refused, the same exposure the line-clear already has.
+    // (`src/window/dbus.rs`: GNOME needs a shell extension, issue #72; KWin
+    // would need the `org_kde_plasma_window_management` Wayland protocol), so
+    // there it stays false and terminals fall back to plain injection at the
+    // cursor (and to plain Ctrl+V on the paste branch). The practical
+    // consequence for the gate is that on those two desktops a multi-line reply
+    // is typed into a terminal rather than refused, the same exposure the
+    // line-clear already has.
     let is_terminal = context
         .window_tracker
         .get_focused_window_class()
@@ -887,8 +889,9 @@ async fn llm_command_background_inner(
 
     // Resolved unconditionally, not just on the paste branch: the multi-line
     // gate needs it too. Same caveat as command mode: `get_focused_window_class()`
-    // returns `None` on KWin and GNOME (issue #72), so this stays false there
-    // and a terminal is treated as an ordinary target.
+    // returns `None` on GNOME (needs a shell extension, issue #72) and on KWin
+    // (would need the `org_kde_plasma_window_management` Wayland protocol), so
+    // this stays false there and a terminal is treated as an ordinary target.
     let is_terminal = context
         .window_tracker
         .get_focused_window_class()

--- a/src/daemon/command_mode.rs
+++ b/src/daemon/command_mode.rs
@@ -394,8 +394,9 @@ async fn command_mode_background_inner(
     // `WindowTracker::get_focused_window_class()` is implemented, which is
     // Hyprland, Niri, Sway and X11. It still returns `None` on KWin and GNOME
     // (`src/window/dbus.rs`: GNOME needs a shell extension, issue #72; KWin
-    // would need the `org_kde_plasma_window_management` Wayland protocol), so
-    // there it stays false and terminals fall back to plain injection at the
+    // would need the `org_kde_plasma_window_management` Wayland protocol,
+    // issue #127), so it stays false and terminals fall back to plain
+    // injection at the
     // cursor (and to plain Ctrl+V on the paste branch). The practical
     // consequence for the gate is that on those two desktops a multi-line reply
     // is typed into a terminal rather than refused, the same exposure the
@@ -890,8 +891,9 @@ async fn llm_command_background_inner(
     // Resolved unconditionally, not just on the paste branch: the multi-line
     // gate needs it too. Same caveat as command mode: `get_focused_window_class()`
     // returns `None` on GNOME (needs a shell extension, issue #72) and on KWin
-    // (would need the `org_kde_plasma_window_management` Wayland protocol), so
-    // this stays false there and a terminal is treated as an ordinary target.
+    // (would need the `org_kde_plasma_window_management` Wayland protocol,
+    // issue #127), so this stays false there and a terminal is treated as an
+    // ordinary target.
     let is_terminal = context
         .window_tracker
         .get_focused_window_class()

--- a/src/window/dbus.rs
+++ b/src/window/dbus.rs
@@ -1,10 +1,11 @@
 //! D-Bus window tracking stub for GNOME and KDE.
 //!
-//! GNOME requires the `window-calls` extension, and KDE requires KWin scripting.
-//! Both are limited and not yet fully implemented. This module provides a stub
-//! that returns clear error messages.
+//! Neither desktop exposes focus tracking to an unprivileged daemon out of the
+//! box: GNOME needs a shell extension, and KDE needs the
+//! `org_kde_plasma_window_management` Wayland protocol. Tracked in issue #72.
+//! This module provides a stub that returns clear error messages.
 
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::WindowTracker;
 
@@ -38,5 +39,20 @@ impl WindowTracker for DbusTracker {
         );
         // Don't fail — graceful degradation.
         Ok(())
+    }
+
+    /// Always `None`: KDE would need the `org_kde_plasma_window_management`
+    /// Wayland protocol and GNOME needs a shell extension (issue #72), so
+    /// neither can report the focused window class here yet.
+    ///
+    /// Logged at `debug!` rather than the `warn!` the other two methods use:
+    /// this is queried on every injection, and the other backends log their
+    /// class lookups at `debug!` too.
+    fn get_focused_window_class(&self) -> Option<String> {
+        debug!(
+            "{} focused window class not yet supported; terminal detection stays off",
+            self.desktop
+        );
+        None
     }
 }

--- a/src/window/dbus.rs
+++ b/src/window/dbus.rs
@@ -3,7 +3,8 @@
 //! Neither desktop exposes focus tracking to an unprivileged daemon out of the
 //! box: GNOME needs a shell extension (issue #72), and KDE would need the
 //! `org_kde_plasma_window_management` Wayland protocol, which whisrs does not
-//! speak. This module provides a stub that returns clear error messages.
+//! speak (issue #127). This module provides a stub that returns clear error
+//! messages.
 
 use tracing::{debug, warn};
 
@@ -42,8 +43,8 @@ impl WindowTracker for DbusTracker {
     }
 
     /// Always `None`: GNOME needs a shell extension (issue #72) and KDE would
-    /// need the `org_kde_plasma_window_management` Wayland protocol, so neither
-    /// can report the focused window class here yet.
+    /// need the `org_kde_plasma_window_management` Wayland protocol (issue
+    /// #127), so neither can report the focused window class here yet.
     ///
     /// Logged at `debug!` rather than the `warn!` the other two methods use:
     /// this is queried on every injection, and the other backends log their

--- a/src/window/dbus.rs
+++ b/src/window/dbus.rs
@@ -1,9 +1,9 @@
 //! D-Bus window tracking stub for GNOME and KDE.
 //!
 //! Neither desktop exposes focus tracking to an unprivileged daemon out of the
-//! box: GNOME needs a shell extension, and KDE needs the
-//! `org_kde_plasma_window_management` Wayland protocol. Tracked in issue #72.
-//! This module provides a stub that returns clear error messages.
+//! box: GNOME needs a shell extension (issue #72), and KDE would need the
+//! `org_kde_plasma_window_management` Wayland protocol, which whisrs does not
+//! speak. This module provides a stub that returns clear error messages.
 
 use tracing::{debug, warn};
 
@@ -41,9 +41,9 @@ impl WindowTracker for DbusTracker {
         Ok(())
     }
 
-    /// Always `None`: KDE would need the `org_kde_plasma_window_management`
-    /// Wayland protocol and GNOME needs a shell extension (issue #72), so
-    /// neither can report the focused window class here yet.
+    /// Always `None`: GNOME needs a shell extension (issue #72) and KDE would
+    /// need the `org_kde_plasma_window_management` Wayland protocol, so neither
+    /// can report the focused window class here yet.
     ///
     /// Logged at `debug!` rather than the `warn!` the other two methods use:
     /// this is queried on every injection, and the other backends log their

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -20,9 +20,16 @@ pub trait WindowTracker: Send + Sync {
 
     /// Get the window class of the currently focused window (e.g. "Alacritty", "firefox").
     /// Returns `None` if the compositor does not support this query.
-    fn get_focused_window_class(&self) -> Option<String> {
-        None
-    }
+    ///
+    /// Implemented on Hyprland, Niri, Sway and X11. Returns `None` on KDE and
+    /// GNOME (`DbusTracker`), which have no unprivileged query for the focused
+    /// window class yet (issue #72).
+    ///
+    /// Deliberately required, with no default: a defaulted `None` here silently
+    /// disabled terminal detection on four platforms until #71, because every
+    /// new tracker inherited the gap without a compile error. A backend that
+    /// cannot answer has to say so with an explicit `None`.
+    fn get_focused_window_class(&self) -> Option<String>;
 }
 
 /// A no-op tracker that always succeeds without doing anything.
@@ -38,6 +45,11 @@ impl WindowTracker for NoopTracker {
     fn focus_window(&self, _id: &str) -> anyhow::Result<()> {
         Ok(())
     }
+
+    /// No compositor was detected, so there is no focused window to report.
+    fn get_focused_window_class(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Auto-detect the compositor and return the appropriate `WindowTracker`.
@@ -47,7 +59,8 @@ impl WindowTracker for NoopTracker {
 /// 2. `$NIRI_SOCKET` → Niri
 /// 3. `$SWAYSOCK` → Sway
 /// 4. `$XDG_SESSION_TYPE == x11` → X11
-/// 5. Fallback → NoopTracker
+/// 5. `$XDG_CURRENT_DESKTOP` contains gnome or kde → DbusTracker
+/// 6. Fallback → NoopTracker
 pub fn detect_tracker() -> Box<dyn WindowTracker> {
     if std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok() {
         info!("detected Hyprland compositor for window tracking");

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -23,7 +23,8 @@ pub trait WindowTracker: Send + Sync {
     ///
     /// Implemented on Hyprland, Niri, Sway and X11. Returns `None` on KDE and
     /// GNOME (`DbusTracker`), which have no unprivileged query for the focused
-    /// window class yet (issue #72).
+    /// window class yet: GNOME needs a shell extension (issue #72), KDE the
+    /// `org_kde_plasma_window_management` Wayland protocol.
     ///
     /// Deliberately required, with no default: a defaulted `None` here silently
     /// disabled terminal detection on four platforms until #71, because every

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -24,7 +24,7 @@ pub trait WindowTracker: Send + Sync {
     /// Implemented on Hyprland, Niri, Sway and X11. Returns `None` on KDE and
     /// GNOME (`DbusTracker`), which have no unprivileged query for the focused
     /// window class yet: GNOME needs a shell extension (issue #72), KDE the
-    /// `org_kde_plasma_window_management` Wayland protocol.
+    /// `org_kde_plasma_window_management` Wayland protocol (issue #127).
     ///
     /// Deliberately required, with no default: a defaulted `None` here silently
     /// disabled terminal detection on four platforms until #71, because every

--- a/src/window/sway.rs
+++ b/src/window/sway.rs
@@ -134,9 +134,7 @@ fn find_focused(node: &swayipc::Node) -> Option<&swayipc::Node> {
 /// classified differently depending on which compositor the user is running.
 /// `is_terminal_class` (`src/daemon/injection.rs`) lowercases before matching,
 /// so case alone is harmless — but the two fields are not case variants of one
-/// another. Foot reports instance `footclient` against class `foot-server`, and
-/// only one of those is in the terminal list, so the field choice decides the
-/// answer.
+/// another in general, so which one gets reported can decide the verdict.
 ///
 /// A candidate that trims to empty is skipped rather than returned, so a view
 /// that advertises an empty `app_id` still gets its XWayland properties

--- a/src/window/sway.rs
+++ b/src/window/sway.rs
@@ -32,11 +32,48 @@ impl WindowTracker for SwayTracker {
         // Walk the tree to find the focused node.
         let focused = find_focused(&tree);
         match focused {
-            Some(id) => {
+            Some(node) => {
+                let id = node.id;
                 debug!("sway focused window con_id: {id}");
                 Ok(id.to_string())
             }
             None => anyhow::bail!("no focused window found in sway tree"),
+        }
+    }
+
+    fn get_focused_window_class(&self) -> Option<String> {
+        let mut conn = match Connection::new() {
+            Ok(conn) => conn,
+            Err(err) => {
+                debug!("sway focused window class: IPC connect failed: {err}");
+                return None;
+            }
+        };
+
+        let tree = match conn.get_tree() {
+            Ok(tree) => tree,
+            Err(err) => {
+                debug!("sway focused window class: get_tree failed: {err}");
+                return None;
+            }
+        };
+
+        let Some(node) = find_focused(&tree) else {
+            debug!("sway focused window class: no focused node in sway tree");
+            return None;
+        };
+
+        match class_from_node(node) {
+            Some(class) => {
+                debug!("sway focused window class: {class}");
+                Some(class)
+            }
+            None => {
+                debug!(
+                    "sway focused window class: empty (focused node reported no app_id, class or instance)"
+                );
+                None
+            }
         }
     }
 
@@ -63,20 +100,170 @@ impl WindowTracker for SwayTracker {
     }
 }
 
-/// Recursively find the focused node in the sway tree, returning its `id`.
-fn find_focused(node: &swayipc::Node) -> Option<i64> {
+/// Recursively find the focused node in the sway tree.
+///
+/// Depth-first, first match wins: the node itself, then its tiling `nodes`,
+/// then its `floating_nodes`.
+fn find_focused(node: &swayipc::Node) -> Option<&swayipc::Node> {
     if node.focused {
-        return Some(node.id);
+        return Some(node);
     }
     for child in &node.nodes {
-        if let Some(id) = find_focused(child) {
-            return Some(id);
+        if let Some(found) = find_focused(child) {
+            return Some(found);
         }
     }
     for child in &node.floating_nodes {
-        if let Some(id) = find_focused(child) {
-            return Some(id);
+        if let Some(found) = find_focused(child) {
+            return Some(found);
         }
     }
     None
+}
+
+/// Extract a window-class-like identifier from a sway tree node.
+///
+/// Resolution order:
+/// 1. `app_id` — set only for xdg-shell (native Wayland) views.
+/// 2. `window_properties.class` — XWayland views only.
+/// 3. `window_properties.instance` — XWayland fallback.
+///
+/// **Why `class` before `instance`:** X11's `WM_CLASS` property is the pair
+/// (instance, class), and the X11 backend reports the *class* field. Sway's
+/// XWayland fallback has to agree with it, or the same terminal would be
+/// classified differently depending on which compositor the user is running.
+/// `is_terminal_class` (`src/daemon/injection.rs`) lowercases before matching,
+/// so case alone is harmless — but the two fields are not case variants of one
+/// another. Foot reports instance `footclient` against class `foot-server`, and
+/// only one of those is in the terminal list, so the field choice decides the
+/// answer.
+///
+/// A candidate that trims to empty is skipped rather than returned, so a view
+/// that advertises an empty `app_id` still gets its XWayland properties
+/// consulted. Returns `None` only when no candidate yields a non-empty value.
+///
+/// Pure: does no IPC, so it is unit-testable against tree fixtures.
+fn class_from_node(node: &swayipc::Node) -> Option<String> {
+    let window_properties = node.window_properties.as_ref();
+    [
+        node.app_id.as_deref(),
+        window_properties.and_then(|props| props.class.as_deref()),
+        window_properties.and_then(|props| props.instance.as_deref()),
+    ]
+    .into_iter()
+    .flatten()
+    .map(str::trim)
+    .find(|candidate| !candidate.is_empty())
+    .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal JSON for a sway tree node. Only the keys without a serde default
+    /// are spelled out; `extra` carries the view fields under test and must
+    /// start with a comma when non-empty.
+    fn node_json(id: i64, focused: bool, nodes: &str, floating_nodes: &str, extra: &str) -> String {
+        let rect = r#"{"x":0,"y":0,"width":0,"height":0}"#;
+        format!(
+            r#"{{"id":{id},"type":"con","border":"none","current_border_width":0,
+"layout":"none","rect":{rect},"window_rect":{rect},"deco_rect":{rect},
+"geometry":{rect},"urgent":false,"focused":{focused},"focus":[],
+"nodes":[{nodes}],"floating_nodes":[{floating_nodes}],"sticky":false{extra}}}"#
+        )
+    }
+
+    fn parse(json: &str) -> swayipc::Node {
+        serde_json::from_str(json).expect("fixture should deserialize as a swayipc::Node")
+    }
+
+    /// A focused leaf view carrying only the class-bearing fields.
+    fn view(extra: &str) -> swayipc::Node {
+        parse(&node_json(1, true, "", "", extra))
+    }
+
+    #[test]
+    fn class_from_node_uses_app_id_for_wayland_views() {
+        let node = view(r#","app_id":"Alacritty""#);
+
+        assert_eq!(class_from_node(&node).as_deref(), Some("Alacritty"));
+    }
+
+    #[test]
+    fn class_from_node_prefers_class_over_instance_for_xwayland_views() {
+        // WM_CLASS is (instance, class); the X11 backend reports class, so this
+        // one must too.
+        let node =
+            view(r#","app_id":null,"window_properties":{"instance":"xterm","class":"XTerm"}"#);
+
+        assert_eq!(class_from_node(&node).as_deref(), Some("XTerm"));
+    }
+
+    #[test]
+    fn class_from_node_falls_back_to_instance_when_class_is_null() {
+        let node = view(r#","app_id":null,"window_properties":{"instance":"xterm","class":null}"#);
+
+        assert_eq!(class_from_node(&node).as_deref(), Some("xterm"));
+    }
+
+    #[test]
+    fn class_from_node_skips_empty_app_id() {
+        let node = view(r#","app_id":"","window_properties":{"instance":"xterm","class":"XTerm"}"#);
+
+        assert_eq!(class_from_node(&node).as_deref(), Some("XTerm"));
+    }
+
+    #[test]
+    fn class_from_node_skips_whitespace_only_candidates() {
+        let node = view(r#","app_id":"  ","window_properties":{"instance":"xterm","class":"   "}"#);
+
+        assert_eq!(class_from_node(&node).as_deref(), Some("xterm"));
+    }
+
+    #[test]
+    fn class_from_node_returns_none_when_nothing_is_reported() {
+        let bare = view("");
+        assert_eq!(class_from_node(&bare), None);
+
+        let all_null = view(r#","app_id":null,"window_properties":{"instance":null,"class":null}"#);
+        assert_eq!(class_from_node(&all_null), None);
+    }
+
+    #[test]
+    fn find_focused_walks_into_tiling_children() {
+        let leaf = node_json(3, true, "", "", r#","app_id":"Alacritty""#);
+        let workspace = node_json(2, false, &leaf, "", "");
+        let root = parse(&node_json(1, false, &workspace, "", ""));
+
+        let focused = find_focused(&root).expect("nested tiling leaf should be found");
+
+        assert_eq!(focused.id, 3);
+        assert_eq!(class_from_node(focused).as_deref(), Some("Alacritty"));
+    }
+
+    #[test]
+    fn find_focused_walks_into_floating_children() {
+        let floating_leaf = node_json(4, true, "", "", r#","app_id":"org.gnome.Nautilus""#);
+        let workspace = node_json(2, false, "", &floating_leaf, "");
+        let root = parse(&node_json(1, false, &workspace, "", ""));
+
+        let focused = find_focused(&root).expect("nested floating leaf should be found");
+
+        assert_eq!(focused.id, 4);
+        assert_eq!(
+            class_from_node(focused).as_deref(),
+            Some("org.gnome.Nautilus")
+        );
+    }
+
+    #[test]
+    fn find_focused_returns_none_when_nothing_is_focused() {
+        let leaf = node_json(3, false, "", "", r#","app_id":"Alacritty""#);
+        let floating_leaf = node_json(4, false, "", "", r#","app_id":"firefox""#);
+        let workspace = node_json(2, false, &leaf, &floating_leaf, "");
+        let root = parse(&node_json(1, false, &workspace, "", ""));
+
+        assert!(find_focused(&root).is_none());
+    }
 }

--- a/src/window/x11.rs
+++ b/src/window/x11.rs
@@ -3,6 +3,8 @@
 use anyhow::Context;
 use tracing::debug;
 use x11rb::connection::Connection;
+use x11rb::errors::ReplyError;
+use x11rb::properties::WmClass;
 use x11rb::protocol::xproto::{AtomEnum, ConnectionExt as _, InputFocus, Window};
 use x11rb::rust_connection::RustConnection;
 
@@ -38,10 +40,14 @@ impl X11Tracker {
             net_active_window_atom: atom_reply.atom,
         })
     }
-}
 
-impl WindowTracker for X11Tracker {
-    fn get_focused_window(&self) -> anyhow::Result<String> {
+    /// Resolve the currently active window from `_NET_ACTIVE_WINDOW`.
+    ///
+    /// Shared by `get_focused_window` and `get_focused_window_class` so there
+    /// is a single copy of this logic. Deliberately not `get_input_focus`:
+    /// that returns the focus-proxy child window used by GTK and Swing, which
+    /// carries no `WM_CLASS` of its own.
+    fn active_window(&self) -> anyhow::Result<Window> {
         let cookie = self.conn.get_property(
             false,
             self.root,
@@ -70,8 +76,98 @@ impl WindowTracker for X11Tracker {
             anyhow::bail!("no active window (root focused)");
         }
 
+        Ok(window_id)
+    }
+}
+
+/// Resolve one half of a `WM_CLASS` property into a usable class string.
+///
+/// `WM_CLASS` holds two NUL-separated strings, instance first and class
+/// second. x11rb hands back everything after the first NUL as the class and
+/// strips only a single trailing NUL, so a malformed property with more than
+/// two fields (`b"World\0Good\0Day"`) still arrives here with interior NULs.
+/// Cut at the first one: a string containing a NUL can never match a terminal
+/// list entry, so passing it through would silently disable terminal
+/// detection instead of degrading to the first field.
+///
+/// The property is not guaranteed to be UTF-8 (ASCII is the norm), so decode
+/// lossily rather than discard a window whose class holds one odd byte.
+fn parse_wm_class(class_bytes: &[u8]) -> Option<String> {
+    let end = class_bytes
+        .iter()
+        .position(|&byte| byte == 0)
+        .unwrap_or(class_bytes.len());
+
+    let class = String::from_utf8_lossy(&class_bytes[..end]);
+    let class = class.trim();
+
+    if class.is_empty() {
+        None
+    } else {
+        Some(class.to_string())
+    }
+}
+
+impl WindowTracker for X11Tracker {
+    fn get_focused_window(&self) -> anyhow::Result<String> {
+        let window_id = self.active_window()?;
+
         debug!("X11 focused window: 0x{window_id:x}");
         Ok(window_id.to_string())
+    }
+
+    /// Report the focused window's `WM_CLASS`.
+    ///
+    /// Contract: the **class** (second) field wins, falling back to the
+    /// **instance** (first) field only when the class is empty or absent. This
+    /// matches the Sway backend, whose XWayland fallback reads
+    /// `window_properties.class` first; the two have to agree, or the same
+    /// terminal gets classified differently depending on which compositor the
+    /// user happens to be running.
+    ///
+    /// `is_terminal_class` (`src/daemon/injection.rs`) lowercases before
+    /// matching, so case is irrelevant here — but the choice of field is
+    /// load-bearing, because `foot-server` is deliberately not a terminal
+    /// while `footclient` is.
+    fn get_focused_window_class(&self) -> Option<String> {
+        let window_id = match self.active_window() {
+            Ok(window_id) => window_id,
+            Err(err) => {
+                debug!("X11 focused window class: active window lookup failed: {err}");
+                return None;
+            }
+        };
+
+        // WM_CLASS is a predefined atom, so this needs no intern_atom round
+        // trip. x11rb owns the property fetch and the NUL split.
+        let wm_class = WmClass::get(&self.conn, window_id)
+            .map_err(ReplyError::from)
+            .and_then(|cookie| cookie.reply());
+
+        let wm_class = match wm_class {
+            Ok(Some(wm_class)) => wm_class,
+            Ok(None) => {
+                debug!("X11 focused window class: no WM_CLASS property on 0x{window_id:x}");
+                return None;
+            }
+            Err(err) => {
+                debug!("X11 focused window class: WM_CLASS request failed: {err}");
+                return None;
+            }
+        };
+
+        if let Some(class) = parse_wm_class(wm_class.class()) {
+            debug!("X11 focused window class: {class}");
+            return Some(class);
+        }
+
+        if let Some(instance) = parse_wm_class(wm_class.instance()) {
+            debug!("X11 focused window class: {instance} (class field empty, used instance)");
+            return Some(instance);
+        }
+
+        debug!("X11 focused window class: empty (WM_CLASS has neither class nor instance)");
+        None
     }
 
     fn focus_window(&self, id: &str) -> anyhow::Result<()> {
@@ -88,5 +184,118 @@ impl WindowTracker for X11Tracker {
             .context("failed to flush X11 connection")?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use x11rb::protocol::xproto::GetPropertyReply;
+
+    /// Build the `WM_CLASS` reply an X server would send, so `WmClass` can be
+    /// exercised end to end without a display.
+    fn wm_class_reply(value: &[u8]) -> GetPropertyReply {
+        GetPropertyReply {
+            format: 8,
+            type_: AtomEnum::STRING.into(),
+            value_len: value.len() as u32,
+            value: value.to_vec(),
+            ..GetPropertyReply::default()
+        }
+    }
+
+    #[test]
+    fn parses_a_plain_class() {
+        assert_eq!(parse_wm_class(b"Alacritty"), Some("Alacritty".to_string()));
+    }
+
+    #[test]
+    fn trailing_nul_and_no_trailing_nul_agree() {
+        // x11rb strips at most one trailing NUL, so both WM_CLASS spellings
+        // reach us as the same class and must resolve identically.
+        assert_eq!(parse_wm_class(b"World"), Some("World".to_string()));
+        assert_eq!(parse_wm_class(b"World\0"), Some("World".to_string()));
+    }
+
+    #[test]
+    fn truncates_at_the_first_interior_nul() {
+        // A malformed WM_CLASS with more than two fields: x11rb hands back
+        // everything after the first NUL verbatim (b"World\0Good\0Day"), which
+        // could never match a terminal-list entry. We tighten that to the
+        // first field.
+        assert_eq!(
+            parse_wm_class(b"World\0Good\0Day"),
+            Some("World".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_input_is_none() {
+        assert_eq!(parse_wm_class(b""), None);
+    }
+
+    #[test]
+    fn whitespace_only_input_is_none() {
+        assert_eq!(parse_wm_class(b"   \t \n "), None);
+        // A lone NUL truncates to nothing, which is also nothing usable.
+        assert_eq!(parse_wm_class(b"\0"), None);
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed() {
+        assert_eq!(parse_wm_class(b"  XTerm  "), Some("XTerm".to_string()));
+    }
+
+    #[test]
+    fn non_utf8_bytes_do_not_panic() {
+        // WM_CLASS is not guaranteed UTF-8. Lossy decoding keeps the window
+        // identifiable instead of dropping it.
+        let class = parse_wm_class(b"Alac\xffritty").expect("lossy decode should yield a class");
+        assert!(class.starts_with("Alac"));
+        assert!(class.ends_with("ritty"));
+    }
+
+    #[test]
+    fn reports_the_class_field_not_the_instance() {
+        // xterm's real WM_CLASS: instance "xterm", class "XTerm".
+        let wm_class = WmClass::from_reply(wm_class_reply(b"xterm\0XTerm\0"))
+            .expect("well-formed WM_CLASS reply should parse")
+            .expect("STRING-typed reply should yield a WmClass");
+
+        assert_eq!(
+            parse_wm_class(wm_class.class()),
+            Some("XTerm".to_string()),
+            "the class half must win"
+        );
+        assert_eq!(
+            parse_wm_class(wm_class.instance()),
+            Some("xterm".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_instance_when_the_class_half_is_absent() {
+        // A window that set only one field: x11rb reports an empty class, so
+        // the instance is all we have.
+        let wm_class = WmClass::from_reply(wm_class_reply(b"Hello World"))
+            .expect("well-formed WM_CLASS reply should parse")
+            .expect("STRING-typed reply should yield a WmClass");
+
+        assert_eq!(parse_wm_class(wm_class.class()), None);
+        assert_eq!(
+            parse_wm_class(wm_class.instance()),
+            Some("Hello World".to_string())
+        );
+    }
+
+    #[test]
+    fn an_empty_wm_class_property_yields_nothing() {
+        let wm_class = WmClass::from_reply(wm_class_reply(b""))
+            .expect("empty WM_CLASS reply should parse")
+            .expect("STRING-typed reply should yield a WmClass");
+
+        assert_eq!(parse_wm_class(wm_class.class()), None);
+        assert_eq!(parse_wm_class(wm_class.instance()), None);
     }
 }

--- a/src/window/x11.rs
+++ b/src/window/x11.rs
@@ -108,6 +108,41 @@ fn parse_wm_class(class_bytes: &[u8]) -> Option<String> {
     }
 }
 
+/// Which half of a `WM_CLASS` property a resolved class came from.
+#[derive(Debug, PartialEq, Eq)]
+enum ClassField {
+    /// The class (second) half — the normal case.
+    Class,
+    /// The instance (first) half, used only when the class half is unusable.
+    Instance,
+}
+
+/// Resolve a whole `WM_CLASS` property into a usable class string.
+///
+/// Contract: the **class** (second) field wins, falling back to the
+/// **instance** (first) field only when the class is empty or absent, and
+/// `None` when neither yields anything. This matches the Sway backend, whose
+/// XWayland fallback reads `window_properties.class` first; the two have to
+/// agree, or the same terminal gets classified differently depending on which
+/// compositor the user happens to be running.
+///
+/// `is_terminal_class` (`src/daemon/injection.rs`) lowercases before matching,
+/// so case alone is harmless — but the two fields are not case variants of one
+/// another in general, so which one gets reported can decide the verdict.
+///
+/// Returns the field it used alongside the class, because the caller logs the
+/// instance fallback differently from a plain class hit.
+///
+/// Pure: takes an already-fetched property, so the precedence is unit-testable
+/// without a display.
+fn class_from_wm_class(wm_class: &WmClass) -> Option<(String, ClassField)> {
+    if let Some(class) = parse_wm_class(wm_class.class()) {
+        return Some((class, ClassField::Class));
+    }
+
+    parse_wm_class(wm_class.instance()).map(|instance| (instance, ClassField::Instance))
+}
+
 impl WindowTracker for X11Tracker {
     fn get_focused_window(&self) -> anyhow::Result<String> {
         let window_id = self.active_window()?;
@@ -118,17 +153,9 @@ impl WindowTracker for X11Tracker {
 
     /// Report the focused window's `WM_CLASS`.
     ///
-    /// Contract: the **class** (second) field wins, falling back to the
-    /// **instance** (first) field only when the class is empty or absent. This
-    /// matches the Sway backend, whose XWayland fallback reads
-    /// `window_properties.class` first; the two have to agree, or the same
-    /// terminal gets classified differently depending on which compositor the
-    /// user happens to be running.
-    ///
-    /// `is_terminal_class` (`src/daemon/injection.rs`) lowercases before
-    /// matching, so case is irrelevant here — but the choice of field is
-    /// load-bearing, because `foot-server` is deliberately not a terminal
-    /// while `footclient` is.
+    /// The class-before-instance precedence lives in `class_from_wm_class`;
+    /// this fetches the property and turns the outcome into the right
+    /// `debug!` line.
     fn get_focused_window_class(&self) -> Option<String> {
         let window_id = match self.active_window() {
             Ok(window_id) => window_id,
@@ -156,18 +183,20 @@ impl WindowTracker for X11Tracker {
             }
         };
 
-        if let Some(class) = parse_wm_class(wm_class.class()) {
-            debug!("X11 focused window class: {class}");
-            return Some(class);
+        match class_from_wm_class(&wm_class) {
+            Some((class, ClassField::Class)) => {
+                debug!("X11 focused window class: {class}");
+                Some(class)
+            }
+            Some((instance, ClassField::Instance)) => {
+                debug!("X11 focused window class: {instance} (class field empty, used instance)");
+                Some(instance)
+            }
+            None => {
+                debug!("X11 focused window class: empty (WM_CLASS has neither class nor instance)");
+                None
+            }
         }
-
-        if let Some(instance) = parse_wm_class(wm_class.instance()) {
-            debug!("X11 focused window class: {instance} (class field empty, used instance)");
-            return Some(instance);
-        }
-
-        debug!("X11 focused window class: empty (WM_CLASS has neither class nor instance)");
-        None
     }
 
     fn focus_window(&self, id: &str) -> anyhow::Result<()> {
@@ -205,6 +234,13 @@ mod tests {
         }
     }
 
+    /// Split a raw `WM_CLASS` property the way `WmClass::get` would.
+    fn wm_class_from(value: &[u8]) -> WmClass {
+        WmClass::from_reply(wm_class_reply(value))
+            .expect("WM_CLASS reply should parse")
+            .expect("STRING-typed reply should yield a WmClass")
+    }
+
     #[test]
     fn parses_a_plain_class() {
         assert_eq!(parse_wm_class(b"Alacritty"), Some("Alacritty".to_string()));
@@ -220,10 +256,11 @@ mod tests {
 
     #[test]
     fn truncates_at_the_first_interior_nul() {
-        // A malformed WM_CLASS with more than two fields: x11rb hands back
-        // everything after the first NUL verbatim (b"World\0Good\0Day"), which
-        // could never match a terminal-list entry. We tighten that to the
-        // first field.
+        // A malformed WM_CLASS with more than two fields, raw property
+        // b"Hello\0World\0Good\0Day": x11rb splits at the first NUL only, so
+        // the class half reaches parse_wm_class as the bytes below, interior
+        // NULs intact. A string holding a NUL could never match a terminal-list
+        // entry, so we cut at the first one and keep the leading field.
         assert_eq!(
             parse_wm_class(b"World\0Good\0Day"),
             Some("World".to_string())
@@ -259,9 +296,7 @@ mod tests {
     #[test]
     fn reports_the_class_field_not_the_instance() {
         // xterm's real WM_CLASS: instance "xterm", class "XTerm".
-        let wm_class = WmClass::from_reply(wm_class_reply(b"xterm\0XTerm\0"))
-            .expect("well-formed WM_CLASS reply should parse")
-            .expect("STRING-typed reply should yield a WmClass");
+        let wm_class = wm_class_from(b"xterm\0XTerm\0");
 
         assert_eq!(
             parse_wm_class(wm_class.class()),
@@ -275,27 +310,46 @@ mod tests {
     }
 
     #[test]
+    fn class_from_wm_class_prefers_class_over_instance() {
+        // The precedence itself, not just the halves it picks between:
+        // swapping the two branches in class_from_wm_class turns xterm's real
+        // WM_CLASS into Some("xterm") and fails here. The Sway backend has the
+        // matching test, and the two orders have to stay in step.
+        assert_eq!(
+            class_from_wm_class(&wm_class_from(b"xterm\0XTerm\0")),
+            Some(("XTerm".to_string(), ClassField::Class))
+        );
+    }
+
+    #[test]
     fn falls_back_to_the_instance_when_the_class_half_is_absent() {
         // A window that set only one field: x11rb reports an empty class, so
         // the instance is all we have.
-        let wm_class = WmClass::from_reply(wm_class_reply(b"Hello World"))
-            .expect("well-formed WM_CLASS reply should parse")
-            .expect("STRING-typed reply should yield a WmClass");
+        let wm_class = wm_class_from(b"Hello World");
 
         assert_eq!(parse_wm_class(wm_class.class()), None);
         assert_eq!(
             parse_wm_class(wm_class.instance()),
             Some("Hello World".to_string())
         );
+
+        // The same shape with the separator NUL present, this time through the
+        // precedence helper rather than a single half.
+        assert_eq!(
+            class_from_wm_class(&wm_class_from(b"xterm\0")),
+            Some(("xterm".to_string(), ClassField::Instance))
+        );
     }
 
     #[test]
     fn an_empty_wm_class_property_yields_nothing() {
-        let wm_class = WmClass::from_reply(wm_class_reply(b""))
-            .expect("empty WM_CLASS reply should parse")
-            .expect("STRING-typed reply should yield a WmClass");
+        let wm_class = wm_class_from(b"");
 
         assert_eq!(parse_wm_class(wm_class.class()), None);
         assert_eq!(parse_wm_class(wm_class.instance()), None);
+
+        // Both halves empty, with and without the separating NUL.
+        assert_eq!(class_from_wm_class(&wm_class), None);
+        assert_eq!(class_from_wm_class(&wm_class_from(b"\0")), None);
     }
 }


### PR DESCRIPTION
Closes #71.

`WindowTracker::get_focused_window_class()` defaulted to `None` and was overridden only by Hyprland and Niri, so `is_terminal` was silently false on Sway and X11. Terminal-aware copy, the multi-line LLM guard, the paste combo and `[input] terminal_classes` all took the GUI branch there.

- **Sway**: `app_id`, then `window_properties.class`, then `.instance`.
- **X11**: the `WM_CLASS` class field, read off `_NET_ACTIVE_WINDOW`. Not `get_input_focus`, which returns focus-proxy children with no `WM_CLASS` under GTK and Swing. Uses x11rb's own `properties::WmClass`, which is ungated, so no new dependency.

Both report the class and fall back to the instance, so a window classifies the same way whichever compositor is running.

The trait method is now required, with explicit `None` on `NoopTracker` and `DbusTracker`. The default body is what let this sit unnoticed on four platforms.

GNOME and KDE still report nothing: GNOME needs a shell extension (#72), KDE would need `org_kde_plasma_window_management` (#127).

### What changes for Sway and X11 users

Terminal detection starts firing, which is existing Hyprland and Niri behavior reaching two more platforms:

- Command mode clears the prompt line with Ctrl+A then Ctrl+K before injecting.
- A multi-line LLM reply is refused at a terminal and kept in `whisrs log` instead of being typed, including inside a terminal-hosted editor.
- The selection copy fallback sends Ctrl+Shift+C instead of Ctrl+C. Stock xterm and urxvt do not bind it. The primary selection is tried first, so this affects the fallback only.
- With `paste = true`, injection sends Ctrl+Shift+V.

The multi-line refusal cannot tell a shell prompt from an editor running in the same terminal. That is pre-existing and now reaches two more platforms, so it is filed as #128.

### Testing

20 new tests, none of which need a compositor or an X server. I'm on Hyprland and confirmed no regression there, but I can't run Sway or X11 end to end, hence `help wanted`.

If you're on either, two checks:

- With `whisrs command` at a shell prompt in your terminal, does the prompt line get cleared before the result is injected?
- Same thing in a GUI text field: does the field stay untouched?

@libussa for X11 if you have time.
