### PR TITLE
fix(window): warn once at startup on GNOME/KDE, not on every dictation

### DIFF
--- a/src/daemon/command_mode.rs
+++ b/src/daemon/command_mode.rs
@@ -392,10 +392,10 @@ async fn command_mode_background_inner(
     //
     // `is_terminal` can only ever be true where
     // `WindowTracker::get_focused_window_class()` is implemented, which is
-    // Hyprland, Niri, Sway and X11. It still returns `None` on KWin and GNOME
-    // (`src/window/dbus.rs`: GNOME needs a shell extension, issue #72; KWin
-    // would need the `org_kde_plasma_window_management` Wayland protocol,
-    // issue #127), so it stays false and terminals fall back to plain
+    // Hyprland, Niri, Sway and X11. It returns `None` on KWin and GNOME
+    // (`src/window/dbus.rs`: GNOME would need a Shell extension, #72; KWin the
+    // `org_kde_plasma_window_management` Wayland protocol, #127), so it stays
+    // false there and terminals fall back to plain
     // injection at the
     // cursor (and to plain Ctrl+V on the paste branch). The practical
     // consequence for the gate is that on those two desktops a multi-line reply
@@ -890,9 +890,9 @@ async fn llm_command_background_inner(
 
     // Resolved unconditionally, not just on the paste branch: the multi-line
     // gate needs it too. Same caveat as command mode: `get_focused_window_class()`
-    // returns `None` on GNOME (needs a shell extension, issue #72) and on KWin
+    // returns `None` on GNOME (would need a Shell extension, #72) and on KWin
     // (would need the `org_kde_plasma_window_management` Wayland protocol,
-    // issue #127), so this stays false there and a terminal is treated as an
+    // #127), so this stays false there and a terminal is treated as an
     // ordinary target.
     let is_terminal = context
         .window_tracker

--- a/src/window/dbus.rs
+++ b/src/window/dbus.rs
@@ -1,10 +1,15 @@
 //! D-Bus window tracking stub for GNOME and KDE.
 //!
 //! Neither desktop exposes focus tracking to an unprivileged daemon out of the
-//! box: GNOME needs a shell extension (issue #72), and KDE would need the
-//! `org_kde_plasma_window_management` Wayland protocol, which whisrs does not
-//! speak (issue #127). This module provides a stub that returns clear error
-//! messages.
+//! box. On GNOME, `org.gnome.Shell.Introspect` returns exactly the right
+//! fields but is allow listed to the GTK and portal backends, and Mutter
+//! implements neither foreign-toplevel protocol; a Shell extension is the only
+//! route. On KDE it would take the `org_kde_plasma_window_management` Wayland
+//! protocol, which whisrs does not speak. See #72 and #127 for the protocol
+//! surveys behind those two sentences.
+//!
+//! So this backend cannot answer, and the only honest thing left is to say so
+//! clearly once instead of failing quietly on every dictation.
 
 use tracing::{debug, warn};
 
@@ -16,7 +21,20 @@ pub struct DbusTracker {
 }
 
 impl DbusTracker {
+    /// Warns once, at construction, rather than once per call.
+    ///
+    /// The daemon builds exactly one tracker ([`super::detect_tracker`]) and
+    /// every method below runs on each dictation, so the per-call warnings
+    /// this replaces were noise repeating a limitation the user can do nothing
+    /// about. One startup line naming both consequences is more useful than a
+    /// hundred lines naming neither.
     pub fn new(desktop: &str) -> Self {
+        warn!(
+            "{desktop} exposes no unprivileged focused-window query, so window tracking is off: \
+             focus is not restored after recording (text goes wherever focus ends up), and \
+             terminal detection never fires, which leaves the terminal-aware selection copy, \
+             the multi-line LLM guard and [input] terminal_classes inactive"
+        );
         Self {
             desktop: desktop.to_string(),
         }
@@ -24,34 +42,33 @@ impl DbusTracker {
 }
 
 impl WindowTracker for DbusTracker {
+    /// A placeholder id, so the caller's save-then-restore flow still runs.
+    ///
+    /// `debug!` rather than `warn!`: [`DbusTracker::new`] already warned once,
+    /// and this runs on every dictation.
     fn get_focused_window(&self) -> anyhow::Result<String> {
-        warn!(
-            "{} window tracking not yet supported — text will be typed at current cursor",
+        debug!(
+            "{} window tracking not supported; returning a stub id",
             self.desktop
         );
-        // Return a placeholder so the flow doesn't break.
         Ok("dbus-stub".to_string())
     }
 
+    /// A no-op, deliberately `Ok`: focus restoration failing is not a reason to
+    /// abandon a transcript the user already spoke.
     fn focus_window(&self, _id: &str) -> anyhow::Result<()> {
-        warn!(
-            "{} window focus restoration not yet supported — skipping",
-            self.desktop
-        );
-        // Don't fail — graceful degradation.
+        debug!("{} focus restoration not supported; skipping", self.desktop);
         Ok(())
     }
 
-    /// Always `None`: GNOME needs a shell extension (issue #72) and KDE would
-    /// need the `org_kde_plasma_window_management` Wayland protocol (issue
-    /// #127), so neither can report the focused window class here yet.
+    /// Always `None`, which is what keeps terminal detection off here.
     ///
-    /// Logged at `debug!` rather than the `warn!` the other two methods use:
-    /// this is queried on every injection, and the other backends log their
-    /// class lookups at `debug!` too.
+    /// Required rather than defaulted since #71: a backend that cannot answer
+    /// has to say so explicitly, because the defaulted `None` this replaced
+    /// disabled terminal detection on four platforms without a compile error.
     fn get_focused_window_class(&self) -> Option<String> {
         debug!(
-            "{} focused window class not yet supported; terminal detection stays off",
+            "{} focused window class not supported; terminal detection stays off",
             self.desktop
         );
         None

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -22,9 +22,9 @@ pub trait WindowTracker: Send + Sync {
     /// Returns `None` if the compositor does not support this query.
     ///
     /// Implemented on Hyprland, Niri, Sway and X11. Returns `None` on KDE and
-    /// GNOME (`DbusTracker`), which have no unprivileged query for the focused
-    /// window class yet: GNOME needs a shell extension (issue #72), KDE the
-    /// `org_kde_plasma_window_management` Wayland protocol (issue #127).
+    /// GNOME (`DbusTracker`), neither of which exposes an unprivileged query
+    /// for the focused window class: GNOME would need a Shell extension (#72),
+    /// KDE the `org_kde_plasma_window_management` Wayland protocol (#127).
     ///
     /// Deliberately required, with no default: a defaulted `None` here silently
     /// disabled terminal detection on four platforms until #71, because every


### PR DESCRIPTION
`DbusTracker` warned from `get_focused_window` and `focus_window` on every call, so a GNOME or KDE user got two log lines per dictation restating a limitation they can do nothing about. Neither line named what it costs them.

The daemon builds exactly one tracker (`src/daemon/main.rs:92`), so the warning moves to `DbusTracker::new()` and states both consequences once:

```
gnome exposes no unprivileged focused-window query, so window tracking is off:
focus is not restored after recording (text goes wherever focus ends up), and
terminal detection never fires, which leaves the terminal-aware selection copy,
the multi-line LLM guard and [input] terminal_classes inactive
```

The three methods drop to `debug!`.

Also retires the "not yet supported" wording in the doc comments at `src/window/mod.rs`, `src/window/dbus.rs` and `src/daemon/command_mode.rs`, which read as work in flight.

### Why #72 and #127 are being closed rather than built

`get_focused_window_class()` is read from four places, none of which is plain dictation:

- `src/daemon/pipeline.rs` behind `[input] paste`, default false
- `src/daemon/speak.rs` behind `[tts] enabled`, default false
- `src/daemon/command_mode.rs`, twice, both needing LLM config

`whisrs toggle` on GNOME or KDE behaves the same as anywhere else, and neither desktop has produced a report about the opt-in paths. Building the GNOME Shell extension route costs a new D-Bus surface on a platform I cannot test, for a failure mode nobody has hit.

### Testing

`DbusTracker` is never constructed on Hyprland, so this is not observable on my setup. No behavior change on any implemented backend.