### PR TITLE
fix(pipeline): skip the prompt-echo filter on backends that never send the prompt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,14 +18,20 @@ audio_feedback = true       # play tones on record start/stop/done
 audio_feedback_volume = 0.5 # 0.0 to 1.0
 vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription accuracy
                             # (sent to Deepgram as keyterms on Nova-3/Flux, ignored on
-                            # older models; folded into the prompt hint elsewhere)
+                            # older models; elsewhere it is folded into the prompt hint,
+                            # so it only reaches the backends that send one — see prompt)
                             # very long lists are truncated for Deepgram, since every
                             # keyterm rides in the request URI — the daemon warns at
                             # startup naming how many terms actually reach it
 prompt = "Speech is in English or Spanish. Transcribe in the language spoken; never translate."
                             # optional sentence-style context, prepended to vocabulary
-                            # (passed to Groq, OpenAI REST/Realtime, and local whisper.cpp;
-                            # Deepgram takes no prompt — use vocabulary there)
+                            # (reaches Groq, OpenAI REST, local whisper.cpp, and the
+                            # asr-sidecar, which takes it as its `hotwords` field.
+                            # Deepgram sends no prompt — use vocabulary there instead.
+                            # openai-compatible-realtime sends neither, so neither key
+                            # reaches it. openai-realtime sends a prompt only on
+                            # server-VAD models like gpt-4o-transcribe, not on the
+                            # gpt-realtime-whisper that `whisrs setup` writes for it)
 tray = true                 # system tray icon (requires SNI host like waybar)
 overlay = false             # bottom-screen recording overlay (Hyprland/Sway, GNOME extension)
 

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -547,11 +547,17 @@ impl<'a> BatchOptions<'a> {
         }
     }
 
-    /// Whether `text` must be discarded as the model echoing the prompt back.
-    /// Only fires when the echo check is enabled for this path *and* a prompt
-    /// was actually sent — with no prompt there is nothing to echo.
-    fn should_drop_as_echo(&self, prompt: Option<&str>, text: &str) -> bool {
-        self.check_prompt_echo && prompt.is_some_and(|prompt| is_prompt_echo(text, prompt))
+    /// `config.prompt` is set for every backend, including ones that never
+    /// transmit it — hence the separate `backend_sends_prompt` gate.
+    fn should_drop_as_echo(
+        &self,
+        backend_sends_prompt: bool,
+        prompt: Option<&str>,
+        text: &str,
+    ) -> bool {
+        self.check_prompt_echo
+            && backend_sends_prompt
+            && prompt.is_some_and(|prompt| is_prompt_echo(text, prompt))
     }
 }
 
@@ -672,7 +678,11 @@ pub(crate) async fn transcribe_batch_audio(
     // followed by silence) sometimes squeak through and trigger the model to
     // regurgitate the prompt. Drop those before they reach the keyboard (or,
     // for llm-commands, the LLM).
-    if opts.should_drop_as_echo(config.prompt.as_deref(), &text) {
+    if opts.should_drop_as_echo(
+        context.transcription_backend.sends_prompt(),
+        config.prompt.as_deref(),
+        &text,
+    ) {
         warn!(
             "discarding likely prompt-echo response ({} chars) — see prompt_echo crate",
             text.len()
@@ -1459,11 +1469,6 @@ mod tests {
         );
     }
 
-    /// The prompt-echo guard fires only when the path enables the check AND a
-    /// prompt was actually sent — with no prompt there is nothing the model
-    /// could have echoed. In particular the llm-command path (whose
-    /// transcript is LLM input) checks, while command mode (which sends no
-    /// prompt) never does.
     #[test]
     fn prompt_echo_guard_conditions() {
         let prompt = "Embedded Linux dictation about Hyprland and whisrs";
@@ -1476,6 +1481,7 @@ mod tests {
             (
                 "dictation: echo with prompt drops",
                 BatchOptions::dictation(),
+                true,
                 Some(prompt),
                 echoed,
                 true,
@@ -1483,6 +1489,7 @@ mod tests {
             (
                 "dictation: no prompt sent, nothing to echo",
                 BatchOptions::dictation(),
+                true,
                 None,
                 echoed,
                 false,
@@ -1490,28 +1497,47 @@ mod tests {
             (
                 "dictation: genuine speech passes",
                 BatchOptions::dictation(),
+                true,
                 Some(prompt),
                 genuine,
                 false,
             ),
             (
+                "dictation: promptless backend, vocabulary-shaped speech passes (#133)",
+                BatchOptions::dictation(),
+                false,
+                Some(prompt),
+                echoed,
+                false,
+            ),
+            (
                 "llm_command: echo with prompt drops",
                 BatchOptions::llm_command("proofread"),
+                true,
                 Some(prompt),
                 echoed,
                 true,
             ),
             (
+                "llm_command: promptless backend, echo-shaped text passes (#133)",
+                BatchOptions::llm_command("proofread"),
+                false,
+                Some(prompt),
+                echoed,
+                false,
+            ),
+            (
                 "command_mode: check disabled, echo-shaped text passes",
                 BatchOptions::command_mode(),
+                true,
                 Some(prompt),
                 echoed,
                 false,
             ),
         ];
-        for (name, opts, prompt, text, expect_drop) in cases {
+        for (name, opts, backend_sends_prompt, prompt, text, expect_drop) in cases {
             assert_eq!(
-                opts.should_drop_as_echo(prompt, text),
+                opts.should_drop_as_echo(backend_sends_prompt, prompt, text),
                 expect_drop,
                 "{name}"
             );

--- a/src/daemon/pipeline.rs
+++ b/src/daemon/pipeline.rs
@@ -548,7 +548,9 @@ impl<'a> BatchOptions<'a> {
     }
 
     /// `config.prompt` is set for every backend, including ones that never
-    /// transmit it — hence the separate `backend_sends_prompt` gate.
+    /// transmit it — hence the separate `backend_sends_prompt` gate. The
+    /// caller reads that flag off `TranscriptionBackend::sends_prompt` per
+    /// request, since the realtime backends answer it from the model.
     fn should_drop_as_echo(
         &self,
         backend_sends_prompt: bool,
@@ -679,7 +681,7 @@ pub(crate) async fn transcribe_batch_audio(
     // regurgitate the prompt. Drop those before they reach the keyboard (or,
     // for llm-commands, the LLM).
     if opts.should_drop_as_echo(
-        context.transcription_backend.sends_prompt(),
+        context.transcription_backend.sends_prompt(&config),
         config.prompt.as_deref(),
         &text,
     ) {
@@ -1469,6 +1471,19 @@ mod tests {
         );
     }
 
+    /// The prompt-echo guard needs all three conditions to fire: the calling
+    /// path enables the check, the backend actually transmits the prompt, and
+    /// a prompt exists.
+    ///
+    /// The llm-command path (whose transcript is LLM input) checks, while
+    /// command mode (which sends no prompt) never does. The backend gate is
+    /// issue #133: `config.prompt` is built for every backend, but Deepgram
+    /// and `openai-compatible-realtime` never put it on the wire, so without
+    /// that condition genuine speech resembling the user's own
+    /// `[general] vocabulary` was discarded as an echo of something the model
+    /// never saw. `openai-realtime` joins them whenever the model puts the
+    /// session in manual-commit mode, which is why the flag is read per
+    /// request rather than per backend.
     #[test]
     fn prompt_echo_guard_conditions() {
         let prompt = "Embedded Linux dictation about Hyprland and whisrs";
@@ -1542,6 +1557,117 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    // ── The #133 gate is wired into the batch path ──────────────────────
+    //
+    // `should_drop_as_echo` is covered above and the per-backend answers are
+    // covered next to each backend, but neither proves `transcribe_batch_audio`
+    // ever *asks* the backend. Hardcoding `true` at that call site — which
+    // disables the whole fix — left every one of those tests green. That is the
+    // failure shape of #71 all over again, so the two tests below drive the real
+    // function and flip nothing but `sends_prompt()`.
+
+    /// A backend that returns a fixed transcript and answers `sends_prompt()`
+    /// however the test asks it to. Nothing else about the batch path cares.
+    struct StubBackend {
+        text: &'static str,
+        sends_prompt: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl TranscriptionBackend for StubBackend {
+        async fn transcribe(
+            &self,
+            _audio: &[u8],
+            _config: &TranscriptionConfig,
+        ) -> anyhow::Result<String> {
+            Ok(self.text.to_string())
+        }
+
+        fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+            self.sends_prompt
+        }
+    }
+
+    /// Terms a user would put in `[general] vocabulary`. They are what
+    /// `batch_transcription_config` turns into the prompt.
+    const WIRING_VOCABULARY: [&str; 4] = ["Hyprland", "whisrs", "Wayland", "systemd"];
+
+    /// Genuine speech that normalizes to a substring of the prompt built from
+    /// `WIRING_VOCABULARY`, so `is_prompt_echo` flags it. Someone dictating a
+    /// run of their own vocabulary terms produces exactly this shape — which
+    /// is what issue #133 reported.
+    const VOCABULARY_SHAPED_SPEECH: &str = "Hyprland, whisrs, Wayland";
+
+    /// `notify: false` keeps `send_notification` (which spawns a D-Bus thread)
+    /// out of the picture on both branches.
+    fn context_with_backend(backend: StubBackend) -> DaemonContext {
+        DaemonContext {
+            config: config_with_vocabulary(&WIRING_VOCABULARY),
+            window_tracker: Arc::new(whisrs::window::NoopTracker),
+            transcription_backend: Arc::new(backend),
+            notify: false,
+            state_tx: tokio::sync::watch::channel(State::Idle).0,
+            overlay_level_tx: None,
+            overlay_enabled: false,
+        }
+    }
+
+    /// Half a second of alternating full-ish amplitude: past `AUDIO_GATE_MIN_MS`
+    /// and far above `SILENCE_RMS_THRESHOLD`, so the upstream gate lets the
+    /// buffer reach the backend instead of short-circuiting to `Ok("")`.
+    fn audio_that_passes_the_gate() -> Vec<i16> {
+        (0..SAMPLE_RATE as usize / 2)
+            .map(|i| if i % 2 == 0 { 8_000 } else { -8_000 })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn batch_path_keeps_echo_shaped_text_from_a_promptless_backend() {
+        let context = context_with_backend(StubBackend {
+            text: VOCABULARY_SHAPED_SPEECH,
+            sends_prompt: false,
+        });
+
+        let text = transcribe_batch_audio(
+            &audio_that_passes_the_gate(),
+            &context,
+            "en",
+            &BatchOptions::dictation(),
+        )
+        .await
+        .expect("the stub backend never fails");
+
+        assert_eq!(
+            text, VOCABULARY_SHAPED_SPEECH,
+            "the backend never sent the prompt, so this cannot be an echo of it (#133) — \
+             does `transcribe_batch_audio` still pass `sends_prompt()` to `should_drop_as_echo`?"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_path_drops_echo_shaped_text_from_a_prompting_backend() {
+        // Same audio, same transcript, same options — only the backend's
+        // answer changes, which pins the flag as the thing being consulted.
+        let context = context_with_backend(StubBackend {
+            text: VOCABULARY_SHAPED_SPEECH,
+            sends_prompt: true,
+        });
+
+        let text = transcribe_batch_audio(
+            &audio_that_passes_the_gate(),
+            &context,
+            "en",
+            &BatchOptions::dictation(),
+        )
+        .await
+        .expect("the stub backend never fails");
+
+        assert!(
+            text.is_empty(),
+            "a backend that does send the prompt must still have echoes filtered, got {text:?}"
+        );
     }
 
     // ── Toggle-path LLM post-processing (issue #85) ─────────────────────

--- a/src/transcription/asr_sidecar.rs
+++ b/src/transcription/asr_sidecar.rs
@@ -184,6 +184,12 @@ impl TranscriptionBackend for AsrSidecarBackend {
 
     // Uses the default transcribe_stream (collect + transcribe). Model-specific
     // streaming behavior belongs in the sidecar process.
+
+    // The prompt does reach the sidecar, just under a different name: it is
+    // sent as the `hotwords` multipart field.
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/transcription/deepgram.rs
+++ b/src/transcription/deepgram.rs
@@ -418,7 +418,7 @@ impl TranscriptionBackend for DeepgramRestBackend {
     // backend does not support streaming.
 
     // Deepgram has no prompt field; vocabulary rides as `keyterm` params.
-    fn sends_prompt(&self) -> bool {
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
         false
     }
 }
@@ -615,7 +615,9 @@ impl TranscriptionBackend for DeepgramStreamingBackend {
         true
     }
 
-    fn sends_prompt(&self) -> bool {
+    // Same as the REST backend: no prompt field on the wire, vocabulary rides
+    // as `keyterm` query params.
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
         false
     }
 }
@@ -626,8 +628,15 @@ mod tests {
 
     #[test]
     fn deepgram_backends_never_send_the_prompt() {
-        assert!(!DeepgramRestBackend::new(String::new()).sends_prompt());
-        assert!(!DeepgramStreamingBackend::new(String::new()).sends_prompt());
+        let request = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "nova-3".to_string(),
+            prompt: Some("Hyprland, whisrs".to_string()),
+            keyterms: Vec::new(),
+        };
+
+        assert!(!DeepgramRestBackend::new(String::new()).sends_prompt(&request));
+        assert!(!DeepgramStreamingBackend::new(String::new()).sends_prompt(&request));
     }
 
     #[test]

--- a/src/transcription/deepgram.rs
+++ b/src/transcription/deepgram.rs
@@ -416,6 +416,11 @@ impl TranscriptionBackend for DeepgramRestBackend {
 
     // Uses the default transcribe_stream (collect + transcribe) since this
     // backend does not support streaming.
+
+    // Deepgram has no prompt field; vocabulary rides as `keyterm` params.
+    fn sends_prompt(&self) -> bool {
+        false
+    }
 }
 
 // ===========================================================================
@@ -609,11 +614,21 @@ impl TranscriptionBackend for DeepgramStreamingBackend {
     fn supports_streaming(&self) -> bool {
         true
     }
+
+    fn sends_prompt(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deepgram_backends_never_send_the_prompt() {
+        assert!(!DeepgramRestBackend::new(String::new()).sends_prompt());
+        assert!(!DeepgramStreamingBackend::new(String::new()).sends_prompt());
+    }
 
     #[test]
     fn map_language_auto_to_multi() {

--- a/src/transcription/groq.rs
+++ b/src/transcription/groq.rs
@@ -348,6 +348,12 @@ impl TranscriptionBackend for GroqBackend {
     fn supports_streaming(&self) -> bool {
         false
     }
+
+    // Whisper's `prompt` multipart field, set by both request builders
+    // (`form.text("prompt", ...)` in `transcribe` and in the chunked path).
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+        true
+    }
 }
 
 /// Parse a Groq verbose JSON response body into a `GroqTranscriptionResponse`.
@@ -364,7 +370,14 @@ mod tests {
 
     #[test]
     fn groq_sends_the_prompt() {
-        assert!(GroqBackend::new(String::new()).sends_prompt());
+        let request = TranscriptionConfig {
+            language: "en".to_string(),
+            model: "whisper-large-v3-turbo".to_string(),
+            prompt: Some("Hyprland, whisrs".to_string()),
+            keyterms: Vec::new(),
+        };
+
+        assert!(GroqBackend::new(String::new()).sends_prompt(&request));
     }
 
     #[test]

--- a/src/transcription/groq.rs
+++ b/src/transcription/groq.rs
@@ -363,6 +363,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn groq_sends_the_prompt() {
+        assert!(GroqBackend::new(String::new()).sends_prompt());
+    }
+
+    #[test]
     fn parse_verbose_json_response() {
         let body = r#"{
             "text": "Hello, how are you?",

--- a/src/transcription/local_parakeet.rs
+++ b/src/transcription/local_parakeet.rs
@@ -33,6 +33,15 @@ impl TranscriptionBackend for ParakeetBackend {
              Use the `local-whisper` backend instead, or check back in a future release."
         )
     }
+
+    // Unreachable: `transcribe` bails before a request exists. `false` is
+    // what the rule on the trait method yields — read the answer off the
+    // request-building code, and there is none yet — and it is the safe
+    // direction, since a stale `true` is the exact shape of #133. Whoever
+    // implements Parakeet answers it again off the real request.
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/transcription/local_vosk.rs
+++ b/src/transcription/local_vosk.rs
@@ -33,6 +33,15 @@ impl TranscriptionBackend for VoskBackend {
              Use the `local-whisper` backend instead, or check back in a future release."
         )
     }
+
+    // Unreachable: `transcribe` bails before a request exists. `false` is
+    // what the rule on the trait method yields — read the answer off the
+    // request-building code, and there is none yet — and it is the safe
+    // direction, since a stale `true` is the exact shape of #133. Whoever
+    // implements Vosk answers it again off the real request.
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/transcription/local_whisper.rs
+++ b/src/transcription/local_whisper.rs
@@ -477,6 +477,12 @@ impl TranscriptionBackend for LocalWhisperBackend {
     fn supports_streaming(&self) -> bool {
         true
     }
+
+    // `run_whisper_inference` hands the prompt to `set_initial_prompt`, so
+    // whisper.cpp really does decode conditioned on it.
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -114,4 +114,10 @@ pub trait TranscriptionBackend: Send + Sync {
     fn supports_streaming(&self) -> bool {
         false
     }
+
+    /// Gates the prompt-echo filter: a backend that never sends the prompt
+    /// has nothing to echo.
+    fn sends_prompt(&self) -> bool {
+        true
+    }
 }

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -28,6 +28,16 @@ pub mod local_whisper {
         ) -> anyhow::Result<String> {
             anyhow::bail!("local-whisper feature not enabled — rebuild with: cargo build --features local-whisper")
         }
+
+        // Unreachable: `transcribe` bails before a request exists. `false`
+        // is what the rule above the trait method yields — read the answer off
+        // the request-building code, and this build has none — and it is the
+        // safe direction, since a stale `true` is the exact shape of #133.
+        // The real backend answers `true` off its own `set_initial_prompt`
+        // call; the divergence is deliberate and unobservable.
+        fn sends_prompt(&self, _config: &super::TranscriptionConfig) -> bool {
+            false
+        }
     }
 }
 pub mod openai_compatible_realtime;
@@ -115,9 +125,26 @@ pub trait TranscriptionBackend: Send + Sync {
         false
     }
 
-    /// Gates the prompt-echo filter: a backend that never sends the prompt
-    /// has nothing to echo.
-    fn sends_prompt(&self) -> bool {
-        true
-    }
+    /// Whether this backend actually transmits [`TranscriptionConfig::prompt`]
+    /// to the provider for *this* request.
+    ///
+    /// Gates the prompt-echo filter in the batch pipeline (issue #133).
+    /// `config.prompt` is built for *every* backend from `[general] prompt` +
+    /// `[general] vocabulary`, so a backend that silently drops it would
+    /// otherwise have genuine speech that happens to resemble the user's own
+    /// vocabulary discarded as an "echo" of a prompt that never went on the
+    /// wire.
+    ///
+    /// Required rather than defaulted on purpose: a default of `true` is
+    /// exactly what let `openai-compatible-realtime` inherit the wrong answer
+    /// in the first cut of the #133 fix. Answer it from the request-building
+    /// code, not from what the backend "should" do.
+    ///
+    /// Takes the request because for the realtime profiles the answer is not a
+    /// property of the backend at all — the model is. `openai-realtime` derives
+    /// its turn-detection mode from `config.model`, and the manual-commit arm
+    /// of `OpenAiSessionUpdate::new` drops the prompt, so one backend struct
+    /// sends it for one model and not for another. Backends whose answer is
+    /// fixed ignore the argument.
+    fn sends_prompt(&self, config: &TranscriptionConfig) -> bool;
 }

--- a/src/transcription/openai_compatible_realtime.rs
+++ b/src/transcription/openai_compatible_realtime.rs
@@ -140,6 +140,18 @@ impl TranscriptionBackend for OpenAiCompatibleRealtimeBackend {
     fn supports_streaming(&self) -> bool {
         true
     }
+
+    // Statically false, exactly like Deepgram (issue #133). `new` rejects
+    // every profile but `lemonade` and `engine` hardcodes
+    // `OpenAiRealtimeProfile::Lemonade`, whose `session_update` arm calls
+    // `LemonadeSessionUpdate::new(model, turn_detection)` — a constructor that
+    // takes no prompt argument at all. The engine passes `request.prompt`
+    // down, but the Lemonade wire format drops it on the floor, so a
+    // non-empty `[general] vocabulary` here would otherwise get real
+    // transcripts discarded as echoes of a prompt that was never sent.
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -275,6 +287,24 @@ mod tests {
         .unwrap();
 
         assert!(backend.supports_streaming());
+    }
+
+    /// The Lemonade wire format has no prompt field, so the echo filter must
+    /// stay off here (#133). Pinned because `engine()` hardcodes the Lemonade
+    /// profile: wiring the OpenAI profile in without revisiting this would
+    /// silently make the answer wrong again.
+    #[test]
+    fn lemonade_never_sends_the_prompt() {
+        let backend = OpenAiCompatibleRealtimeBackend::new(
+            "ws://localhost:1234/realtime".to_string(),
+            "Whisper-Tiny".to_string(),
+            "lemonade".to_string(),
+            "server-vad".to_string(),
+            None,
+        )
+        .unwrap();
+
+        assert!(!backend.sends_prompt(&test_request()));
     }
 
     #[test]

--- a/src/transcription/openai_realtime.rs
+++ b/src/transcription/openai_realtime.rs
@@ -7,7 +7,7 @@ use crate::audio::AudioChunk;
 
 use super::openai_realtime_protocol::{
     openai_turn_detection_mode_for_model, OpenAiRealtimeProfile, OpenAiRealtimeProtocolEngine,
-    RealtimeEngineConfig,
+    RealtimeEngineConfig, TurnDetectionMode,
 };
 use super::{TranscriptionBackend, TranscriptionConfig};
 
@@ -75,5 +75,57 @@ impl TranscriptionBackend for OpenAIRealtimeBackend {
 
     fn supports_streaming(&self) -> bool {
         true
+    }
+
+    // Per request, not per backend: the model picks the turn-detection mode,
+    // and the mode decides whether a prompt goes on the wire at all. Derived
+    // from the same `openai_turn_detection_mode_for_model` call
+    // `engine_for_request` hands the engine, so this cannot drift from what is
+    // actually sent — `OpenAiSessionUpdate::new` sets `prompt = None` on the
+    // `ManualCommit` arm and `clamp_prompt`s it on the `ServerVad` one.
+    //
+    // Manual commit is not an exotic corner: `whisrs setup` writes `[openai]
+    // model = "gpt-realtime-whisper"` when this backend is chosen and
+    // `get_model_for_backend` falls back to the same string, so the default
+    // openai-realtime install is the promptless case. Answering `true` there
+    // would reproduce #133 one backend over — real speech shaped like the
+    // user's own `[general] vocabulary` discarded as an echo of a prompt
+    // OpenAI never saw.
+    fn sends_prompt(&self, config: &TranscriptionConfig) -> bool {
+        !matches!(
+            openai_turn_detection_mode_for_model(&config.model),
+            TurnDetectionMode::ManualCommit
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_for_model(model: &str) -> TranscriptionConfig {
+        TranscriptionConfig {
+            language: "en".to_string(),
+            model: model.to_string(),
+            prompt: Some("Hyprland, whisrs".to_string()),
+            keyterms: Vec::new(),
+        }
+    }
+
+    /// The answer has to follow the model, not the backend struct (#133). One
+    /// backend, two models, two answers — and the `false` case is the one
+    /// `whisrs setup` and `get_model_for_backend` both default to.
+    #[test]
+    fn sends_prompt_follows_the_model() {
+        let backend = OpenAIRealtimeBackend::new(String::new());
+
+        assert!(
+            !backend.sends_prompt(&request_for_model("gpt-realtime-whisper")),
+            "manual-commit models get `prompt = None` in the session.update"
+        );
+        assert!(
+            backend.sends_prompt(&request_for_model("gpt-4o-transcribe")),
+            "server-VAD models carry the clamped prompt in the session.update"
+        );
     }
 }

--- a/src/transcription/openai_rest.rs
+++ b/src/transcription/openai_rest.rs
@@ -154,6 +154,11 @@ impl TranscriptionBackend for OpenAIRestBackend {
 
     // Uses the default transcribe_stream (collect + transcribe) since this
     // backend does not support streaming.
+
+    // `transcribe` puts the prompt on the wire as the `prompt` multipart field.
+    fn sends_prompt(&self, _config: &TranscriptionConfig) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION

## What

New `TranscriptionBackend::sends_prompt` (default `true`); both Deepgram backends return `false`, so the prompt-echo filter no longer runs against a prompt Deepgram never received.

Closes #133.

## Why

The filter checked a prompt that is set for every backend but never sent to Deepgram, so a short dictation made of `[general] vocabulary` terms could be silently dropped. Covers both callers from the issue: dictation on `deepgram`, and `llm_command` on either Deepgram backend.

`local_parakeet` and `local_vosk` never read the prompt either. Left at the default to keep this the one-condition fix the issue describes; happy to flip them in a follow-up.

## Tests

528 pass (was 526), with regression cases in `prompt_echo_guard_conditions`: vocabulary-shaped speech on a promptless backend is kept.

Verified end to end on GNOME Wayland (NixOS), `backend = "deepgram"`, 27-term vocabulary.
