### PR TITLE
feat(deepgram): send [general] vocabulary as keyterm params

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,10 +17,12 @@ filler_words = []           # custom list (empty = use built-in defaults)
 audio_feedback = true       # play tones on record start/stop/done
 audio_feedback_volume = 0.5 # 0.0 to 1.0
 vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription accuracy
+                            # (sent to Deepgram as keyterms on Nova-3/Flux, ignored on
+                            # older models; folded into the prompt hint elsewhere)
 prompt = "Speech is in English or Spanish. Transcribe in the language spoken; never translate."
                             # optional sentence-style context, prepended to vocabulary
                             # (passed to Groq, OpenAI REST/Realtime, and local whisper.cpp;
-                            # Deepgram does not accept a prompt)
+                            # Deepgram takes no prompt — use vocabulary there)
 tray = true                 # system tray icon (requires SNI host like waybar)
 overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,9 @@ audio_feedback_volume = 0.5 # 0.0 to 1.0
 vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription accuracy
                             # (sent to Deepgram as keyterms on Nova-3/Flux, ignored on
                             # older models; folded into the prompt hint elsewhere)
+                            # very long lists are truncated for Deepgram, since every
+                            # keyterm rides in the request URI — the daemon warns at
+                            # startup naming how many terms actually reach it
 prompt = "Speech is in English or Spanish. Transcribe in the language spoken; never translate."
                             # optional sentence-style context, prepended to vocabulary
                             # (passed to Groq, OpenAI REST/Realtime, and local whisper.cpp;

--- a/docs/version-roadmap.md
+++ b/docs/version-roadmap.md
@@ -17,7 +17,7 @@ historical record; current development happens against the v0.1.x patch line.
 ## v0.1.3 — Command Mode & Custom Vocabulary ✓
 
 - [x] **Command mode** (`whisrs command`): Select text + hotkey → record voice instruction → LLM rewrites the selection. Toggleable (press again to stop early). (Originally pasted the result via simulated Ctrl+C/Ctrl+V; later releases inject it through the dictation pipeline instead: typed at the cursor by default, pasted when `[input] paste` is set, with terminals clearing the prompt line first.)
-- [x] **Custom vocabulary**: `vocabulary = ["term1", "term2"]` in config — passed as prompt hint to Groq, OpenAI REST, and local whisper backends
+- [x] **Custom vocabulary**: `vocabulary = ["term1", "term2"]` in config — sent to Deepgram as keyterms on Nova-3/Flux (ignored on older models), and folded into the prompt hint for Groq, OpenAI REST, and local whisper backends
 - [x] **LLM integration**: `[llm]` config section with provider selection (OpenAI, Groq, OpenRouter, Google Gemini) and model menus with latest models. "Other" option for custom model names.
 
 ---

--- a/examples/issue55_stream_check.rs
+++ b/examples/issue55_stream_check.rs
@@ -239,6 +239,7 @@ async fn main() -> anyhow::Result<ExitCode> {
         language: "en".to_string(),
         model: "base.en".to_string(),
         prompt: None,
+        keyterms: Vec::new(),
     };
 
     let (audio_tx, audio_rx) = mpsc::channel::<Vec<i16>>(256);

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -324,7 +324,7 @@ pub(crate) fn configure_backend(
             let model = existing
                 .and_then(|c| c.deepgram.as_ref())
                 .map(|d| d.model.clone())
-                .unwrap_or_else(|| "nova-3".to_string());
+                .unwrap_or_else(crate::config::types::default_deepgram_model);
             Ok(BackendConfigSelection {
                 deepgram: Some(DeepgramConfig { api_key, model }),
                 ..BackendConfigSelection::default()

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::hotkey;
 use crate::llm;
+use crate::transcription::deepgram;
 use crate::transcription::openai_realtime_protocol::{OpenAiRealtimeProfile, TurnDetectionMode};
 use crate::WhisrsError;
 
@@ -588,7 +589,12 @@ fn default_llm_instruction() -> String {
 fn default_key_delay_ms() -> u64 {
     2
 }
-fn default_deepgram_model() -> String {
+/// The `[deepgram] model` a config gets when the section omits it.
+///
+/// `pub(crate)` so `whisrs setup` writes this rather than its own copy of the
+/// string. It is the single source for the default: [`Config::deepgram_model`]
+/// routes through it, and the daemon's model resolution routes through that.
+pub(crate) fn default_deepgram_model() -> String {
     "nova-3".to_string()
 }
 fn default_groq_model() -> String {
@@ -1030,6 +1036,8 @@ impl Config {
             });
         }
 
+        warnings.extend(self.deepgram_keyterm_warnings(backend));
+
         // Streaming backends (including local-whisper, which always streams
         // regardless of its `segmentation` mode) type dictated text
         // incrementally as it arrives and never go through the
@@ -1297,6 +1305,96 @@ impl Config {
         }
 
         Ok(warnings)
+    }
+
+    /// The Deepgram model this config will actually transcribe with.
+    ///
+    /// `[deepgram]` is an optional section: a config that names the backend but
+    /// omits the section still gets the section's own serde default. Resolving
+    /// through [`default_deepgram_model`] rather than repeating the string
+    /// keeps the keyterm gate below in step with that default — a literal copy
+    /// rots silently the day the default moves.
+    ///
+    /// `pub`, not private, because the model that actually goes on the wire is
+    /// resolved by the daemon's `get_model_for_backend`, and the daemon is a
+    /// separate binary crate. It used to carry its own `"nova-3"` literal, and
+    /// that literal was unpinned: flipping it to `"nova-2"` left the whole test
+    /// suite green while every request would have 400'd with `validate` silent,
+    /// because the gate here inspected a different string than the wire used.
+    /// One function, one answer.
+    pub fn deepgram_model(&self) -> String {
+        self.deepgram
+            .as_ref()
+            .map(|d| d.model.clone())
+            .unwrap_or_else(default_deepgram_model)
+    }
+
+    /// Load-time warnings about `[general] vocabulary` reaching Deepgram.
+    ///
+    /// The vocabulary rides to Deepgram as repeated `keyterm` query params, and
+    /// both ways it can fail to arrive are invisible at run time: the backend
+    /// logs the drop at `debug!`, which the daemon's default `info` filter
+    /// hides. Say it once at load instead, the same way the GNOME/KDE
+    /// window-tracker gap is reported.
+    ///
+    /// The `backend` gate is load-bearing, not decoration. `whisrs setup`
+    /// writes a `[deepgram]` section, and people leave it behind when they
+    /// switch backends — without the gate a `backend = "groq"` user with a
+    /// stale `[deepgram] model = "nova-2"` and any vocabulary at all gets a
+    /// bogus "vocabulary is ignored" warning on every daemon start, about a
+    /// backend they are not using.
+    fn deepgram_keyterm_warnings(&self, backend: &str) -> Vec<ConfigWarning> {
+        let mut warnings = Vec::new();
+        if !matches!(backend, "deepgram" | "deepgram-streaming") {
+            return warnings;
+        }
+
+        // Blank entries are not terms, so a vocabulary of nothing but blanks
+        // has nothing to warn about.
+        let usable = deepgram::usable_keyterms(&self.general.vocabulary).count();
+        if usable == 0 {
+            return warnings;
+        }
+
+        let model = self.deepgram_model();
+        if !deepgram::supports_keyterm(&model) {
+            warnings.push(ConfigWarning {
+                message: format!(
+                    "[general] vocabulary is ignored with [deepgram] model = \"{model}\": \
+                     keyterm prompting is a Nova-3/Flux feature and Deepgram rejects the \
+                     parameter on older models, so the {usable} term(s) are dropped from every \
+                     request. Switch to a nova-3 model to bias transcription toward them."
+                ),
+            });
+            return warnings;
+        }
+
+        // One list, one count: `effective_keyterms` is the same function the
+        // request builder slices with, so the number named here is the number
+        // that goes on the wire.
+        //
+        // "N of M", not "the first N": `effective_keyterms` skips a term that
+        // does not fit and keeps going, so the surviving terms are not a prefix
+        // of the list.
+        let effective = deepgram::effective_keyterms(&self.general.vocabulary).len();
+        if effective < usable {
+            warnings.push(ConfigWarning {
+                message: format!(
+                    "[general] vocabulary: {effective} of {usable} usable term(s) reach \
+                     Deepgram. Keyterms are capped at {} bytes of query string, {} terms and \
+                     {} words per request, because every term rides in the request URI: an \
+                     oversized URI is rejected by the edge as a bare 400 that never mentions \
+                     the vocabulary, and Deepgram's own 500-token keyterm cap is answered the \
+                     same way. Terms that do not fit are skipped individually, so the ones \
+                     that arrive are not necessarily the first ones. Trim the list to keep it \
+                     predictable.",
+                    deepgram::KEYTERM_QUERY_BUDGET_BYTES,
+                    deepgram::KEYTERM_MAX_TERMS,
+                    deepgram::KEYTERM_MAX_WORDS
+                ),
+            });
+        }
+        warnings
     }
 
     /// Check if any transcription backend has an API key configured.
@@ -2038,6 +2136,218 @@ mod tests {
 
         assert!(config.validate().is_ok());
         assert!(config.asr_sidecar.is_some());
+    }
+
+    /// A deepgram config on `model` with the given vocabulary terms.
+    fn deepgram_config_with_vocabulary(model: &str, vocabulary: &[String]) -> Config {
+        let mut config: Config = toml::from_str("").expect("empty config uses defaults");
+        config.general.backend = "deepgram".to_string();
+        config.general.vocabulary = vocabulary.to_vec();
+        config.deepgram = Some(DeepgramConfig {
+            api_key: "test-key".to_string(),
+            model: model.to_string(),
+        });
+        config
+    }
+
+    #[test]
+    fn config_validate_warns_vocabulary_ignored_on_pre_nova3_deepgram_model() {
+        // The backend drops the terms at `debug!`, which the daemon's default
+        // `info` filter hides — so this has to be said once at load.
+        let vocabulary = vec!["whisrs".to_string(), "Hyprland".to_string()];
+        let config = deepgram_config_with_vocabulary("nova-2", &vocabulary);
+        let warnings = config.validate().unwrap();
+        let warning = warnings
+            .iter()
+            .find(|w| w.message.contains("vocabulary"))
+            .unwrap_or_else(|| panic!("nova-2 + vocabulary must warn: {warnings:?}"));
+        assert!(
+            warning.message.contains("nova-2"),
+            "the warning must name the model: {}",
+            warning.message
+        );
+        assert!(
+            warning.message.contains("ignored") || warning.message.contains("dropped"),
+            "the warning must say the terms do not reach Deepgram: {}",
+            warning.message
+        );
+    }
+
+    #[test]
+    fn config_validate_does_not_warn_about_vocabulary_on_nova3() {
+        let vocabulary = vec!["whisrs".to_string()];
+        let config = deepgram_config_with_vocabulary("nova-3", &vocabulary);
+        let warnings = config.validate().unwrap();
+        assert!(
+            warnings.iter().all(|w| !w.message.contains("vocabulary")),
+            "nova-3 supports keyterm; nothing to warn about: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn config_validate_does_not_warn_without_vocabulary() {
+        let config = deepgram_config_with_vocabulary("nova-2", &[]);
+        let warnings = config.validate().unwrap();
+        assert!(
+            warnings.iter().all(|w| !w.message.contains("vocabulary")),
+            "no vocabulary means nothing is being dropped: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn config_validate_warns_when_vocabulary_exceeds_the_keyterm_budget() {
+        // An unbounded vocabulary builds an oversized request URI and
+        // Deepgram's edge answers a bare 400 that never mentions it.
+        let vocabulary: Vec<String> = (0..1000).map(|i| format!("term{i:04}")).collect();
+        let config = deepgram_config_with_vocabulary("nova-3", &vocabulary);
+        let warnings = config.validate().unwrap();
+        let warning = warnings
+            .iter()
+            .find(|w| w.message.contains("vocabulary"))
+            .unwrap_or_else(|| panic!("an oversized vocabulary must warn: {warnings:?}"));
+        let fitting = deepgram::effective_keyterms(&vocabulary).len();
+        assert!(
+            warning.message.contains(&format!(
+                "{fitting} of {} usable term(s) reach",
+                vocabulary.len()
+            )),
+            "the warning must name how many terms are actually sent ({fitting}): {}",
+            warning.message
+        );
+        // All three limits, spelled with their units — a bare `contains("200")`
+        // would be satisfied by the term count itself.
+        assert!(
+            warning.message.contains(&format!(
+                "{} bytes of query string",
+                deepgram::KEYTERM_QUERY_BUDGET_BYTES
+            )),
+            "the warning must name the byte budget: {}",
+            warning.message
+        );
+        assert!(
+            warning
+                .message
+                .contains(&format!("{} terms and", deepgram::KEYTERM_MAX_TERMS)),
+            "the warning must name the term cap: {}",
+            warning.message
+        );
+        assert!(
+            warning.message.contains(&format!(
+                "{} words per request",
+                deepgram::KEYTERM_MAX_WORDS
+            )),
+            "the warning must name the word cap: {}",
+            warning.message
+        );
+    }
+
+    /// The term count `Config::validate` advertises, parsed back out of its
+    /// warning text.
+    ///
+    /// The whole point of the warning is that the number it names is the number
+    /// of `keyterm` params the request carries. Reading it back out of the
+    /// message is what lets a test compare the two, rather than compare
+    /// `effective_keyterms` against itself.
+    fn advertised_keyterm_count(warnings: &[ConfigWarning]) -> Option<usize> {
+        let message = &warnings
+            .iter()
+            .find(|w| w.message.starts_with("[general] vocabulary: "))?
+            .message;
+        message
+            .trim_start_matches("[general] vocabulary: ")
+            .split(' ')
+            .next()?
+            .parse()
+            .ok()
+    }
+
+    #[test]
+    fn config_validate_advertises_the_count_that_goes_on_the_wire() {
+        // The no-drift invariant, in every shape that trips a different limit.
+        // This broke once already: blanks were charged against the byte budget
+        // and filtered afterwards, so `validate` promised 335 while the request
+        // carried 135.
+        let cases: Vec<(&str, Vec<String>)> = vec![
+            // Byte-budget-bound: 1000 short single-word terms.
+            (
+                "byte budget",
+                (0..1000).map(|i| format!("term{i:04}")).collect(),
+            ),
+            // Term-cap-bound: terms short enough that 200 of them use barely
+            // half the byte budget.
+            ("term cap", (0..500).map(|i| format!("t{i:03}")).collect()),
+            // Word-cap-bound: three words each, so 300 words arrives at 100
+            // terms, well before the byte budget's 195.
+            ("word cap", vec!["ab cd ef".to_string(); 400]),
+            // Blanks interleaved: blanks are not terms and must cost nothing.
+            (
+                "blanks interleaved",
+                (0..1000)
+                    .flat_map(|i| ["   ".to_string(), format!("term{i:04}")])
+                    .collect(),
+            ),
+            // One oversized term first: it must be skipped, not fatal.
+            (
+                "long term first",
+                vec![
+                    "x".repeat(5000),
+                    "whisrs".to_string(),
+                    "Hyprland".to_string(),
+                ],
+            ),
+        ];
+
+        for (label, vocabulary) in cases {
+            let config = deepgram_config_with_vocabulary("nova-3", &vocabulary);
+            let warnings = config.validate().expect("a keyed deepgram config is valid");
+            let advertised = advertised_keyterm_count(&warnings).unwrap_or_else(|| {
+                panic!("{label}: a truncated vocabulary must warn: {warnings:?}")
+            });
+            let on_wire = deepgram::effective_keyterms(&config.general.vocabulary).len();
+            assert_eq!(
+                advertised, on_wire,
+                "{label}: validate advertised {advertised} but the request carries {on_wire}"
+            );
+        }
+    }
+
+    #[test]
+    fn config_validate_does_not_warn_about_deepgram_vocabulary_on_another_backend() {
+        // `whisrs setup` writes a [deepgram] section, and people leave it
+        // behind when they switch backends. Without the backend gate, this
+        // groq user gets a "vocabulary is ignored" warning on every daemon
+        // start about a backend they are not using.
+        let mut config = deepgram_config_with_vocabulary(
+            "nova-2",
+            &["whisrs".to_string(), "Hyprland".to_string()],
+        );
+        config.general.backend = "groq".to_string();
+        config.groq = Some(GroqConfig {
+            api_key: "test-key".to_string(),
+            model: default_groq_model(),
+        });
+        let warnings = config.validate().unwrap();
+        assert!(
+            warnings.iter().all(|w| !w.message.contains("vocabulary")),
+            "a stale [deepgram] section must not warn on another backend: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn deepgram_keyterm_warnings_without_a_deepgram_section_use_the_default_model() {
+        // `[deepgram]` is optional; the section's serde default (nova-3)
+        // supports keyterm, so an absent section must not produce the
+        // "vocabulary is ignored" warning. Goes through the warning builder
+        // rather than `validate` because `validate` rejects a deepgram backend
+        // with no section and no `WHISRS_DEEPGRAM_API_KEY` before it gets here.
+        let mut config = deepgram_config_with_vocabulary("nova-3", &["whisrs".to_string()]);
+        config.deepgram = None;
+        assert_eq!(config.deepgram_model(), default_deepgram_model());
+        let warnings = config.deepgram_keyterm_warnings("deepgram");
+        assert!(
+            warnings.is_empty(),
+            "the default model supports keyterm; nothing to warn about: {warnings:?}"
+        );
     }
 
     #[test]

--- a/src/daemon/factory.rs
+++ b/src/daemon/factory.rs
@@ -84,7 +84,10 @@ pub(crate) fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
                 warn!("no Deepgram API key configured");
             }
             info!("using Deepgram REST transcription backend");
-            Arc::new(DeepgramRestBackend::new(api_key))
+            Arc::new(DeepgramRestBackend::new(
+                api_key,
+                config.general.vocabulary.clone(),
+            ))
         }
         "deepgram-streaming" => {
             let api_key = resolve_deepgram_api_key(config).unwrap_or_default();
@@ -92,7 +95,10 @@ pub(crate) fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
                 warn!("no Deepgram API key configured");
             }
             info!("using Deepgram streaming transcription backend");
-            Arc::new(DeepgramStreamingBackend::new(api_key))
+            Arc::new(DeepgramStreamingBackend::new(
+                api_key,
+                config.general.vocabulary.clone(),
+            ))
         }
         "groq" => {
             let api_key = resolve_groq_api_key(config).unwrap_or_default();

--- a/src/daemon/factory.rs
+++ b/src/daemon/factory.rs
@@ -84,10 +84,7 @@ pub(crate) fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
                 warn!("no Deepgram API key configured");
             }
             info!("using Deepgram REST transcription backend");
-            Arc::new(DeepgramRestBackend::new(
-                api_key,
-                config.general.vocabulary.clone(),
-            ))
+            Arc::new(DeepgramRestBackend::new(api_key))
         }
         "deepgram-streaming" => {
             let api_key = resolve_deepgram_api_key(config).unwrap_or_default();
@@ -95,10 +92,7 @@ pub(crate) fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
                 warn!("no Deepgram API key configured");
             }
             info!("using Deepgram streaming transcription backend");
-            Arc::new(DeepgramStreamingBackend::new(
-                api_key,
-                config.general.vocabulary.clone(),
-            ))
+            Arc::new(DeepgramStreamingBackend::new(api_key))
         }
         "groq" => {
             let api_key = resolve_groq_api_key(config).unwrap_or_default();
@@ -231,11 +225,13 @@ pub(crate) fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
 
 pub(crate) fn get_model_for_backend(config: &Config) -> String {
     match config.general.backend.as_str() {
-        "deepgram" | "deepgram-streaming" => config
-            .deepgram
-            .as_ref()
-            .map(|d| d.model.clone())
-            .unwrap_or_else(|| "nova-3".to_string()),
+        // Not a local literal: `Config::deepgram_model` is the same function
+        // `Config::validate`'s keyterm gate inspects, so the model warned about
+        // at load is the model that goes on the wire. A separate copy here was
+        // unpinned — flipping it to "nova-2" left all 498 tests green, which
+        // would have meant `validate` staying silent while every keyterm
+        // request 400'd.
+        "deepgram" | "deepgram-streaming" => config.deepgram_model(),
         "groq" => config
             .groq
             .as_ref()
@@ -312,5 +308,27 @@ mod tests {
         };
 
         assert_eq!(get_model_for_backend(&config), "Whisper-Tiny");
+    }
+
+    #[test]
+    fn deepgram_model_on_the_wire_is_the_one_validate_gates_on() {
+        // `[deepgram]` is optional, and with the section absent this factory
+        // used to fall back to its own `"nova-3"` literal while
+        // `Config::validate`'s keyterm gate consulted
+        // `Config::deepgram_model`. Two independent strings, neither pinned:
+        // flipping the one here to "nova-2" left the whole suite green, and
+        // would have meant `validate` staying silent about a vocabulary while
+        // every request 400'd on an unsupported `keyterm` parameter.
+        let mut config: Config = toml::from_str("").expect("empty config uses defaults");
+        config.deepgram = None;
+
+        for backend in ["deepgram", "deepgram-streaming"] {
+            config.general.backend = backend.to_string();
+            assert_eq!(
+                get_model_for_backend(&config),
+                config.deepgram_model(),
+                "{backend}: the wire model and the model validate inspects disagree"
+            );
+        }
     }
 }

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -628,15 +628,7 @@ pub(crate) async fn transcribe_batch_audio(
     let wav_data = encode_wav(samples)?;
     info!("encoded WAV: {} bytes", wav_data.len());
 
-    let config = if opts.use_prompt {
-        build_transcription_config(&context.config, language)
-    } else {
-        TranscriptionConfig {
-            language: language.to_string(),
-            model: get_model_for_backend(&context.config),
-            prompt: None,
-        }
-    };
+    let config = batch_transcription_config(&context.config, language, opts.use_prompt);
 
     let text = match context
         .transcription_backend
@@ -1019,6 +1011,31 @@ pub(crate) fn build_transcription_config(config: &Config, language: &str) -> Tra
         language: language.to_string(),
         model: get_model_for_backend(config),
         prompt: transcription_prompt(config.general.prompt.as_deref(), &config.general.vocabulary),
+        keyterms: config.general.vocabulary.clone(),
+    }
+}
+
+/// Pick the [`TranscriptionConfig`] for one batch run.
+///
+/// `use_prompt = false` is the command-mode opt-out: the recording is a spoken
+/// instruction, not content, so it gets neither the prompt hint nor the
+/// vocabulary keyterms. `keyterms: Vec::new()` is the same opt-out as
+/// `prompt: None` — biasing "make this shorter" toward the dictation
+/// vocabulary is wrong for exactly the reason the prompt is withheld.
+fn batch_transcription_config(
+    config: &Config,
+    language: &str,
+    use_prompt: bool,
+) -> TranscriptionConfig {
+    if use_prompt {
+        build_transcription_config(config, language)
+    } else {
+        TranscriptionConfig {
+            language: language.to_string(),
+            model: get_model_for_backend(config),
+            prompt: None,
+            keyterms: Vec::new(),
+        }
     }
 }
 
@@ -1120,6 +1137,40 @@ mod tests {
     #[test]
     fn transcription_prompt_empty_string_with_empty_vocab_is_none() {
         assert_eq!(transcription_prompt(Some(""), &[]), None);
+    }
+
+    /// A default config with the given vocabulary, for the keyterm routing
+    /// tests. Every `Config` field is `#[serde(default)]`, so an empty
+    /// document deserializes to the defaults.
+    fn config_with_vocabulary(vocabulary: &[&str]) -> Config {
+        let mut config: Config = toml::from_str("").expect("empty config uses defaults");
+        config.general.vocabulary = vocabulary.iter().map(|t| t.to_string()).collect();
+        config
+    }
+
+    #[test]
+    fn dictation_batch_config_carries_vocabulary_as_keyterms() {
+        let config = config_with_vocabulary(&["whisrs", "Hyprland"]);
+        let built = batch_transcription_config(&config, "en", BatchOptions::dictation().use_prompt);
+        assert_eq!(built.keyterms, vec!["whisrs", "Hyprland"]);
+        assert!(built.prompt.is_some());
+    }
+
+    #[test]
+    fn command_mode_batch_config_sends_no_keyterms() {
+        // Regression guard: keyterms must ride the same opt-out as `prompt`.
+        // A spoken instruction is not content, so biasing it toward the
+        // dictation vocabulary is wrong for the same reason the prompt is
+        // withheld — see `BatchOptions::command_mode`.
+        let config = config_with_vocabulary(&["whisrs", "Hyprland"]);
+        let built =
+            batch_transcription_config(&config, "en", BatchOptions::command_mode().use_prompt);
+        assert!(
+            built.keyterms.is_empty(),
+            "command mode leaked the dictation vocabulary: {:?}",
+            built.keyterms
+        );
+        assert!(built.prompt.is_none());
     }
 
     #[test]

--- a/src/transcription/asr_sidecar.rs
+++ b/src/transcription/asr_sidecar.rs
@@ -142,6 +142,7 @@ mod tests {
             language: "en".to_string(),
             model: "test-asr-model".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let err = backend.transcribe(&[], &config).await.unwrap_err();
         assert!(err.to_string().contains("empty audio"));
@@ -154,6 +155,7 @@ mod tests {
             language: "en".to_string(),
             model: "test-asr-model".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let err = backend.transcribe(&[1, 2, 3], &config).await.unwrap_err();
         assert!(err.to_string().contains("sidecar URL"));

--- a/src/transcription/deepgram.rs
+++ b/src/transcription/deepgram.rs
@@ -48,9 +48,37 @@ fn map_language(language: &str) -> &str {
     }
 }
 
+/// Percent-encode one query-string value.
+///
+/// The streaming URL below is assembled by hand and there is no encoder in the
+/// dependency tree, so this has to exist: Deepgram rejects the handshake with a
+/// bare 400 when a multi-word keyterm leaves a raw space in the URI.
+fn percent_encode(value: &str) -> String {
+    value
+        .bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                (b as char).to_string()
+            }
+            _ => format!("%{b:02X}"),
+        })
+        .collect()
+}
+
+/// Whether `model` accepts the `keyterm` parameter.
+///
+/// Deepgram answers `400 INVALID_QUERY_PARAMETER` — "`keyterm` is only
+/// supported for Nova-3 and Flux" — on anything else, so a user who sets
+/// `vocabulary` while pinning an older model must not have every request
+/// rejected because of it.
+fn supports_keyterm(model: &str) -> bool {
+    model.starts_with("nova-3") || model.starts_with("flux")
+}
+
 /// Build common query parameters for Deepgram requests.
 fn build_query_params<'a>(
     config: &'a TranscriptionConfig,
+    keyterms: &'a [String],
     extra: &[(&'a str, &'a str)],
 ) -> Vec<(&'a str, &'a str)> {
     let mut params = vec![
@@ -58,6 +86,18 @@ fn build_query_params<'a>(
         ("language", map_language(&config.language)),
         ("smart_format", "true"),
     ];
+    // Keyterm prompting: one repeated `keyterm` per term. Deepgram rejects
+    // weights/intensifiers and comma- or semicolon-separated lists, and caps the
+    // set at 500 tokens per request.
+    if supports_keyterm(&config.model) {
+        params.extend(keyterms.iter().map(|t| ("keyterm", t.as_str())));
+    } else if !keyterms.is_empty() {
+        debug!(
+            "model {} does not support keyterm prompting — ignoring {} vocabulary term(s)",
+            config.model,
+            keyterms.len()
+        );
+    }
     params.extend_from_slice(extra);
     params
 }
@@ -122,13 +162,15 @@ struct StreamingChannel {
 pub struct DeepgramRestBackend {
     client: reqwest::Client,
     api_key: String,
+    keyterms: Vec<String>,
 }
 
 impl DeepgramRestBackend {
-    pub fn new(api_key: String) -> Self {
+    pub fn new(api_key: String, keyterms: Vec<String>) -> Self {
         Self {
             client: reqwest::Client::new(),
             api_key,
+            keyterms,
         }
     }
 }
@@ -153,7 +195,7 @@ impl TranscriptionBackend for DeepgramRestBackend {
             config.language
         );
 
-        let params = build_query_params(config, &[]);
+        let params = build_query_params(config, &self.keyterms, &[]);
 
         let response = self
             .client
@@ -219,11 +261,12 @@ impl TranscriptionBackend for DeepgramRestBackend {
 /// results to avoid duplicates.
 pub struct DeepgramStreamingBackend {
     api_key: String,
+    keyterms: Vec<String>,
 }
 
 impl DeepgramStreamingBackend {
-    pub fn new(api_key: String) -> Self {
-        Self { api_key }
+    pub fn new(api_key: String, keyterms: Vec<String>) -> Self {
+        Self { api_key, keyterms }
     }
 }
 
@@ -278,6 +321,7 @@ impl TranscriptionBackend for DeepgramStreamingBackend {
 
         let params = build_query_params(
             config,
+            &self.keyterms,
             &[
                 ("encoding", "linear16"),
                 ("sample_rate", "16000"),
@@ -289,7 +333,7 @@ impl TranscriptionBackend for DeepgramStreamingBackend {
         // Build the WebSocket URL with query parameters.
         let query_string: String = params
             .iter()
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(k, v)| format!("{k}={}", percent_encode(v)))
             .collect::<Vec<_>>()
             .join("&");
         let url = format!("{DEEPGRAM_WS_URL}?{query_string}");
@@ -512,7 +556,7 @@ mod tests {
 
     #[tokio::test]
     async fn rest_rejects_empty_audio() {
-        let backend = DeepgramRestBackend::new("test-key".to_string());
+        let backend = DeepgramRestBackend::new("test-key".to_string(), Vec::new());
         let config = TranscriptionConfig {
             language: "en".to_string(),
             model: "nova-3".to_string(),
@@ -529,7 +573,7 @@ mod tests {
             model: "nova-3".to_string(),
             prompt: None,
         };
-        let params = build_query_params(&config, &[]);
+        let params = build_query_params(&config, &[], &[]);
         assert!(params
             .iter()
             .any(|(k, v)| *k == "smart_format" && *v == "true"));
@@ -544,9 +588,61 @@ mod tests {
             model: "nova-3".to_string(),
             prompt: None,
         };
-        let params = build_query_params(&config, &[]);
+        let params = build_query_params(&config, &[], &[]);
         assert!(params
             .iter()
             .any(|(k, v)| *k == "language" && *v == "multi"));
+    }
+
+    #[test]
+    fn build_query_params_emits_one_keyterm_per_vocabulary_entry() {
+        let config = TranscriptionConfig {
+            language: "auto".to_string(),
+            model: "nova-3".to_string(),
+            prompt: None,
+        };
+        let keyterms = vec!["whisrs".to_string(), "GNOME Shell".to_string()];
+        let params = build_query_params(&config, &keyterms, &[]);
+        let terms: Vec<&str> = params
+            .iter()
+            .filter(|(k, _)| *k == "keyterm")
+            .map(|(_, v)| *v)
+            .collect();
+        assert_eq!(terms, vec!["whisrs", "GNOME Shell"]);
+    }
+
+    #[test]
+    fn build_query_params_omits_keyterm_on_models_that_reject_it() {
+        // nova-2 answers 400 INVALID_QUERY_PARAMETER when `keyterm` is present,
+        // so a vocabulary set alongside an older model must be dropped rather
+        // than break every request.
+        let config = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "nova-2".to_string(),
+            prompt: None,
+        };
+        let keyterms = vec!["whisrs".to_string()];
+        let params = build_query_params(&config, &keyterms, &[]);
+        assert!(!params.iter().any(|(k, _)| *k == "keyterm"));
+    }
+
+    #[test]
+    fn build_query_params_without_vocabulary_sends_no_keyterm() {
+        let config = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "nova-3".to_string(),
+            prompt: None,
+        };
+        let params = build_query_params(&config, &[], &[]);
+        assert!(!params.iter().any(|(k, _)| *k == "keyterm"));
+    }
+
+    #[test]
+    fn percent_encode_escapes_spaces_and_leaves_plain_values_alone() {
+        // A raw space in a multi-word keyterm makes the streaming URI invalid
+        // and Deepgram answers the handshake with a bare 400.
+        assert_eq!(percent_encode("GNOME Shell"), "GNOME%20Shell");
+        assert_eq!(percent_encode("nova-3"), "nova-3");
+        assert_eq!(percent_encode("linear16"), "linear16");
     }
 }

--- a/src/transcription/deepgram.rs
+++ b/src/transcription/deepgram.rs
@@ -65,20 +65,178 @@ fn percent_encode(value: &str) -> String {
         .collect()
 }
 
+/// Assemble a query string from `params`, percent-encoding every value.
+///
+/// Extracted from `transcribe_stream` so the encoding is testable: reqwest does
+/// this for the REST path, but the WebSocket URI is built by hand and a raw
+/// space in a multi-word keyterm makes it invalid.
+fn build_query_string(params: &[(&str, &str)]) -> String {
+    params
+        .iter()
+        .map(|(k, v)| format!("{k}={}", percent_encode(v)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Byte budget for the `keyterm` portion of a Deepgram request.
+///
+/// Every parameter rides in the URI — the request line for REST, the handshake
+/// target for the WebSocket — and proxies and Deepgram's own edge typically cap
+/// a request line around 8KB. Past that the edge answers a bare `400` that
+/// never mentions the vocabulary, so streaming dictation just stops working.
+/// 4096 leaves ample room for the endpoint, the fixed parameters and any
+/// forward proxy's own additions.
+///
+/// This bounds **bytes and nothing else**. It does not imply a bound on the
+/// number of terms, and it does not imply a bound on tokens: `"ab cd ef"` × 400
+/// stops here at 195 terms / 4095 bytes while carrying at least 585
+/// whitespace-delimited words. [`KEYTERM_MAX_TERMS`] and [`KEYTERM_MAX_WORDS`]
+/// are what bound those.
+pub(crate) const KEYTERM_QUERY_BUDGET_BYTES: usize = 4096;
+
+/// Ceiling on how many `keyterm` params ride in one request.
+///
+/// This bounds **the parameter count and nothing else**: it keeps a vocabulary
+/// of very short terms from turning one request into thousands of query params,
+/// which the byte budget alone permits (single-char terms cost 10 bytes each,
+/// so 4096 bytes is ~409 params). It is deliberately *not* a token bound — an
+/// earlier revision of this comment claimed staying under 200 terms kept a
+/// byte-legal vocabulary inside Deepgram's 500-token cap, and that is false:
+/// the byte budget cuts `"ab cd ef"` × 400 off at 195 terms, below this cap,
+/// with ≥585 words on the wire. [`KEYTERM_MAX_WORDS`] is the token bound.
+pub(crate) const KEYTERM_MAX_TERMS: usize = 200;
+
+/// Ceiling on the total whitespace-delimited word count across all `keyterm`s.
+///
+/// Deepgram caps the keyterm set at 500 **tokens** per request, not 500 terms,
+/// and whisrs cannot tokenize client-side. Neither limit above bounds tokens.
+/// Measured against the two gates as they stood: `"ab cd ef"` × 400 → 195 terms
+/// at 4095 bytes and ≥585 words; `"a b c d e"` × 400 → 157 terms at 4082 bytes
+/// and ≥785 words. So a ~136-term two-word domain glossary ("atrial
+/// fibrillation") passes both, lands at roughly 550-800 tokens, and earns
+/// exactly the opaque `400` these limits exist to prevent — after
+/// `Config::validate` has already told the user how many terms reach Deepgram,
+/// when in fact none do, because the whole request is rejected.
+///
+/// A tokenizer never emits fewer tokens than there are whitespace-delimited
+/// words, so a word count is a lower bound on tokens and capping it at 300
+/// keeps the request conservatively inside the 500-token cap.
+pub(crate) const KEYTERM_MAX_WORDS: usize = 300;
+
+/// `&keyterm=` — the separator and key that precede every term on the wire.
+const KEYTERM_PARAM_OVERHEAD: usize = 9;
+
+/// Worst-case encoded byte length of one `keyterm` value.
+///
+/// Deliberately the worst case of the two encoders, because the two Deepgram
+/// paths do not encode alike: the REST path hands params to `reqwest.query()`,
+/// which **form**-encodes (space → `+`, `~` → `%7E`), while the streaming URI is
+/// assembled by hand with [`percent_encode`] (RFC 3986: `~` stays raw, space →
+/// `%20`). Measuring with either one alone under-counts the other — a
+/// `~`-heavy vocabulary costed with `percent_encode` came out at half what the
+/// REST request line actually carried, which put the request right back on the
+/// ~8KB ceiling this budget exists to stay clear of. So: 3 bytes for any byte
+/// *either* encoder escapes (`~` included, and space as `%20` rather than the
+/// shorter `+`), 1 byte only for `A-Za-z0-9-_.`, which both leave alone.
+fn keyterm_encoded_cost(value: &str) -> usize {
+    value
+        .bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' => 1,
+            _ => 3,
+        })
+        .sum()
+}
+
+/// The vocabulary entries that are terms at all: trimmed, blanks dropped.
+///
+/// A hand-edited `config.toml` can hold blank entries and a bare `keyterm=` is
+/// not a term. Kept separate from [`effective_keyterms`] only so callers can
+/// report how many terms the *limits* dropped without counting blank config
+/// entries as drops.
+pub(crate) fn usable_keyterms(keyterms: &[String]) -> impl Iterator<Item = &str> {
+    keyterms.iter().map(|t| t.trim()).filter(|t| !t.is_empty())
+}
+
+/// The `keyterm` values a Deepgram request actually carries, in order.
+///
+/// The single place the effective list is decided — `Config::validate` and
+/// [`build_query_params`] both call this, so the count warned about at load is
+/// by construction the count that goes on the wire. Normalization happens
+/// first: entries are trimmed and blanks dropped *before* anything is charged,
+/// then the remainder is charged against all three of
+/// [`KEYTERM_QUERY_BUDGET_BYTES`], [`KEYTERM_MAX_TERMS`] and
+/// [`KEYTERM_MAX_WORDS`]. Each bounds a different thing and none implies
+/// another — see their own docs.
+///
+/// Ordering matters. An earlier split — count the budget over the raw list,
+/// filter the blanks afterwards — let blank entries burn budget they never
+/// spent: 200 blanks in front of a real vocabulary had `validate` advertise 335
+/// terms while the request carried 135, with 105 real terms discarded for
+/// nothing.
+///
+/// A term that does not fit is **skipped, not fatal**: iteration continues and
+/// later, smaller terms can still make it. Stopping at the first misfit let one
+/// pathological entry discard everything behind it —
+/// `["x" × 5000, "whisrs", "Hyprland"]` put zero terms on the wire and warned
+/// that "the first 0" reached Deepgram, while the same three terms reordered
+/// kept both real ones. The consequence is that the result is no longer a
+/// prefix of the input, so callers must report "N of M", never "the first N".
+pub(crate) fn effective_keyterms(keyterms: &[String]) -> Vec<&str> {
+    let mut used_bytes = 0usize;
+    let mut used_words = 0usize;
+    let mut effective = Vec::new();
+    for term in usable_keyterms(keyterms) {
+        if effective.len() >= KEYTERM_MAX_TERMS {
+            break;
+        }
+        let cost = KEYTERM_PARAM_OVERHEAD + keyterm_encoded_cost(term);
+        let words = term.split_whitespace().count();
+        if used_bytes + cost > KEYTERM_QUERY_BUDGET_BYTES || used_words + words > KEYTERM_MAX_WORDS
+        {
+            continue;
+        }
+        used_bytes += cost;
+        used_words += words;
+        effective.push(term);
+    }
+    effective
+}
+
 /// Whether `model` accepts the `keyterm` parameter.
 ///
 /// Deepgram answers `400 INVALID_QUERY_PARAMETER` — "`keyterm` is only
 /// supported for Nova-3 and Flux" — on anything else, so a user who sets
 /// `vocabulary` while pinning an older model must not have every request
-/// rejected because of it.
-fn supports_keyterm(model: &str) -> bool {
+/// rejected because of it. Pre-Nova-3 models bias through a different
+/// parameter (`keywords`, with its own weighting syntax and its own
+/// deprecation story); not wiring that up is deliberate scope for this
+/// change, not an oversight.
+pub(crate) fn supports_keyterm(model: &str) -> bool {
     model.starts_with("nova-3") || model.starts_with("flux")
+}
+
+/// What to log when the configured model cannot take the vocabulary at all, or
+/// `None` when there is nothing to report.
+///
+/// A function rather than an inline condition so the emptiness test is
+/// testable. This branch used to gate on `keyterms.is_empty()` while every
+/// other count in this file goes through [`usable_keyterms`], so a
+/// vocabulary of nothing but blank entries logged "ignoring 0 vocabulary
+/// term(s)" on a nova-2 config.
+fn unsupported_model_keyterm_notice(model: &str, keyterms: &[String]) -> Option<String> {
+    let ignored = usable_keyterms(keyterms).count();
+    if ignored == 0 {
+        return None;
+    }
+    Some(format!(
+        "model {model} does not support keyterm prompting — ignoring {ignored} vocabulary term(s)"
+    ))
 }
 
 /// Build common query parameters for Deepgram requests.
 fn build_query_params<'a>(
     config: &'a TranscriptionConfig,
-    keyterms: &'a [String],
     extra: &[(&'a str, &'a str)],
 ) -> Vec<(&'a str, &'a str)> {
     let mut params = vec![
@@ -88,15 +246,27 @@ fn build_query_params<'a>(
     ];
     // Keyterm prompting: one repeated `keyterm` per term. Deepgram rejects
     // weights/intensifiers and comma- or semicolon-separated lists, and caps the
-    // set at 500 tokens per request.
+    // set at 500 tokens per request (see `KEYTERM_MAX_WORDS`).
     if supports_keyterm(&config.model) {
-        params.extend(keyterms.iter().map(|t| ("keyterm", t.as_str())));
-    } else if !keyterms.is_empty() {
-        debug!(
-            "model {} does not support keyterm prompting — ignoring {} vocabulary term(s)",
-            config.model,
-            keyterms.len()
-        );
+        let effective = effective_keyterms(&config.keyterms);
+        let usable = usable_keyterms(&config.keyterms).count();
+        if effective.len() < usable {
+            // "N of M", never "the first N": `effective_keyterms` skips a term
+            // that does not fit rather than stopping there, so the terms that
+            // survive are not a prefix of the vocabulary.
+            debug!(
+                "vocabulary exceeds the Deepgram keyterm limits ({} bytes / {} terms / \
+                 {} words) — sending {} of {} term(s)",
+                KEYTERM_QUERY_BUDGET_BYTES,
+                KEYTERM_MAX_TERMS,
+                KEYTERM_MAX_WORDS,
+                effective.len(),
+                usable
+            );
+        }
+        params.extend(effective.into_iter().map(|t| ("keyterm", t)));
+    } else if let Some(notice) = unsupported_model_keyterm_notice(&config.model, &config.keyterms) {
+        debug!("{notice}");
     }
     params.extend_from_slice(extra);
     params
@@ -162,15 +332,13 @@ struct StreamingChannel {
 pub struct DeepgramRestBackend {
     client: reqwest::Client,
     api_key: String,
-    keyterms: Vec<String>,
 }
 
 impl DeepgramRestBackend {
-    pub fn new(api_key: String, keyterms: Vec<String>) -> Self {
+    pub fn new(api_key: String) -> Self {
         Self {
             client: reqwest::Client::new(),
             api_key,
-            keyterms,
         }
     }
 }
@@ -195,7 +363,7 @@ impl TranscriptionBackend for DeepgramRestBackend {
             config.language
         );
 
-        let params = build_query_params(config, &self.keyterms, &[]);
+        let params = build_query_params(config, &[]);
 
         let response = self
             .client
@@ -261,12 +429,11 @@ impl TranscriptionBackend for DeepgramRestBackend {
 /// results to avoid duplicates.
 pub struct DeepgramStreamingBackend {
     api_key: String,
-    keyterms: Vec<String>,
 }
 
 impl DeepgramStreamingBackend {
-    pub fn new(api_key: String, keyterms: Vec<String>) -> Self {
-        Self { api_key, keyterms }
+    pub fn new(api_key: String) -> Self {
+        Self { api_key }
     }
 }
 
@@ -321,7 +488,6 @@ impl TranscriptionBackend for DeepgramStreamingBackend {
 
         let params = build_query_params(
             config,
-            &self.keyterms,
             &[
                 ("encoding", "linear16"),
                 ("sample_rate", "16000"),
@@ -331,11 +497,7 @@ impl TranscriptionBackend for DeepgramStreamingBackend {
         );
 
         // Build the WebSocket URL with query parameters.
-        let query_string: String = params
-            .iter()
-            .map(|(k, v)| format!("{k}={}", percent_encode(v)))
-            .collect::<Vec<_>>()
-            .join("&");
+        let query_string = build_query_string(&params);
         let url = format!("{DEEPGRAM_WS_URL}?{query_string}");
 
         info!("connecting to Deepgram streaming API");
@@ -554,26 +716,47 @@ mod tests {
         assert_eq!(parsed.msg_type, "Metadata");
     }
 
+    /// A [`TranscriptionConfig`] with just the fields the query builder reads.
+    fn query_config(model: &str, keyterms: &[&str]) -> TranscriptionConfig {
+        TranscriptionConfig {
+            language: "en".to_string(),
+            model: model.to_string(),
+            prompt: None,
+            keyterms: keyterms.iter().map(|t| t.to_string()).collect(),
+        }
+    }
+
+    /// Same as [`query_config`] for a vocabulary that is already owned.
+    fn owned_query_config(model: &str, keyterms: &[String]) -> TranscriptionConfig {
+        TranscriptionConfig {
+            language: "en".to_string(),
+            model: model.to_string(),
+            prompt: None,
+            keyterms: keyterms.to_vec(),
+        }
+    }
+
+    /// The `keyterm` values `build_query_params` put on the wire, in order.
+    fn keyterm_values<'a>(params: &'a [(&'a str, &'a str)]) -> Vec<&'a str> {
+        params
+            .iter()
+            .filter(|(k, _)| *k == "keyterm")
+            .map(|(_, v)| *v)
+            .collect()
+    }
+
     #[tokio::test]
     async fn rest_rejects_empty_audio() {
-        let backend = DeepgramRestBackend::new("test-key".to_string(), Vec::new());
-        let config = TranscriptionConfig {
-            language: "en".to_string(),
-            model: "nova-3".to_string(),
-            prompt: None,
-        };
+        let backend = DeepgramRestBackend::new("test-key".to_string());
+        let config = query_config("nova-3", &[]);
         let err = backend.transcribe(&[], &config).await.unwrap_err();
         assert!(err.to_string().contains("empty audio"));
     }
 
     #[test]
     fn build_query_params_includes_smart_format() {
-        let config = TranscriptionConfig {
-            language: "en".to_string(),
-            model: "nova-3".to_string(),
-            prompt: None,
-        };
-        let params = build_query_params(&config, &[], &[]);
+        let config = query_config("nova-3", &[]);
+        let params = build_query_params(&config, &[]);
         assert!(params
             .iter()
             .any(|(k, v)| *k == "smart_format" && *v == "true"));
@@ -583,12 +766,9 @@ mod tests {
 
     #[test]
     fn build_query_params_auto_language() {
-        let config = TranscriptionConfig {
-            language: "auto".to_string(),
-            model: "nova-3".to_string(),
-            prompt: None,
-        };
-        let params = build_query_params(&config, &[], &[]);
+        let mut config = query_config("nova-3", &[]);
+        config.language = "auto".to_string();
+        let params = build_query_params(&config, &[]);
         assert!(params
             .iter()
             .any(|(k, v)| *k == "language" && *v == "multi"));
@@ -596,19 +776,9 @@ mod tests {
 
     #[test]
     fn build_query_params_emits_one_keyterm_per_vocabulary_entry() {
-        let config = TranscriptionConfig {
-            language: "auto".to_string(),
-            model: "nova-3".to_string(),
-            prompt: None,
-        };
-        let keyterms = vec!["whisrs".to_string(), "GNOME Shell".to_string()];
-        let params = build_query_params(&config, &keyterms, &[]);
-        let terms: Vec<&str> = params
-            .iter()
-            .filter(|(k, _)| *k == "keyterm")
-            .map(|(_, v)| *v)
-            .collect();
-        assert_eq!(terms, vec!["whisrs", "GNOME Shell"]);
+        let config = query_config("nova-3", &["whisrs", "GNOME Shell"]);
+        let params = build_query_params(&config, &[]);
+        assert_eq!(keyterm_values(&params), vec!["whisrs", "GNOME Shell"]);
     }
 
     #[test]
@@ -616,25 +786,303 @@ mod tests {
         // nova-2 answers 400 INVALID_QUERY_PARAMETER when `keyterm` is present,
         // so a vocabulary set alongside an older model must be dropped rather
         // than break every request.
-        let config = TranscriptionConfig {
-            language: "en".to_string(),
-            model: "nova-2".to_string(),
-            prompt: None,
-        };
-        let keyterms = vec!["whisrs".to_string()];
-        let params = build_query_params(&config, &keyterms, &[]);
+        let config = query_config("nova-2", &["whisrs"]);
+        let params = build_query_params(&config, &[]);
         assert!(!params.iter().any(|(k, _)| *k == "keyterm"));
     }
 
     #[test]
     fn build_query_params_without_vocabulary_sends_no_keyterm() {
-        let config = TranscriptionConfig {
-            language: "en".to_string(),
-            model: "nova-3".to_string(),
-            prompt: None,
-        };
-        let params = build_query_params(&config, &[], &[]);
+        let config = query_config("nova-3", &[]);
+        let params = build_query_params(&config, &[]);
         assert!(!params.iter().any(|(k, _)| *k == "keyterm"));
+    }
+
+    #[test]
+    fn build_query_params_skips_blank_vocabulary_entries() {
+        // `whisrs config` strips these, but a hand-edited config.toml can hold
+        // them and a bare `keyterm=` is not a term.
+        let config = query_config("nova-3", &["whisrs", "", "  ", "\t"]);
+        let params = build_query_params(&config, &[]);
+        assert_eq!(keyterm_values(&params), vec!["whisrs"]);
+    }
+
+    #[test]
+    fn build_query_params_sends_keyterms_trimmed() {
+        let config = query_config("nova-3", &["  GNOME Shell  "]);
+        let params = build_query_params(&config, &[]);
+        assert_eq!(keyterm_values(&params), vec!["GNOME Shell"]);
+    }
+
+    #[test]
+    fn build_query_params_truncates_vocabulary_to_the_query_budget() {
+        // 1000 terms builds a ~28KB URI; Deepgram's edge rejects the handshake
+        // with a bare 400 that never mentions the vocabulary. Terms are short
+        // enough here that the byte budget bites before `KEYTERM_MAX_TERMS`
+        // would — 4096 / (9 + 8) is 240, above the 200-term cap, so keep the
+        // assertion on the cap that actually fires.
+        let terms: Vec<String> = (0..1000).map(|i| format!("term{i:04}")).collect();
+        let config = owned_query_config("nova-3", &terms);
+        let params = build_query_params(&config, &[]);
+        let sent = keyterm_values(&params);
+        assert!(
+            sent.len() < terms.len(),
+            "budget must drop terms, sent all {}",
+            sent.len()
+        );
+        assert!(!sent.is_empty(), "budget must still send the leading terms");
+        // The terms it does send are a prefix, and they fit the budget.
+        assert_eq!(sent[0], "term0000");
+        let bytes: usize = sent
+            .iter()
+            .map(|t| KEYTERM_PARAM_OVERHEAD + keyterm_encoded_cost(t))
+            .sum();
+        assert!(
+            bytes <= KEYTERM_QUERY_BUDGET_BYTES,
+            "sent {bytes} bytes of keyterms, over the {KEYTERM_QUERY_BUDGET_BYTES} budget"
+        );
+    }
+
+    #[test]
+    fn effective_keyterms_admits_a_small_vocabulary_whole() {
+        let terms = vec!["whisrs".to_string(), "GNOME Shell".to_string()];
+        assert_eq!(effective_keyterms(&terms), vec!["whisrs", "GNOME Shell"]);
+    }
+
+    #[test]
+    fn effective_keyterms_is_what_build_query_params_puts_on_the_wire() {
+        // The bug this pins: blanks used to be charged against the budget and
+        // filtered afterwards, so the advertised count and the wire disagreed.
+        // 200 whitespace-only entries in front of 1000 real terms had
+        // `validate` promise 335 while the request carried 135 — 105 real terms
+        // discarded and 1801 budget bytes burned on nothing.
+        let mut terms: Vec<String> = vec!["   ".to_string(); 200];
+        terms.extend((0..1000).map(|i| format!("term{i:04}")));
+
+        let config = owned_query_config("nova-3", &terms);
+        let params = build_query_params(&config, &[]);
+        let sent = keyterm_values(&params);
+        let advertised = effective_keyterms(&terms);
+
+        assert_eq!(
+            sent, advertised,
+            "the advertised list must be the list on the wire"
+        );
+        assert!(
+            sent.iter().all(|t| !t.trim().is_empty()),
+            "a blank entry reached the wire: {sent:?}"
+        );
+        assert_eq!(
+            sent[0], "term0000",
+            "blanks must not shift which real terms are kept"
+        );
+        // Blanks cost nothing, so the real terms get the whole budget: the same
+        // 1000 terms with no blanks in front produce exactly the same list.
+        let without_blanks: Vec<String> = (0..1000).map(|i| format!("term{i:04}")).collect();
+        assert_eq!(
+            advertised,
+            effective_keyterms(&without_blanks),
+            "blank entries still consumed budget"
+        );
+
+        // And the number `Config::validate` advertises at load is the number of
+        // `keyterm` params this same vocabulary puts on the wire. This is the
+        // whole point of routing both through `effective_keyterms`: the two
+        // used to be computed separately and disagreed.
+        let mut config: crate::Config = toml::from_str("").expect("empty config uses defaults");
+        config.general.backend = "deepgram".to_string();
+        config.general.vocabulary = terms.clone();
+        config.deepgram = Some(crate::DeepgramConfig {
+            api_key: "test-key".to_string(),
+            model: "nova-3".to_string(),
+        });
+        let warnings = config.validate().expect("a keyed deepgram config is valid");
+        let warning = warnings
+            .iter()
+            .find(|w| w.message.contains("vocabulary"))
+            .unwrap_or_else(|| panic!("a truncated vocabulary must warn: {warnings:?}"));
+        assert!(
+            warning.message.contains(&format!("{} of ", sent.len())),
+            "validate advertised a different count than the {} terms on the wire: {}",
+            sent.len(),
+            warning.message
+        );
+    }
+
+    #[test]
+    fn effective_keyterms_caps_the_word_count_before_the_byte_budget() {
+        // The claim `KEYTERM_MAX_TERMS` used to make — that staying under 200
+        // terms keeps a byte-legal vocabulary inside Deepgram's 500-token cap —
+        // is false, and this is the counterexample. 400 copies of "ab cd ef"
+        // stop at 195 terms on the byte budget alone: under the term cap, at
+        // 4095 of 4096 bytes, and carrying at least 585 whitespace-delimited
+        // words. `KEYTERM_MAX_WORDS` is what actually bounds it.
+        let terms: Vec<String> = vec!["ab cd ef".to_string(); 400];
+
+        // What the other two limits alone would have allowed.
+        let cost = KEYTERM_PARAM_OVERHEAD + keyterm_encoded_cost("ab cd ef");
+        let byte_bound = KEYTERM_QUERY_BUDGET_BYTES / cost;
+        assert!(
+            byte_bound < KEYTERM_MAX_TERMS,
+            "fixture must be byte-bound below the term cap, got {byte_bound}"
+        );
+        assert!(
+            byte_bound * 3 > 500,
+            "fixture must blow the 500-token cap without the word limit: {} words",
+            byte_bound * 3
+        );
+
+        let effective = effective_keyterms(&terms);
+        assert_eq!(
+            effective.len(),
+            KEYTERM_MAX_WORDS / 3,
+            "the word limit, not the byte budget, must be what bites"
+        );
+        let words: usize = effective.iter().map(|t| t.split_whitespace().count()).sum();
+        assert!(
+            words <= KEYTERM_MAX_WORDS,
+            "sent {words} words, over the {KEYTERM_MAX_WORDS} cap"
+        );
+
+        // And the count that goes on the wire is the count `validate` advertises.
+        let config = owned_query_config("nova-3", &terms);
+        let params = build_query_params(&config, &[]);
+        let sent = keyterm_values(&params);
+        assert_eq!(sent.len(), effective.len());
+
+        let mut config: crate::Config = toml::from_str("").expect("empty config uses defaults");
+        config.general.backend = "deepgram".to_string();
+        config.general.vocabulary = terms.clone();
+        config.deepgram = Some(crate::DeepgramConfig {
+            api_key: "test-key".to_string(),
+            model: "nova-3".to_string(),
+        });
+        let warnings = config.validate().expect("a keyed deepgram config is valid");
+        let warning = warnings
+            .iter()
+            .find(|w| w.message.contains("vocabulary"))
+            .unwrap_or_else(|| panic!("a word-capped vocabulary must warn: {warnings:?}"));
+        assert!(
+            warning
+                .message
+                .contains(&format!("{} of {} usable term(s)", sent.len(), terms.len())),
+            "validate advertised a different count than the {} terms on the wire: {}",
+            sent.len(),
+            warning.message
+        );
+    }
+
+    #[test]
+    fn one_oversized_term_does_not_discard_the_rest_of_the_vocabulary() {
+        // `effective_keyterms` used to `break` on the first term that would not
+        // fit, so a single pathological entry nuked everything behind it: this
+        // vocabulary put zero terms on the wire and warned that "the first 0"
+        // reached Deepgram, while the same three terms reordered kept both real
+        // ones. Skipping the misfit and continuing is what makes the outcome
+        // independent of where the long term sits.
+        let long = "x".repeat(5000);
+        let first = vec![long.clone(), "whisrs".to_string(), "Hyprland".to_string()];
+        let last = vec!["whisrs".to_string(), "Hyprland".to_string(), long];
+
+        assert!(
+            KEYTERM_PARAM_OVERHEAD + keyterm_encoded_cost(&"x".repeat(5000))
+                > KEYTERM_QUERY_BUDGET_BYTES,
+            "the fixture term must not fit on its own"
+        );
+        assert_eq!(effective_keyterms(&first), vec!["whisrs", "Hyprland"]);
+        assert_eq!(effective_keyterms(&last), vec!["whisrs", "Hyprland"]);
+
+        let config = owned_query_config("nova-3", &first);
+        let params = build_query_params(&config, &[]);
+        assert_eq!(keyterm_values(&params), vec!["whisrs", "Hyprland"]);
+    }
+
+    #[test]
+    fn unsupported_model_notice_uses_the_same_emptiness_test_as_the_rest_of_the_file() {
+        // The unsupported-model branch used to gate on `keyterms.is_empty()`
+        // while every other count here goes through `usable_keyterms`, so a
+        // blanks-only vocabulary logged "ignoring 0 vocabulary term(s)".
+        let blanks = ["".to_string(), "  ".to_string(), "\t".to_string()];
+        assert!(!blanks.is_empty(), "the old gate would have fired here");
+        assert_eq!(unsupported_model_keyterm_notice("nova-2", &blanks), None);
+        assert_eq!(unsupported_model_keyterm_notice("nova-2", &[]), None);
+
+        let notice =
+            unsupported_model_keyterm_notice("nova-2", &["whisrs".to_string(), "   ".to_string()])
+                .expect("a real term must be reported");
+        assert!(
+            notice.contains("ignoring 1 vocabulary term(s)"),
+            "blank entries must not be counted: {notice}"
+        );
+        assert!(notice.contains("nova-2"), "the notice must name the model");
+
+        // And a blanks-only vocabulary still puts no `keyterm` on the wire.
+        let config = query_config("nova-2", &["", "  ", "\t"]);
+        let params = build_query_params(&config, &[]);
+        assert!(!params.iter().any(|(k, _)| *k == "keyterm"));
+    }
+
+    #[test]
+    fn keyterm_cost_charges_three_bytes_for_anything_either_encoder_escapes() {
+        // `~` is the trap: RFC 3986 leaves it raw (so `percent_encode` charges
+        // 1) but `reqwest.query()` form-encodes it to `%7E`. Costing with
+        // `percent_encode` let a `~`-heavy vocabulary put ~2x the counted bytes
+        // on the REST request line, right back on the ~8KB ceiling.
+        assert_eq!(keyterm_encoded_cost("~~~~~~~~"), 24);
+        assert_eq!(percent_encode("~~~~~~~~").len(), 8, "RFC 3986 leaves ~ raw");
+        // Space is charged as `%20`, not the shorter form-encoded `+`.
+        assert_eq!(keyterm_encoded_cost("GNOME Shell"), 13);
+        // The unreserved set both encoders agree on stays at one byte each.
+        assert_eq!(keyterm_encoded_cost("nova-3_v.1"), 10);
+    }
+
+    #[test]
+    fn keyterm_budget_is_not_overrun_by_a_tilde_heavy_vocabulary() {
+        // 300 copies of `~~~~~~~~`: the whole point is that what the budget
+        // counts is an upper bound on what the form-encoding REST path emits.
+        let terms: Vec<String> = vec!["~~~~~~~~".to_string(); 300];
+        let effective = effective_keyterms(&terms);
+        let counted: usize = effective
+            .iter()
+            .map(|t| KEYTERM_PARAM_OVERHEAD + keyterm_encoded_cost(t))
+            .sum();
+        // What reqwest's form encoding actually puts on the REST request line.
+        let form_encoded: usize = effective
+            .iter()
+            .map(|t| KEYTERM_PARAM_OVERHEAD + t.len() * "%7E".len())
+            .sum();
+        assert!(
+            form_encoded <= counted,
+            "REST carries {form_encoded} bytes but the budget only counted {counted}"
+        );
+        assert!(
+            counted <= KEYTERM_QUERY_BUDGET_BYTES,
+            "counted {counted} bytes, over the {KEYTERM_QUERY_BUDGET_BYTES} budget"
+        );
+    }
+
+    #[test]
+    fn effective_keyterms_caps_the_term_count_well_inside_the_byte_budget() {
+        // Deepgram's real limit is 500 tokens, which the byte budget does not
+        // bound. These terms are short enough that the first 200 of them use
+        // barely half the byte budget, so if `KEYTERM_MAX_TERMS` were not
+        // enforced the byte budget would let ~315 through instead of 200.
+        let terms: Vec<String> = (0..500).map(|i| format!("t{i:03}")).collect();
+        let bytes: usize = terms
+            .iter()
+            .take(KEYTERM_MAX_TERMS)
+            .map(|t| KEYTERM_PARAM_OVERHEAD + keyterm_encoded_cost(t))
+            .sum();
+        assert!(
+            bytes < KEYTERM_QUERY_BUDGET_BYTES,
+            "fixture must be inside the byte budget so the term cap is what fires"
+        );
+        assert_eq!(effective_keyterms(&terms).len(), KEYTERM_MAX_TERMS);
+
+        let config = owned_query_config("nova-3", &terms);
+        let params = build_query_params(&config, &[]);
+        let sent = keyterm_values(&params);
+        assert_eq!(sent.len(), KEYTERM_MAX_TERMS);
     }
 
     #[test]
@@ -644,5 +1092,26 @@ mod tests {
         assert_eq!(percent_encode("GNOME Shell"), "GNOME%20Shell");
         assert_eq!(percent_encode("nova-3"), "nova-3");
         assert_eq!(percent_encode("linear16"), "linear16");
+    }
+
+    #[test]
+    fn build_query_string_percent_encodes_values() {
+        // The streaming URI is assembled from these params by hand, so the
+        // encoding has to survive the join, not just `percent_encode`.
+        let config = query_config("nova-3", &["GNOME Shell"]);
+        let params = build_query_params(&config, &[]);
+        let query = build_query_string(&params);
+        assert!(
+            query.contains("keyterm=GNOME%20Shell"),
+            "multi-word keyterm must be percent-encoded: {query}"
+        );
+        assert!(
+            !query.contains("GNOME Shell"),
+            "raw space left in the query string: {query}"
+        );
+        assert!(
+            query.contains("model=nova-3"),
+            "the fixed params must survive encoding: {query}"
+        );
     }
 }

--- a/src/transcription/groq.rs
+++ b/src/transcription/groq.rs
@@ -432,6 +432,7 @@ mod tests {
             language: "en".to_string(),
             model: "whisper-large-v3-turbo".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let err = backend.transcribe(&[], &config).await.unwrap_err();
         assert!(err.to_string().contains("empty audio"));
@@ -444,6 +445,7 @@ mod tests {
             language: "en".to_string(),
             model: "whisper-large-v3-turbo".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let huge = vec![0u8; MAX_FILE_SIZE + 1];
         let err = backend.transcribe(&huge, &config).await.unwrap_err();

--- a/src/transcription/local_parakeet.rs
+++ b/src/transcription/local_parakeet.rs
@@ -46,6 +46,7 @@ mod tests {
             language: "en".to_string(),
             model: "eou-120m".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let err = backend.transcribe(&[], &config).await.unwrap_err();
         assert!(err.to_string().contains("not yet implemented"));

--- a/src/transcription/local_vosk.rs
+++ b/src/transcription/local_vosk.rs
@@ -46,6 +46,7 @@ mod tests {
             language: "en".to_string(),
             model: "small-en-us".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let err = backend.transcribe(&[], &config).await.unwrap_err();
         assert!(err.to_string().contains("not yet implemented"));

--- a/src/transcription/local_whisper.rs
+++ b/src/transcription/local_whisper.rs
@@ -490,6 +490,7 @@ mod tests {
             language: "en".to_string(),
             model: "base.en".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let err = backend.transcribe(&[1, 2, 3], &config).await.unwrap_err();
         let msg = err.to_string();

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -50,6 +50,15 @@ pub struct TranscriptionConfig {
     pub model: String,
     /// Optional prompt hint for the transcription model (vocabulary, context).
     pub prompt: Option<String>,
+    /// Backend-specific keyword-biasing terms — Deepgram keyterm prompting.
+    ///
+    /// Carried alongside `prompt` rather than on the backend struct so both
+    /// forms of "bias the model toward these words" travel the same channel:
+    /// a path that deliberately sends no prompt (command mode, where the
+    /// recording is a spoken instruction rather than content) sends no
+    /// keyterms either. Backends with no equivalent parameter ignore these —
+    /// they receive the same terms folded into `prompt`.
+    pub keyterms: Vec<String>,
 }
 
 /// Trait for transcription backends.

--- a/src/transcription/openai_compatible_realtime.rs
+++ b/src/transcription/openai_compatible_realtime.rs
@@ -257,6 +257,7 @@ mod tests {
             language: "auto".to_string(),
             model: "   ".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         });
 
         assert_eq!(request.model, "Whisper-Tiny");
@@ -295,6 +296,7 @@ mod tests {
             language: "auto".to_string(),
             model: "Whisper-Tiny".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         }
     }
 

--- a/src/transcription/openai_realtime_protocol/engine.rs
+++ b/src/transcription/openai_realtime_protocol/engine.rs
@@ -1097,6 +1097,7 @@ mod stream_lifecycle_tests {
             language: "en".to_string(),
             model: "gpt-4o-mini-transcribe".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         }
     }
 

--- a/src/transcription/openai_rest.rs
+++ b/src/transcription/openai_rest.rs
@@ -167,6 +167,7 @@ mod tests {
             language: "en".to_string(),
             model: "gpt-4o-mini-transcribe".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let err = backend.transcribe(&[], &config).await.unwrap_err();
         assert!(err.to_string().contains("empty audio"));
@@ -179,6 +180,7 @@ mod tests {
             language: "en".to_string(),
             model: "gpt-4o-mini-transcribe".to_string(),
             prompt: None,
+            keyterms: Vec::new(),
         };
         let huge = vec![0u8; MAX_FILE_SIZE + 1];
         let err = backend.transcribe(&huge, &config).await.unwrap_err();


### PR DESCRIPTION
## Summary

`[general] vocabulary` is honored by Groq, OpenAI REST/Realtime and local whisper.cpp through the prompt hint, but the Deepgram backends built only `model`, `language` and `smart_format`, so the setting was silently inert there. Anyone on `backend = "deepgram"` could fill `vocabulary` and nothing would change.

This maps it to Deepgram keyterm prompting, which is the equivalent feature on their side: one repeated `keyterm` per term, up to 500 tokens per request, supported on Nova-3 (monolingual and multilingual) and Flux.

Follow-up to #13, which added `vocabulary` and `prompt` but left the Deepgram path out.

## Changes

- **`build_query_params` takes the keyterms** and emits one `keyterm=` per entry. `create_backend` passes `config.general.vocabulary` to both Deepgram backends.
- **Gated on the models that accept the parameter.** nova-2 answers `400 INVALID_QUERY_PARAMETER` ("`keyterm` is only supported for Nova-3 and Flux"), so sending it unconditionally would turn a set `vocabulary` into a hard failure for anyone pinning an older model. `supports_keyterm` checks the prefix and logs at debug level when it drops terms.
- **Percent-encoding for the streaming URL.** `transcribe_stream` assembles its query string by hand with `format!("{k}={v}")`, so a multi-word keyterm left a raw space in the URI and Deepgram rejected the handshake with a bare 400. Added a small `percent_encode` helper rather than pulling in a dependency. It is a no-op on the existing values (`nova-3`, `linear16`, `16000`).
- **docs**: `docs/configuration.md` said Deepgram does not accept a prompt, which is still true, but it did not say that `vocabulary` now reaches it. Updated both lines.

## Testing

Unit tests: 481 pass (was 477). The four new ones cover keyterm emission, the empty-vocabulary case, the nova-2 gate, and percent-encoding.

Verified against the live API before writing the code:

- `keyterm` with `model=nova-2` returns `400 INVALID_QUERY_PARAMETER`, while the same handshake without it returns `101`. That is what the gate exists for.
- `keyterm` works with `language=multi` on nova-3, on both REST and the streaming websocket.
- A raw space in a multi-word term makes the streaming URI invalid, and the handshake fails with a 400 before any audio is sent.

End to end on GNOME Wayland (NixOS), `backend = "deepgram"`, `language = "auto"`, French and English mixed in one utterance. With an empty `vocabulary`, the word "whisrs" was dropped from the transcript entirely and my own first name came back as "Ilias". With the terms set, both are correct, and the casing follows the config (`Gnome` becomes `GNOME`, `Claude code` becomes `Claude Code`).

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor
