### PR TITLE
feat(asr-sidecar): add optional API key support - support endpoints that require auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,7 @@ Environment variable overrides:
 - `WHISRS_DEEPGRAM_API_KEY` — overrides `[deepgram] api_key` (also used by the `deepgram` TTS backend)
 - `WHISRS_GROQ_API_KEY` — overrides `[groq] api_key` (also used by the `groq` TTS backend)
 - `WHISRS_OPENAI_API_KEY` — overrides `[openai] api_key` (also used by the `openai` TTS backend)
+- `WHISRS_ASR_SIDECAR_API_KEY` — overrides `[asr-sidecar] api_key` (optional bearer token for authenticated sidecar endpoints)
 - `RUST_LOG` — controls daemon log verbosity
 
 ## CI Checks

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ overlay = false    # bottom-screen recording overlay
 api_key = "gsk_..."
 ```
 
-Env-var overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, `WHISRS_OPENAI_API_KEY`.
+Env-var overrides: `WHISRS_GROQ_API_KEY`, `WHISRS_DEEPGRAM_API_KEY`, `WHISRS_OPENAI_API_KEY`, `WHISRS_ASR_SIDECAR_API_KEY`.
 
 For the full reference (overlay, `[input]`, `[openai-compatible-realtime]`, `[asr-sidecar]`, `[llm]`, `[hotkeys]`, `[hooks]`, GNOME extension setup), see [docs/configuration.md](docs/configuration.md).
 

--- a/contrib/openrc/whisrs.confd
+++ b/contrib/openrc/whisrs.confd
@@ -18,6 +18,7 @@
 #WHISRS_DEEPGRAM_API_KEY=""
 #WHISRS_GROQ_API_KEY=""
 #WHISRS_OPENAI_API_KEY=""
+#WHISRS_ASR_SIDECAR_API_KEY=""
 
 # Where whisrsd's stdout/stderr are written.
 # Default: ${XDG_STATE_HOME:-$HOME/.local/state}/whisrs

--- a/contrib/openrc/whisrs.initd
+++ b/contrib/openrc/whisrs.initd
@@ -51,6 +51,7 @@ error_log="${whisrsd_log_dir}/whisrsd.log"
 # reads from its own environment.
 for _var in RUST_LOG \
 	WHISRS_DEEPGRAM_API_KEY WHISRS_GROQ_API_KEY WHISRS_OPENAI_API_KEY \
+	WHISRS_ASR_SIDECAR_API_KEY \
 	XKB_DEFAULT_LAYOUT XKB_DEFAULT_VARIANT
 do
 	eval "[ -n \"\${$_var}\" ]" && export "$_var"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,6 +408,7 @@ The following variables override the matching `api_key` in `config.toml`:
 - `WHISRS_GROQ_API_KEY`
 - `WHISRS_DEEPGRAM_API_KEY`
 - `WHISRS_OPENAI_API_KEY`
+- `WHISRS_ASR_SIDECAR_API_KEY`
 
 These provider keys are also used by the matching TTS backend (`groq`/`openai`/`deepgram`) unless `[tts] api_key` is set. The `tts-sidecar` backend needs no key.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,6 +235,10 @@ model_path = "~/.local/share/whisrs/models/ggml-base.en.bin"
 [asr-sidecar]
 url = "http://127.0.0.1:8765/transcribe"
 model = "microsoft/VibeVoice-ASR-HF"
+# Optional bearer token. Only needed for endpoints that require auth (a hosted
+# gateway, or a sidecar behind an authenticating proxy); local sidecars need
+# none. WHISRS_ASR_SIDECAR_API_KEY overrides it.
+# api_key = "optional bearer token"
 
 # Command mode: LLM for voice-driven text rewriting.
 # Also used by [[llm_commands]] (see below) and by

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -176,7 +176,15 @@ fn current_key_summary(config: &Config) -> String {
             };
         }
         "asr-sidecar" | "asr" | "vibevoice" => {
-            return format!("{DIM}(sidecar backend — no API key needed){RESET}");
+            return match config
+                .asr_sidecar
+                .as_ref()
+                .and_then(|s| s.api_key.as_deref())
+                .filter(|key| !key.trim().is_empty())
+            {
+                Some(key) => format!("{BOLD}{}{RESET}", setup::mask_api_key(key)),
+                None => format!("{DIM}(optional API key not set){RESET}"),
+            };
         }
         _ => None,
     };
@@ -793,6 +801,9 @@ fn render_masked_toml(config: &Config) -> Result<String> {
     }
     if let Some(r) = clone.openai_compatible_realtime.as_mut() {
         r.api_key = r.api_key.as_ref().map(|key| setup::mask_api_key(key));
+    }
+    if let Some(s) = clone.asr_sidecar.as_mut() {
+        s.api_key = s.api_key.as_ref().map(|key| setup::mask_api_key(key));
     }
     if let Some(l) = clone.llm.as_mut() {
         l.api_key = setup::mask_api_key(&l.api_key);

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -1451,6 +1451,7 @@ fn openrc_initd_contents(whisrsd_path: &str) -> String {
          # whisrsd reads from its own environment, or they are silently lost.\n\
          for _var in RUST_LOG \\\n\
          \tWHISRS_DEEPGRAM_API_KEY WHISRS_GROQ_API_KEY WHISRS_OPENAI_API_KEY \\\n\
+         \tWHISRS_ASR_SIDECAR_API_KEY \\\n\
          \tXKB_DEFAULT_LAYOUT XKB_DEFAULT_VARIANT\n\
          do\n\
          \teval \"[ -n \\\"\\${{$_var}}\\\" ]\" && export \"$_var\"\n\
@@ -2107,28 +2108,69 @@ fn print_done() {
 mod tests {
     use super::*;
 
+    /// Slice out the `for _var in ... done` conf.d re-export loop.
+    ///
+    /// Searching the whole script for a variable name is also satisfied by a
+    /// name that only appears in the comment above the loop — which is exactly
+    /// the drift being guarded against — so the assertions below run against
+    /// the loop alone.
+    fn confd_reexport_loop(script: &str) -> &str {
+        const END: &str = "\ndone\n";
+        let start = script
+            .find("for _var in ")
+            .expect("OpenRC script must re-export conf.d variables");
+        let from_loop = &script[start..];
+        let end = from_loop
+            .find(END)
+            .expect("conf.d re-export loop must be terminated by `done`")
+            + END.len();
+        &from_loop[..end]
+    }
+
     /// The inline OpenRC fallback is used on `cargo install`, where `contrib/`
     /// is not on disk. It is a hand-maintained copy of
     /// `contrib/openrc/whisrs.initd`, so it silently drifts: an earlier
     /// revision omitted the conf.d re-export loop, which made
     /// `XKB_DEFAULT_LAYOUT` in conf.d a no-op with no diagnostic.
+    ///
+    /// `contrib/openrc/whisrs.initd` is the copy users actually install, so it
+    /// is held to the same list: asserting the two loops are byte-equal catches
+    /// drift in either direction and covers the shipped file's own var list.
     #[test]
-    fn inline_openrc_fallback_reexports_confd_vars() {
+    fn openrc_scripts_reexport_confd_vars() {
         let script = openrc_initd_contents("/usr/bin/whisrsd");
+        let inline_loop = confd_reexport_loop(&script);
         for var in [
             "RUST_LOG",
             "WHISRS_DEEPGRAM_API_KEY",
             "WHISRS_GROQ_API_KEY",
             "WHISRS_OPENAI_API_KEY",
+            "WHISRS_ASR_SIDECAR_API_KEY",
             "XKB_DEFAULT_LAYOUT",
             "XKB_DEFAULT_VARIANT",
         ] {
             assert!(
-                script.contains(var),
-                "inline OpenRC fallback must re-export {var}; conf.d values are \
-                 sourced, not exported, so omitting it silently drops the setting"
+                inline_loop.contains(var),
+                "inline OpenRC fallback must re-export {var} from inside the \
+                 `for _var in ... done` loop; conf.d values are sourced, not \
+                 exported, so omitting it silently drops the setting. Naming it \
+                 in the comment above the loop does not count."
             );
         }
+
+        // `cargo install` builds have no contrib/ on disk; skip rather than fail.
+        let Some(shipped_path) = find_contrib_file("openrc/whisrs.initd") else {
+            return;
+        };
+        let shipped = fs::read_to_string(&shipped_path).unwrap_or_else(|e| {
+            panic!("failed to read {}: {e}", shipped_path.display());
+        });
+        assert_eq!(
+            confd_reexport_loop(&shipped),
+            inline_loop,
+            "contrib/openrc/whisrs.initd is the script users install, and its \
+             conf.d re-export loop must stay identical to the inline fallback's"
+        );
     }
 
     /// Exporting an empty `DISPLAY` is worse than leaving it unset: it makes

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -516,8 +516,18 @@ pub(crate) fn configure_backend(
                 .interact_text()
                 .context("failed to read ASR sidecar model")?;
 
+            let api_key = prompt_optional_api_key_with_existing(
+                "Optional bearer token",
+                "Leave blank for local sidecars that do not require auth.",
+                existing_sidecar.and_then(|v| v.api_key.as_ref()),
+            )?;
+
             Ok(BackendConfigSelection {
-                asr_sidecar: Some(AsrSidecarConfig { url, model }),
+                asr_sidecar: Some(AsrSidecarConfig {
+                    url,
+                    model,
+                    api_key,
+                }),
                 ..BackendConfigSelection::default()
             })
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -543,6 +543,8 @@ pub struct AsrSidecarConfig {
     pub url: String,
     #[serde(default = "default_asr_sidecar_model")]
     pub model: String,
+    #[serde(default)]
+    pub api_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2009,6 +2011,7 @@ mod tests {
             asr_sidecar: Some(AsrSidecarConfig {
                 url: "http://127.0.0.1:8765/transcribe".to_string(),
                 model: "microsoft/VibeVoice-ASR-HF".to_string(),
+                api_key: None,
             }),
             openai_compatible_realtime: None,
             llm: None,

--- a/src/daemon/factory.rs
+++ b/src/daemon/factory.rs
@@ -65,6 +65,21 @@ fn resolve_deepgram_api_key(config: &Config) -> Option<String> {
     config.deepgram.as_ref().map(|d| d.api_key.clone())
 }
 
+fn resolve_asr_sidecar_api_key(config: &Config) -> Option<String> {
+    if let Ok(key) = std::env::var("WHISRS_ASR_SIDECAR_API_KEY") {
+        let trimmed = key.trim().to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
+    config
+        .asr_sidecar
+        .as_ref()
+        .and_then(|s| s.api_key.as_deref())
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+}
+
 fn sanitize_ws_endpoint_for_log(url: &str) -> String {
     let Ok(mut parsed) = reqwest::Url::parse(url) else {
         return "<invalid ws endpoint>".to_string();
@@ -174,13 +189,16 @@ pub(crate) fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
             Arc::new(ParakeetBackend::new(model_path))
         }
         "asr-sidecar" | "asr" | "vibevoice" => {
-            let url = config
-                .asr_sidecar
-                .as_ref()
+            let sidecar = config.asr_sidecar.as_ref();
+            let url = sidecar
                 .map(|v| v.url.clone())
                 .unwrap_or_else(|| "http://127.0.0.1:8765/transcribe".to_string());
+            let api_key = resolve_asr_sidecar_api_key(config);
+            if api_key.is_some() {
+                info!("ASR sidecar API key configured");
+            }
             info!("using ASR sidecar transcription backend ({url})");
-            Arc::new(AsrSidecarBackend::new(url))
+            Arc::new(AsrSidecarBackend::new(url, api_key))
         }
         "openai-compatible-realtime" => {
             let realtime = config.openai_compatible_realtime.as_ref().cloned();

--- a/src/daemon/factory.rs
+++ b/src/daemon/factory.rs
@@ -65,11 +65,17 @@ fn resolve_deepgram_api_key(config: &Config) -> Option<String> {
     config.deepgram.as_ref().map(|d| d.api_key.clone())
 }
 
-fn resolve_asr_sidecar_api_key(config: &Config) -> Option<String> {
-    if let Ok(key) = std::env::var("WHISRS_ASR_SIDECAR_API_KEY") {
-        let trimmed = key.trim().to_string();
+/// Resolution rules for the ASR sidecar key, with the environment passed in.
+///
+/// Env vars are process-global, so the resolution itself is kept pure and
+/// [`asr_sidecar_backend`] is the only thing that reads the environment.
+/// `WHISRS_ASR_SIDECAR_API_KEY` wins over `[asr-sidecar] api_key`; both sides
+/// are trimmed and a blank value on either side counts as absent.
+fn resolve_asr_sidecar_api_key_from(env_key: Option<&str>, config: &Config) -> Option<String> {
+    if let Some(key) = env_key {
+        let trimmed = key.trim();
         if !trimmed.is_empty() {
-            return Some(trimmed);
+            return Some(trimmed.to_string());
         }
     }
     config
@@ -78,6 +84,37 @@ fn resolve_asr_sidecar_api_key(config: &Config) -> Option<String> {
         .and_then(|s| s.api_key.as_deref())
         .map(|k| k.trim().to_string())
         .filter(|k| !k.is_empty())
+}
+
+/// Build the ASR sidecar backend described by `config`.
+///
+/// This is the only place the sidecar URL and the resolved API key are joined
+/// into a backend — [`create_backend`] just wraps the result in an `Arc`. It
+/// returns the concrete type so a test can assert that both actually made it
+/// in; a refactor that dropped the key here would otherwise show up nowhere
+/// but as a 401 against the user's sidecar.
+fn asr_sidecar_backend(config: &Config) -> AsrSidecarBackend {
+    asr_sidecar_backend_from(
+        std::env::var("WHISRS_ASR_SIDECAR_API_KEY").ok().as_deref(),
+        config,
+    )
+}
+
+/// [`asr_sidecar_backend`] with the environment passed in, so a stray
+/// `WHISRS_ASR_SIDECAR_API_KEY` in the shell running the tests cannot change
+/// what they assert.
+fn asr_sidecar_backend_from(env_key: Option<&str>, config: &Config) -> AsrSidecarBackend {
+    let url = config
+        .asr_sidecar
+        .as_ref()
+        .map(|v| v.url.clone())
+        .unwrap_or_else(|| "http://127.0.0.1:8765/transcribe".to_string());
+    let api_key = resolve_asr_sidecar_api_key_from(env_key, config);
+    if api_key.is_some() {
+        info!("ASR sidecar API key configured");
+    }
+    info!("using ASR sidecar transcription backend ({url})");
+    AsrSidecarBackend::new(url, api_key)
 }
 
 fn sanitize_ws_endpoint_for_log(url: &str) -> String {
@@ -188,18 +225,7 @@ pub(crate) fn create_backend(config: &Config) -> Arc<dyn TranscriptionBackend> {
             info!("using Parakeet transcription backend (model: {model_path})");
             Arc::new(ParakeetBackend::new(model_path))
         }
-        "asr-sidecar" | "asr" | "vibevoice" => {
-            let sidecar = config.asr_sidecar.as_ref();
-            let url = sidecar
-                .map(|v| v.url.clone())
-                .unwrap_or_else(|| "http://127.0.0.1:8765/transcribe".to_string());
-            let api_key = resolve_asr_sidecar_api_key(config);
-            if api_key.is_some() {
-                info!("ASR sidecar API key configured");
-            }
-            info!("using ASR sidecar transcription backend ({url})");
-            Arc::new(AsrSidecarBackend::new(url, api_key))
-        }
+        "asr-sidecar" | "asr" | "vibevoice" => Arc::new(asr_sidecar_backend(config)),
         "openai-compatible-realtime" => {
             let realtime = config.openai_compatible_realtime.as_ref().cloned();
             let Some(realtime) = realtime else {
@@ -283,6 +309,133 @@ pub(crate) fn get_model_for_backend(config: &Config) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A bare config carrying only the `[asr-sidecar]` section under test.
+    fn config_with_sidecar_key(api_key: Option<&str>) -> Config {
+        Config {
+            general: Default::default(),
+            audio: Default::default(),
+            input: Default::default(),
+            deepgram: None,
+            groq: None,
+            openai: None,
+            local_whisper: None,
+            local_vosk: None,
+            local_parakeet: None,
+            asr_sidecar: Some(whisrs::AsrSidecarConfig {
+                url: "http://127.0.0.1:8765/transcribe".to_string(),
+                model: "microsoft/VibeVoice-ASR-HF".to_string(),
+                api_key: api_key.map(str::to_string),
+            }),
+            openai_compatible_realtime: None,
+            llm: None,
+            hotkeys: None,
+            hooks: None,
+            llm_commands: Vec::new(),
+            overlay: None,
+            tts: None,
+        }
+    }
+
+    #[test]
+    fn asr_sidecar_env_key_wins_over_config() {
+        let config = config_with_sidecar_key(Some("config-key"));
+        assert_eq!(
+            resolve_asr_sidecar_api_key_from(Some("env-key"), &config).as_deref(),
+            Some("env-key")
+        );
+    }
+
+    #[test]
+    fn asr_sidecar_config_key_used_when_env_is_absent() {
+        let config = config_with_sidecar_key(Some("config-key"));
+        assert_eq!(
+            resolve_asr_sidecar_api_key_from(None, &config).as_deref(),
+            Some("config-key")
+        );
+    }
+
+    #[test]
+    fn asr_sidecar_blank_env_key_falls_through_to_config() {
+        let config = config_with_sidecar_key(Some("config-key"));
+        assert_eq!(
+            resolve_asr_sidecar_api_key_from(Some("   "), &config).as_deref(),
+            Some("config-key")
+        );
+    }
+
+    #[test]
+    fn asr_sidecar_blank_config_key_resolves_to_none() {
+        let config = config_with_sidecar_key(Some("   "));
+        assert_eq!(resolve_asr_sidecar_api_key_from(Some(""), &config), None);
+        assert_eq!(resolve_asr_sidecar_api_key_from(None, &config), None);
+    }
+
+    #[test]
+    fn asr_sidecar_keys_are_trimmed_on_both_paths() {
+        let config = config_with_sidecar_key(Some("  config-key\n"));
+        assert_eq!(
+            resolve_asr_sidecar_api_key_from(Some("  env-key\n"), &config).as_deref(),
+            Some("env-key")
+        );
+        assert_eq!(
+            resolve_asr_sidecar_api_key_from(None, &config).as_deref(),
+            Some("config-key")
+        );
+    }
+
+    #[test]
+    fn asr_sidecar_missing_section_resolves_to_none() {
+        let mut config = config_with_sidecar_key(None);
+        config.asr_sidecar = None;
+        assert_eq!(resolve_asr_sidecar_api_key_from(None, &config), None);
+    }
+
+    /// Assert the constructed backend, not the resolver. `asr_sidecar_backend`
+    /// is the single join between a resolved key and the thing that sends it,
+    /// so a refactor that dropped the key there would leave every
+    /// `resolve_*` test above green and only fail against a real sidecar.
+    #[test]
+    fn asr_sidecar_backend_carries_the_configured_url_and_key() {
+        let mut config = config_with_sidecar_key(Some("sk-config-key"));
+        config.asr_sidecar.as_mut().unwrap().url = "http://sidecar.local:9000/asr".to_string();
+
+        let backend = asr_sidecar_backend_from(None, &config);
+
+        assert_eq!(backend.url(), "http://sidecar.local:9000/asr");
+        assert_eq!(backend.api_key(), Some("sk-config-key"));
+    }
+
+    #[test]
+    fn asr_sidecar_backend_carries_the_env_key() {
+        let config = config_with_sidecar_key(None);
+
+        let backend = asr_sidecar_backend_from(Some("sk-env-key"), &config);
+
+        assert_eq!(backend.api_key(), Some("sk-env-key"));
+    }
+
+    #[test]
+    fn asr_sidecar_backend_is_unauthenticated_without_a_key() {
+        let config = config_with_sidecar_key(None);
+
+        let backend = asr_sidecar_backend_from(None, &config);
+
+        assert_eq!(backend.api_key(), None);
+    }
+
+    /// `[asr-sidecar]` is optional, so selecting the backend with no section at
+    /// all must still point at the address the contrib sidecar recipes bind to.
+    #[test]
+    fn asr_sidecar_backend_falls_back_to_the_default_url() {
+        let mut config = config_with_sidecar_key(None);
+        config.asr_sidecar = None;
+
+        let backend = asr_sidecar_backend_from(None, &config);
+
+        assert_eq!(backend.url(), "http://127.0.0.1:8765/transcribe");
+        assert_eq!(backend.api_key(), None);
+    }
 
     #[test]
     fn sanitize_ws_endpoint_for_log_strips_credentials_and_query() {

--- a/src/transcription/asr_sidecar.rs
+++ b/src/transcription/asr_sidecar.rs
@@ -18,14 +18,18 @@ const MAX_FILE_SIZE: usize = 1024 * 1024 * 1024;
 pub struct AsrSidecarBackend {
     client: reqwest::Client,
     url: String,
+    api_key: Option<String>,
 }
 
 impl AsrSidecarBackend {
-    /// Create a new sidecar backend with the transcription URL.
-    pub fn new(url: String) -> Self {
+    /// Create a new sidecar backend with the transcription URL and optional API key.
+    pub fn new(url: String, api_key: Option<String>) -> Self {
         Self {
             client: reqwest::Client::new(),
             url,
+            api_key: api_key
+                .map(|k| k.trim().to_string())
+                .filter(|k| !k.is_empty()),
         }
     }
 }
@@ -102,7 +106,18 @@ impl TranscriptionBackend for AsrSidecarBackend {
             form = form.text("hotwords", prompt.clone());
         }
 
-        let response = self.client.post(&self.url).multipart(form).send().await?;
+        // Some OpenAI-compatible endpoints 307-redirect when the URL has a trailing
+        // slash, which can downgrade http→https and cause reqwest to abort multipart
+        // POSTs. Trim trailing slashes so both forms work without a redirect.
+        let effective_url = self.url.trim_end_matches('/');
+        if effective_url != self.url {
+            debug!("trimmed trailing slashes from ASR sidecar URL: {effective_url}");
+        }
+        let mut request = self.client.post(effective_url);
+        if let Some(key) = &self.api_key {
+            request = request.header("Authorization", format!("Bearer {key}"));
+        }
+        let response = request.multipart(form).send().await?;
         let status = response.status();
         let body = response.text().await?;
 
@@ -137,7 +152,7 @@ mod tests {
 
     #[tokio::test]
     async fn transcribe_rejects_empty_audio() {
-        let backend = AsrSidecarBackend::new("http://127.0.0.1:8765/transcribe".to_string());
+        let backend = AsrSidecarBackend::new("http://127.0.0.1:8765/transcribe".to_string(), None);
         let config = TranscriptionConfig {
             language: "en".to_string(),
             model: "test-asr-model".to_string(),
@@ -149,7 +164,7 @@ mod tests {
 
     #[tokio::test]
     async fn transcribe_rejects_missing_url() {
-        let backend = AsrSidecarBackend::new(String::new());
+        let backend = AsrSidecarBackend::new(String::new(), None);
         let config = TranscriptionConfig {
             language: "en".to_string(),
             model: "test-asr-model".to_string(),
@@ -157,6 +172,42 @@ mod tests {
         };
         let err = backend.transcribe(&[1, 2, 3], &config).await.unwrap_err();
         assert!(err.to_string().contains("sidecar URL"));
+    }
+
+    #[test]
+    fn empty_api_key_is_normalized_to_none() {
+        let backend = AsrSidecarBackend::new(
+            "http://127.0.0.1:8765/transcribe".to_string(),
+            Some(String::new()),
+        );
+        assert!(backend.api_key.is_none());
+    }
+
+    #[test]
+    fn api_key_is_stored_when_present() {
+        let backend = AsrSidecarBackend::new(
+            "http://127.0.0.1:8765/transcribe".to_string(),
+            Some("sk-test-key".to_string()),
+        );
+        assert_eq!(backend.api_key.as_deref(), Some("sk-test-key"));
+    }
+
+    #[test]
+    fn whitespace_only_api_key_is_normalized_to_none() {
+        let backend = AsrSidecarBackend::new(
+            "http://127.0.0.1:8765/transcribe".to_string(),
+            Some("   ".to_string()),
+        );
+        assert!(backend.api_key.is_none());
+    }
+
+    #[test]
+    fn api_key_whitespace_is_trimmed() {
+        let backend = AsrSidecarBackend::new(
+            "http://127.0.0.1:8765/transcribe".to_string(),
+            Some("  sk-test-key  ".to_string()),
+        );
+        assert_eq!(backend.api_key.as_deref(), Some("sk-test-key"));
     }
 
     #[test]

--- a/src/transcription/asr_sidecar.rs
+++ b/src/transcription/asr_sidecar.rs
@@ -32,6 +32,49 @@ impl AsrSidecarBackend {
                 .filter(|k| !k.is_empty()),
         }
     }
+
+    /// The endpoint this backend posts to, exactly as configured.
+    ///
+    /// Test seam. The backend factory is the only place a URL and a key are
+    /// joined into a backend, and it lives in the `whisrsd` binary crate, so
+    /// neither `#[cfg(test)]` nor `pub(crate)` here is visible to the test that
+    /// proves that wiring. Hidden from the docs to keep it off the supported
+    /// surface.
+    #[doc(hidden)]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// The normalized API key, or `None` for an unauthenticated sidecar.
+    /// Test seam; see [`AsrSidecarBackend::url`].
+    #[doc(hidden)]
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+}
+
+/// The URL actually posted to, with trailing path slashes removed.
+///
+/// Some OpenAI-compatible endpoints 307-redirect when the URL has a trailing
+/// slash, which can downgrade http→https and cause reqwest to abort multipart
+/// POSTs. Trimming makes both forms work without a redirect. A URL made only of
+/// slashes would trim to the empty string, which reqwest rejects with an opaque
+/// relative-URL error, so keep the original in that case and let the request
+/// fail against what the user actually configured.
+///
+/// Only the *path* carries that noise. A trailing slash inside a query value or
+/// a fragment is data the user typed, so a URL carrying `?` or `#` is posted
+/// exactly as configured rather than silently rewritten.
+fn effective_url(url: &str) -> &str {
+    if url.contains('?') || url.contains('#') {
+        return url;
+    }
+    let trimmed = url.trim_end_matches('/');
+    if trimmed.is_empty() {
+        url
+    } else {
+        trimmed
+    }
 }
 
 /// Response from the ASR sidecar.
@@ -106,14 +149,11 @@ impl TranscriptionBackend for AsrSidecarBackend {
             form = form.text("hotwords", prompt.clone());
         }
 
-        // Some OpenAI-compatible endpoints 307-redirect when the URL has a trailing
-        // slash, which can downgrade http→https and cause reqwest to abort multipart
-        // POSTs. Trim trailing slashes so both forms work without a redirect.
-        let effective_url = self.url.trim_end_matches('/');
-        if effective_url != self.url {
-            debug!("trimmed trailing slashes from ASR sidecar URL: {effective_url}");
+        let url = effective_url(&self.url);
+        if url != self.url {
+            debug!("trimmed trailing slashes from ASR sidecar URL: {url}");
         }
-        let mut request = self.client.post(effective_url);
+        let mut request = self.client.post(url);
         if let Some(key) = &self.api_key {
             request = request.header("Authorization", format!("Bearer {key}"));
         }
@@ -149,6 +189,182 @@ impl TranscriptionBackend for AsrSidecarBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn test_config() -> TranscriptionConfig {
+        TranscriptionConfig {
+            language: "en".to_string(),
+            model: "test-asr-model".to_string(),
+            prompt: None,
+        }
+    }
+
+    /// One-shot HTTP server: accepts a single connection, reads the whole
+    /// request, answers `200 OK` with `body`, and hands back the request head
+    /// so a test can assert on what was actually put on the wire.
+    async fn serve_once(listener: TcpListener, body: &'static str) -> String {
+        let (mut stream, _) = listener.accept().await.unwrap();
+
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        let head_end = loop {
+            let n = stream.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client closed before sending a request head");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..head_end]).into_owned();
+
+        // Drain the multipart body first: replying while the client is still
+        // writing surfaces as a connection reset instead of a parsed response.
+        let content_length: usize = head
+            .to_ascii_lowercase()
+            .lines()
+            .find_map(|line| line.strip_prefix("content-length:"))
+            .and_then(|value| value.trim().parse().ok())
+            .expect(
+                "reqwest must send content-length for a multipart body with known part lengths",
+            );
+        while buf.len() < head_end + content_length {
+            let n = stream.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+        }
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+        head
+    }
+
+    #[tokio::test]
+    async fn transcribe_sends_bearer_authorization_header() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once(listener, r#"{"text": "ok"}"#));
+
+        let backend = AsrSidecarBackend::new(
+            format!("http://{addr}/transcribe"),
+            Some("sk-test-key".to_string()),
+        );
+        let text = backend
+            .transcribe(&[1, 2, 3], &test_config())
+            .await
+            .unwrap();
+        assert_eq!(text, "ok");
+
+        // reqwest lowercases header names on the wire, so compare lowercased.
+        let head = server.await.unwrap().to_ascii_lowercase();
+        assert!(
+            head.contains("authorization: bearer sk-test-key"),
+            "request head is missing the bearer token: {head}"
+        );
+    }
+
+    #[tokio::test]
+    async fn transcribe_sends_no_authorization_header_without_key() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once(listener, r#"{"text": "ok"}"#));
+
+        let backend = AsrSidecarBackend::new(format!("http://{addr}/transcribe"), None);
+        let text = backend
+            .transcribe(&[1, 2, 3], &test_config())
+            .await
+            .unwrap();
+        assert_eq!(text, "ok");
+
+        let head = server.await.unwrap().to_ascii_lowercase();
+        assert!(
+            !head.contains("authorization:"),
+            "unauthenticated request must not carry an authorization header: {head}"
+        );
+    }
+
+    #[tokio::test]
+    async fn transcribe_posts_to_the_trimmed_path() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_once(listener, r#"{"text": "ok"}"#));
+
+        // A trailing slash makes some OpenAI-compatible servers 307-redirect,
+        // which aborts the multipart POST; the request must go out trimmed.
+        let backend = AsrSidecarBackend::new(format!("http://{addr}/transcribe/"), None);
+        let text = backend
+            .transcribe(&[1, 2, 3], &test_config())
+            .await
+            .unwrap();
+        assert_eq!(text, "ok");
+
+        let head = server.await.unwrap();
+        assert!(
+            head.starts_with("POST /transcribe HTTP/1.1\r\n"),
+            "expected the trailing slash to be trimmed off the request line: {head}"
+        );
+    }
+
+    #[test]
+    fn effective_url_leaves_a_plain_url_alone() {
+        assert_eq!(
+            effective_url("http://127.0.0.1:8765/transcribe"),
+            "http://127.0.0.1:8765/transcribe"
+        );
+    }
+
+    #[test]
+    fn effective_url_trims_one_trailing_slash() {
+        assert_eq!(
+            effective_url("http://127.0.0.1:8765/transcribe/"),
+            "http://127.0.0.1:8765/transcribe"
+        );
+    }
+
+    #[test]
+    fn effective_url_trims_multiple_trailing_slashes() {
+        assert_eq!(
+            effective_url("http://127.0.0.1:8765/transcribe///"),
+            "http://127.0.0.1:8765/transcribe"
+        );
+    }
+
+    #[test]
+    fn effective_url_keeps_original_when_trimming_would_empty_it() {
+        // Trimming "/" to "" passes the empty-URL guard (which checks the
+        // configured value) and then dies inside reqwest with an opaque
+        // relative-URL error. Keep what the user configured instead.
+        assert_eq!(effective_url("/"), "/");
+        assert_eq!(effective_url("///"), "///");
+    }
+
+    #[test]
+    fn effective_url_leaves_a_query_alone() {
+        // The trailing slash belongs to the query value, not the path, so
+        // trimming it would post a different `x=` than the user configured.
+        assert_eq!(
+            effective_url("http://127.0.0.1:8765/transcribe?x=1/"),
+            "http://127.0.0.1:8765/transcribe?x=1/"
+        );
+        assert_eq!(
+            effective_url("http://127.0.0.1:8765/transcribe/?x=1"),
+            "http://127.0.0.1:8765/transcribe/?x=1"
+        );
+    }
+
+    #[test]
+    fn effective_url_leaves_a_fragment_alone() {
+        assert_eq!(
+            effective_url("http://127.0.0.1:8765/transcribe#frag/"),
+            "http://127.0.0.1:8765/transcribe#frag/"
+        );
+    }
 
     #[tokio::test]
     async fn transcribe_rejects_empty_audio() {


### PR DESCRIPTION
## Summary

Adds optional API key (bearer token) support to the ASR sidecar transcription backend. Previously the sidecar assumed a local sidecar with no authentication. Now users can optionally provide a token via config, environment variable, or the interactive setup wizard.

## What's Changed

- **Config**: New `api_key` field on `[asr-sidecar]` (`Option<String>`, defaults to `None`)
- **Env var**: `WHISRS_ASR_SIDECAR_API_KEY` overrides config, consistent with existing `WHISRS_GROQ_API_KEY` etc.
- **HTTP**: `Authorization: Bearer <key>` header sent when a key is configured
- **Setup wizard**: Prompts for optional bearer token during sidecar backend selection
- **Config editor**: Shows masked key or "optional API key not set"; masks key in TOML output
- **URL handling**: Trailing slashes trimmed to avoid 307-redirect issues with OpenAI-compatible endpoints (tested with Speaches + LiteLLM)
- **Input hardening**: Whitespace-only keys normalized to `None` at all resolution points
- **Docs**: Updated CLAUDE.md, README.md, and configuration.md

## Testing

- 2 new unit tests: empty key normalization, whitespace trimming
- Existing tests updated to match new constructor signature
- All 113 tests pass, clippy clean, formatting clean

## Migration

Existing configs without `api_key` under `[asr-sidecar]` continue to work unchanged (field defaults to `None`).

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested on at least one compositor (Hyprland — hotkey `whisrs toggle` verified)