### PR TITLE
fix(lint): adopt as_chunks for the new clippy 1.98 lint

### DIFF
--- a/src/overlay/render.rs
+++ b/src/overlay/render.rs
@@ -743,7 +743,7 @@ mod tests {
         let t = Theme::ember();
         draw_overlay(&mut pm, State::Recording, 0, 1.0, shown(), &t);
         // tiny-skia stores premultiplied RGBA; alpha lives in the 4th byte.
-        assert!(pm.data().chunks_exact(4).any(|px| px[3] != 0));
+        assert!(pm.data().as_chunks::<4>().0.iter().any(|px| px[3] != 0));
     }
 
     #[test]
@@ -753,7 +753,9 @@ mod tests {
         // speaking frame paints green-dominant bar pixels that the recording
         // frame does not.
         fn green_dominant(data: &[u8]) -> usize {
-            data.chunks_exact(4)
+            data.as_chunks::<4>()
+                .0
+                .iter()
                 .filter(|px| px[1] > 150 && px[0] < 120 && px[1] > px[0])
                 .count()
         }
@@ -777,7 +779,7 @@ mod tests {
         let mut pm = fresh_pixmap();
         let t = Theme::ember();
         draw_overlay(&mut pm, State::Synthesizing, 0, 0.0, shown(), &t);
-        assert!(pm.data().chunks_exact(4).any(|px| px[3] != 0));
+        assert!(pm.data().as_chunks::<4>().0.iter().any(|px| px[3] != 0));
     }
 
     #[test]
@@ -808,7 +810,9 @@ mod tests {
         // count amber-dominant pixels (high R, mid G, low B) to measure
         // bar area independent of the bg pill.
         fn amber_pixels(data: &[u8]) -> usize {
-            data.chunks_exact(4)
+            data.as_chunks::<4>()
+                .0
+                .iter()
                 .filter(|px| px[0] > 200 && px[1] > 70 && px[1] < 180 && px[2] < 60)
                 .count()
         }

--- a/src/transcription/openai_realtime_protocol/profile.rs
+++ b/src/transcription/openai_realtime_protocol/profile.rs
@@ -398,8 +398,10 @@ mod tests {
             .decode(&encoded)
             .unwrap();
         let decoded_samples: Vec<i16> = decoded_bytes
-            .chunks_exact(2)
-            .map(|c| i16::from_le_bytes([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| i16::from_le_bytes(*c))
             .collect();
         assert_eq!(decoded_samples, samples);
     }


### PR DESCRIPTION
Rust 1.98.0 added `clippy::chunks_exact_to_as_chunks`, which fires on five constant-size `chunks_exact` calls:

- `src/overlay/render.rs:746, 756, 780, 811`
- `src/transcription/openai_realtime_protocol/profile.rs:401`

All five are in `#[cfg(test)]` code, so the failure surfaced as "could not compile `whisrs` (lib test)". All five predate #126; CI went red on the first push after the runner picked up 1.98, and would have on any push.

Test-only, no runtime behavior change. Verified clean under both 1.95.0 and 1.98.0: clippy with `-D warnings`, 468 tests, fmt and build.
