### PR TITLE
feat(config): read extra vocabulary from vocabulary.txt next to config.toml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,8 @@ vocabulary = ["whisrs", "Hyprland"]  # custom terms for better transcription acc
                             # very long lists are truncated for Deepgram, since every
                             # keyterm rides in the request URI — the daemon warns at
                             # startup naming how many terms actually reach it
+                            # more terms can come from an optional vocabulary.txt next
+                            # to this file — see "The vocabulary file" below
 prompt = "Speech is in English or Spanish. Transcribe in the language spoken; never translate."
                             # optional sentence-style context, prepended to vocabulary
                             # (passed to Groq, OpenAI REST/Realtime, and local whisper.cpp;
@@ -409,6 +411,35 @@ Terminal detection needs the compositor to report the focused window class,
 which today means Hyprland, Niri, Sway and X11. On KDE and GNOME a terminal is
 treated as an ordinary target, so a multi-line reply is typed there. Add any
 class the built-in list misses to `[input] terminal_classes`.
+
+## The vocabulary file
+
+Vocabulary terms can also live in `~/.config/whisrs/vocabulary.txt`, next to
+`config.toml`. This exists for setups where `config.toml` is generated and
+read-only (Nix, chezmoi, any templated dotfiles), where adding one proper noun
+to `[general] vocabulary` would otherwise mean a rebuild. The path is fixed —
+there is deliberately no config key naming it, since setting one would need
+the very `config.toml` edit the file avoids.
+
+```
+# One term per line. Blank lines and lines starting with # are skipped.
+whisrs
+Claude Code
+NixOS
+```
+
+At daemon startup the file is merged into `[general] vocabulary` — config.toml's
+terms first, then the file's, duplicates dropped — before the config is
+validated, so the Deepgram keyterm limits and their startup warnings count the
+real list. A missing file is simply ignored; the feature is opt-in by creating
+it. Like the rest of the config, the file is read once at startup, so run
+`whisrs restart` after editing it.
+
+When the file exists, the `whisrs config` vocabulary editor shows the merged
+list and writes it back to `vocabulary.txt` on save (config.toml is then saved
+with an empty `vocabulary`, so no term is stored twice). The rewrite drops any
+comment lines you added by hand. Only `vocabulary` gets this treatment —
+`prompt` and everything else stay in `config.toml`.
 
 ## Environment variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -428,6 +428,10 @@ Claude Code
 NixOS
 ```
 
+A term that starts with `#` is stored with a single leading backslash
+(`\#rust`), which is stripped when the file is read; a `#` anywhere else on the
+line is literal, so `C# dev` needs nothing.
+
 At daemon startup the file is merged into `[general] vocabulary` — config.toml's
 terms first, then the file's, duplicates dropped — before the config is
 validated, so the Deepgram keyterm limits and their startup warnings count the
@@ -436,10 +440,15 @@ it. Like the rest of the config, the file is read once at startup, so run
 `whisrs restart` after editing it.
 
 When the file exists, the `whisrs config` vocabulary editor shows the merged
-list and writes it back to `vocabulary.txt` on save (config.toml is then saved
-with an empty `vocabulary`, so no term is stored twice). The rewrite drops any
-comment lines you added by hand. Only `vocabulary` gets this treatment —
-`prompt` and everything else stay in `config.toml`.
+list. If you change that list, the whole of it is written back to
+`vocabulary.txt` on save and config.toml is saved with an empty `vocabulary`,
+so no term is stored twice. That rewrite is flat, so any comment lines and
+blank-line grouping you added by hand are dropped at that point. If you leave
+the vocabulary alone — including opening the editor and accepting the list as
+shown — saving other settings touches neither store: your `vocabulary.txt`
+keeps its comments and config.toml keeps its terms. Only
+`vocabulary` gets this treatment; `prompt` and everything else stay in
+`config.toml`.
 
 ## Environment variables
 

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -13,7 +13,7 @@ use std::fs;
 use anyhow::{Context, Result};
 use dialoguer::{Confirm, Editor, Input, Select};
 
-use crate::config::setup;
+use crate::config::{setup, vocabulary};
 use crate::service::ServiceManager;
 use crate::{Config, HotkeyConfig, RestartOutcome};
 
@@ -34,6 +34,24 @@ pub fn run_config_menu() -> Result<()> {
                  Run {BOLD}whisrs setup{RESET} for the full onboarding flow."
             );
             (default_config(), true)
+        }
+    };
+
+    let vocab_path = vocabulary::vocabulary_path();
+    let use_vocab_file = match vocabulary::load_vocabulary_file(&vocab_path) {
+        Ok(Some(terms)) => {
+            config.general.vocabulary =
+                vocabulary::merge_vocabulary(std::mem::take(&mut config.general.vocabulary), terms);
+            true
+        }
+        Ok(None) => false,
+        Err(e) => {
+            println!(
+                "  {YELLOW}Could not read {}: {e} — its terms are not shown and \
+                 vocabulary edits stay in config.toml.{RESET}",
+                vocab_path.display()
+            );
+            false
         }
     };
 
@@ -78,7 +96,7 @@ pub fn run_config_menu() -> Result<()> {
             1 => edit_language(&mut config)?,
             2 => edit_behavior(&mut config)?,
             3 => edit_filler_words(&mut config)?,
-            4 => edit_vocabulary_and_prompt(&mut config)?,
+            4 => edit_vocabulary_and_prompt(&mut config, use_vocab_file)?,
             5 => edit_audio_device(&mut config)?,
             6 => edit_key_delay(&mut config)?,
             7 => edit_clipboard_fallback(&mut config)?,
@@ -101,7 +119,7 @@ pub fn run_config_menu() -> Result<()> {
                 // separator — no-op
             }
             17 => {
-                if save_and_restart(&config, fresh)? {
+                if save_and_restart(&config, fresh, use_vocab_file)? {
                     return Ok(());
                 }
                 // Validation failed — fall through to next loop iteration,
@@ -326,9 +344,15 @@ fn edit_filler_words(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-fn edit_vocabulary_and_prompt(config: &mut Config) -> Result<()> {
+fn edit_vocabulary_and_prompt(config: &mut Config, use_vocab_file: bool) -> Result<()> {
     println!("\n  {BOLD}Vocabulary & prompt{RESET}");
     println!("  {DIM}Domain terms/names sent as a hint to the backend to improve accuracy.{RESET}");
+    if use_vocab_file {
+        println!(
+            "  {DIM}Includes the terms from vocabulary.txt — on save the whole list is \
+             written back there.{RESET}"
+        );
+    }
 
     let current = if config.general.vocabulary.is_empty() {
         "(empty)".to_string()
@@ -848,7 +872,10 @@ fn open_in_editor(config: &mut Config) -> Result<bool> {
 /// `fresh` is true when we created the config from defaults (no file on disk
 /// at startup) — in that case we point the user at `whisrs setup` for the
 /// permissions/systemd/keybinding bits we deliberately skipped.
-fn save_and_restart(config: &Config, fresh: bool) -> Result<bool> {
+///
+/// With `use_vocab_file`, config.toml is written with an empty `vocabulary`
+/// so no term is stored twice and a deletion cannot resurrect from it.
+fn save_and_restart(config: &Config, fresh: bool, use_vocab_file: bool) -> Result<bool> {
     match config.validate() {
         Ok(warnings) => {
             for w in warnings {
@@ -865,7 +892,16 @@ fn save_and_restart(config: &Config, fresh: bool) -> Result<bool> {
         }
     }
 
-    let path = setup::write_config(config).context("failed to write config")?;
+    let mut on_disk = config.clone();
+    if use_vocab_file {
+        let vocab_path = vocabulary::vocabulary_path();
+        vocabulary::write_vocabulary_file(&vocab_path, &config.general.vocabulary)
+            .with_context(|| format!("failed to write {}", vocab_path.display()))?;
+        println!("\n  {GREEN}Wrote {}{RESET}", vocab_path.display());
+        on_disk.general.vocabulary = Vec::new();
+    }
+
+    let path = setup::write_config(&on_disk).context("failed to write config")?;
     println!("\n  {GREEN}Wrote {}{RESET}", path.display());
 
     // Permissions are set to 0600 by write_config(); double-check for the

--- a/src/config/edit.rs
+++ b/src/config/edit.rs
@@ -9,6 +9,7 @@
 //! compositor keybinding — while `config` only edits the TOML.
 
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use dialoguer::{Confirm, Editor, Input, Select};
@@ -38,6 +39,7 @@ pub fn run_config_menu() -> Result<()> {
     };
 
     let vocab_path = vocabulary::vocabulary_path();
+    let config_toml_vocabulary = config.general.vocabulary.clone();
     let use_vocab_file = match vocabulary::load_vocabulary_file(&vocab_path) {
         Ok(Some(terms)) => {
             config.general.vocabulary =
@@ -53,6 +55,11 @@ pub fn run_config_menu() -> Result<()> {
             );
             false
         }
+    };
+    let vocabulary_baseline = VocabularyBaseline {
+        use_file: use_vocab_file,
+        config_toml: config_toml_vocabulary,
+        merged: config.general.vocabulary.clone(),
     };
 
     loop {
@@ -119,7 +126,7 @@ pub fn run_config_menu() -> Result<()> {
                 // separator — no-op
             }
             17 => {
-                if save_and_restart(&config, fresh, use_vocab_file)? {
+                if save_and_restart(&config, fresh, &vocabulary_baseline)? {
                     return Ok(());
                 }
                 // Validation failed — fall through to next loop iteration,
@@ -349,8 +356,9 @@ fn edit_vocabulary_and_prompt(config: &mut Config, use_vocab_file: bool) -> Resu
     println!("  {DIM}Domain terms/names sent as a hint to the backend to improve accuracy.{RESET}");
     if use_vocab_file {
         println!(
-            "  {DIM}Includes the terms from vocabulary.txt — on save the whole list is \
-             written back there.{RESET}"
+            "  {DIM}Includes the terms from vocabulary.txt. Change the list and the whole \
+             of it is written back there on save; leave it alone and both files stay as \
+             they are.{RESET}"
         );
     }
 
@@ -863,6 +871,157 @@ fn open_in_editor(config: &mut Config) -> Result<bool> {
     }
 }
 
+/// Where the vocabulary stood when this `whisrs config` session started.
+///
+/// Two lists, because the editor works on the merged view while config.toml
+/// only ever held its own half. A save that did not touch the vocabulary has to
+/// put `config_toml` back, or the file's terms leak into config.toml and end up
+/// stored twice.
+struct VocabularyBaseline {
+    /// `vocabulary.txt` exists and was read successfully. False when it is
+    /// missing (feature not opted into) or unreadable, in which case the file
+    /// is never written and vocabulary edits stay in config.toml.
+    use_file: bool,
+    /// `[general] vocabulary` as read from config.toml, before the merge.
+    config_toml: Vec<String>,
+    /// The merged list the vocabulary editor started from.
+    merged: Vec<String>,
+}
+
+/// Whether this save should move the vocabulary into `vocabulary.txt`.
+///
+/// The migration is gated on an actual edit, not just on the file existing.
+/// Rewriting on every save made two unrelated saves destructive: it blanked
+/// `[general] vocabulary` in config.toml the first time anyone changed an
+/// unrelated setting (so deleting `vocabulary.txt` later lost the terms), and
+/// it flattened a hand-maintained `vocabulary.txt`, dropping its comments and
+/// grouping, for a save that had nothing to do with vocabulary.
+///
+/// Gating on the edit is also what makes an empty `vocabulary.txt` behave. An
+/// empty file is a legitimate way to opt in, and it stays untouched until the
+/// user actually adds a term — at which point the file is written non-empty,
+/// which is what the daemon-side merge requires.
+///
+/// The comparison is made on both lists *after* [`normalized_vocabulary`], so
+/// it is like-for-like.
+fn should_migrate_vocabulary(
+    use_vocab_file: bool,
+    baseline: &[String],
+    current: &[String],
+) -> bool {
+    use_vocab_file && normalized_vocabulary(baseline) != normalized_vocabulary(current)
+}
+
+/// A vocabulary list as the editor would hand it back.
+///
+/// The baseline is the raw merged list; anything that came out of "Vocabulary &
+/// prompt" has been through `join(", ")` and [`parse_csv_list`], and that round
+/// trip is not the identity — it trims padding and splits on commas. Comparing
+/// the two directly made an *unedited* pass through the editor look like an
+/// edit: a config.toml term with padding (`vocabulary = [" whisrs "]`, which is
+/// exactly what the templated-config setups this feature exists for produce) or
+/// with a comma in it fired the destructive migration when the user opened the
+/// section to change only the prompt and pressed Enter over the vocabulary
+/// line. Normalizing both sides removes the difference the editor itself
+/// introduced, leaving only the differences the user actually made.
+///
+/// The transform is idempotent — its output has no commas, no padding and no
+/// empty entries — so normalizing a list the editor already produced is a
+/// no-op, and the never-opened-the-editor path compares equal too.
+fn normalized_vocabulary(terms: &[String]) -> Vec<String> {
+    parse_csv_list(&terms.join(", "))
+}
+
+/// What `[general] vocabulary` config.toml should hold after this save.
+///
+/// The editor works on the merged view, so writing the in-memory list straight
+/// out would copy `vocabulary.txt`'s terms into config.toml and store every one
+/// of them twice. On a migration config.toml is emptied, since the file is now
+/// the single store. On an untouched vocabulary it gets back exactly the half
+/// it started with. With no `vocabulary.txt` in play there was no merge, so the
+/// edited list is written as-is, which is the pre-feature behavior.
+fn config_toml_vocabulary(vocab: &VocabularyBaseline, current: &[String]) -> Vec<String> {
+    if should_migrate_vocabulary(vocab.use_file, &vocab.merged, current) {
+        Vec::new()
+    } else if vocab.use_file {
+        vocab.config_toml.clone()
+    } else {
+        current.to_vec()
+    }
+}
+
+/// Everything a save does about the vocabulary, decided in one place.
+///
+/// The two halves are not independent — blanking `[general] vocabulary` is only
+/// safe *because* the same save wrote the terms to `vocabulary.txt` — so they
+/// are computed together and handed to the writer as a finished plan. Splitting
+/// the decision across the call site is what let a one-line slip there (write
+/// the blanked list to the file, skip the file write, write the merged list to
+/// config.toml) destroy every term the user had with every unit test still
+/// green.
+#[derive(Debug, PartialEq, Eq)]
+struct VocabularySavePlan {
+    /// The list `[general] vocabulary` is written with.
+    config_toml: Vec<String>,
+    /// The list `vocabulary.txt` is written with, or `None` to leave the file
+    /// exactly as it is (including its comments and grouping).
+    vocabulary_txt: Option<Vec<String>>,
+}
+
+/// Decide both halves of the save. Pure: it touches no disk.
+fn vocabulary_save_plan(vocab: &VocabularyBaseline, current: &[String]) -> VocabularySavePlan {
+    VocabularySavePlan {
+        config_toml: config_toml_vocabulary(vocab, current),
+        vocabulary_txt: should_migrate_vocabulary(vocab.use_file, &vocab.merged, current)
+            .then(|| current.to_vec()),
+    }
+}
+
+/// Execute a [`VocabularySavePlan`] and write config.toml, in that order.
+///
+/// The only place either store is written on save. `save_and_restart` calls
+/// this and does nothing else with the vocabulary, so there is no second copy
+/// of the decision for a call-site edit to get wrong.
+///
+/// Ordering: `vocabulary.txt` goes first because it is the direction that
+/// cannot lose a term. If config.toml then fails to write, every term the user
+/// kept is still on disk somewhere — the new list in `vocabulary.txt`, the old
+/// one still in config.toml. What that does *not* guarantee is that the save
+/// took effect: on a deletion config.toml keeps the removed term, and the next
+/// daemon start merges it straight back in. The error context says which half
+/// landed so the user is not left thinking the save rolled back cleanly.
+fn write_config_and_vocabulary(
+    config: &Config,
+    vocab: &VocabularyBaseline,
+    config_path: &Path,
+    vocab_path: &Path,
+) -> Result<Option<PathBuf>> {
+    let plan = vocabulary_save_plan(vocab, &config.general.vocabulary);
+
+    let mut vocabulary_written = None;
+    if let Some(terms) = &plan.vocabulary_txt {
+        vocabulary::write_vocabulary_file(vocab_path, terms)
+            .with_context(|| format!("failed to write {}", vocab_path.display()))?;
+        vocabulary_written = Some(vocab_path.to_path_buf());
+    }
+
+    let mut on_disk = config.clone();
+    on_disk.general.vocabulary = plan.config_toml;
+
+    if let Err(e) = setup::write_config_to(&on_disk, config_path) {
+        return Err(match &vocabulary_written {
+            Some(path) => e.context(format!(
+                "failed to write config: your vocabulary edits were already saved to {}, \
+                 but config.toml was not updated",
+                path.display()
+            )),
+            None => e.context("failed to write config"),
+        });
+    }
+
+    Ok(vocabulary_written)
+}
+
 /// Validate, write, and restart. Called only from the "Save & exit" branch.
 ///
 /// Returns `Ok(true)` on a successful save (caller should exit the menu) and
@@ -873,9 +1032,10 @@ fn open_in_editor(config: &mut Config) -> Result<bool> {
 /// at startup) — in that case we point the user at `whisrs setup` for the
 /// permissions/systemd/keybinding bits we deliberately skipped.
 ///
-/// With `use_vocab_file`, config.toml is written with an empty `vocabulary`
-/// so no term is stored twice and a deletion cannot resurrect from it.
-fn save_and_restart(config: &Config, fresh: bool, use_vocab_file: bool) -> Result<bool> {
+/// The vocabulary is not decided here: [`vocabulary_save_plan`] decides and
+/// [`write_config_and_vocabulary`] executes, and this function only reports
+/// which paths were written.
+fn save_and_restart(config: &Config, fresh: bool, vocab: &VocabularyBaseline) -> Result<bool> {
     match config.validate() {
         Ok(warnings) => {
             for w in warnings {
@@ -892,16 +1052,16 @@ fn save_and_restart(config: &Config, fresh: bool, use_vocab_file: bool) -> Resul
         }
     }
 
-    let mut on_disk = config.clone();
-    if use_vocab_file {
-        let vocab_path = vocabulary::vocabulary_path();
-        vocabulary::write_vocabulary_file(&vocab_path, &config.general.vocabulary)
-            .with_context(|| format!("failed to write {}", vocab_path.display()))?;
-        println!("\n  {GREEN}Wrote {}{RESET}", vocab_path.display());
-        on_disk.general.vocabulary = Vec::new();
-    }
+    // Both stores are written by one call, from one plan: see
+    // `write_config_and_vocabulary`. Nothing about the vocabulary is decided
+    // here.
+    let path = crate::config_path();
+    let vocabulary_written =
+        write_config_and_vocabulary(config, vocab, &path, &vocabulary::vocabulary_path())?;
 
-    let path = setup::write_config(&on_disk).context("failed to write config")?;
+    if let Some(vocab_path) = &vocabulary_written {
+        println!("\n  {GREEN}Wrote {}{RESET}", vocab_path.display());
+    }
     println!("\n  {GREEN}Wrote {}{RESET}", path.display());
 
     // Permissions are set to 0600 by write_config(); double-check for the
@@ -1009,6 +1169,463 @@ mod tests {
                 "edit_hotkeys never prompts for `{field}`, so editing hotkeys deletes it"
             );
         }
+    }
+
+    fn terms(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// No vocabulary.txt means no migration, however the list was edited: the
+    /// terms stay in config.toml, which is the pre-feature behavior.
+    #[test]
+    fn without_a_vocabulary_file_nothing_migrates() {
+        assert!(!should_migrate_vocabulary(
+            false,
+            &terms(&["whisrs"]),
+            &terms(&["whisrs", "NixOS"])
+        ));
+    }
+
+    /// The bug this gate exists for: a save that never touched the vocabulary
+    /// used to rewrite vocabulary.txt flat and blank `[general] vocabulary` in
+    /// config.toml. An unchanged list must leave both stores alone.
+    #[test]
+    fn an_unchanged_vocabulary_does_not_migrate() {
+        // Equal by value, not the same Vec: the save path compares the list
+        // the editor started from against the one it ends with.
+        assert!(!should_migrate_vocabulary(
+            true,
+            &terms(&["whisrs", "Hyprland"]),
+            &terms(&["whisrs", "Hyprland"])
+        ));
+    }
+
+    /// An empty vocabulary.txt is a legitimate way to opt in, so its mere
+    /// existence is not a reason to write anything. Nothing on either side, or
+    /// terms that only ever lived in config.toml, both stay put.
+    #[test]
+    fn an_empty_vocabulary_file_alone_does_not_migrate() {
+        assert!(!should_migrate_vocabulary(true, &[], &[]));
+        assert!(!should_migrate_vocabulary(
+            true,
+            &terms(&["whisrs"]),
+            &terms(&["whisrs"])
+        ));
+    }
+
+    /// Adding, removing or reordering a term is an edit, and an edit is what
+    /// moves the whole list into vocabulary.txt.
+    #[test]
+    fn any_vocabulary_edit_migrates() {
+        let baseline = terms(&["whisrs", "Hyprland"]);
+        for current in [
+            terms(&["whisrs", "Hyprland", "NixOS"]),
+            terms(&["whisrs"]),
+            terms(&["Hyprland", "whisrs"]),
+        ] {
+            assert!(
+                should_migrate_vocabulary(true, &baseline, &current),
+                "editing {baseline:?} into {current:?} must migrate"
+            );
+        }
+    }
+
+    /// Deleting every term still migrates, so vocabulary.txt is written empty
+    /// rather than left holding the terms the user just removed.
+    #[test]
+    fn clearing_the_vocabulary_migrates() {
+        assert!(should_migrate_vocabulary(
+            true,
+            &terms(&["whisrs", "Hyprland"]),
+            &[]
+        ));
+    }
+
+    /// Casing is part of the term: Deepgram echoes each keyterm back in the
+    /// casing configured, so `Whisrs` is a different term from `whisrs`.
+    #[test]
+    fn a_case_only_vocabulary_change_migrates() {
+        assert!(should_migrate_vocabulary(
+            true,
+            &terms(&["whisrs"]),
+            &terms(&["Whisrs"])
+        ));
+    }
+
+    fn baseline(use_file: bool, config_toml: &[&str], file: &[&str]) -> VocabularyBaseline {
+        VocabularyBaseline {
+            use_file,
+            config_toml: terms(config_toml),
+            merged: crate::config::vocabulary::merge_vocabulary(terms(config_toml), terms(file)),
+        }
+    }
+
+    /// The regression a naive "just don't migrate" fix introduces: the editor
+    /// holds the merged list, so an untouched save must put config.toml's own
+    /// half back rather than write the merge into it. Otherwise vocabulary.txt's
+    /// terms are silently copied into config.toml and stored twice.
+    #[test]
+    fn an_untouched_save_leaves_config_toml_holding_only_its_own_terms() {
+        let vocab = baseline(true, &["whisrs"], &["NixOS"]);
+        let current = vocab.merged.clone();
+        assert_eq!(
+            config_toml_vocabulary(&vocab, &current),
+            terms(&["whisrs"]),
+            "NixOS lives in vocabulary.txt and must not be copied into config.toml"
+        );
+    }
+
+    /// Once the user edits the list, vocabulary.txt becomes the single store
+    /// and config.toml is emptied, so deleting a term cannot resurrect it.
+    #[test]
+    fn an_edited_vocabulary_empties_config_toml() {
+        let vocab = baseline(true, &["whisrs"], &["NixOS"]);
+        assert!(
+            config_toml_vocabulary(&vocab, &terms(&["whisrs", "NixOS", "Hyprland"])).is_empty()
+        );
+        assert!(config_toml_vocabulary(&vocab, &[]).is_empty());
+    }
+
+    /// With no vocabulary.txt there was no merge, so the edited list is what
+    /// config.toml gets — the behavior from before the file existed.
+    #[test]
+    fn without_a_vocabulary_file_config_toml_keeps_the_edited_list() {
+        let vocab = baseline(false, &["whisrs"], &[]);
+        assert_eq!(
+            config_toml_vocabulary(&vocab, &terms(&["whisrs", "Hyprland"])),
+            terms(&["whisrs", "Hyprland"])
+        );
+    }
+
+    /// One row of the save-time state table: what the two stores were, what the
+    /// editor ended up holding, and what each store must be written with.
+    struct PlanRow {
+        what: &'static str,
+        /// `vocabulary.txt` exists and was read.
+        use_file: bool,
+        /// `[general] vocabulary` as config.toml held it at startup.
+        config_toml: &'static [&'static str],
+        /// The terms `vocabulary.txt` held at startup.
+        file: &'static [&'static str],
+        /// The list in memory when the user hit "Save & exit".
+        current: &'static [&'static str],
+        /// What `[general] vocabulary` must be written with.
+        expect_config_toml: &'static [&'static str],
+        /// What `vocabulary.txt` must be written with, `None` to leave it be.
+        expect_file: Option<&'static [&'static str]>,
+    }
+
+    /// The whole save-time decision, one row per reachable state.
+    ///
+    /// This is the table [`vocabulary_save_plan`] exists to satisfy. It is the
+    /// only decision the save makes about the vocabulary, so a slip in
+    /// `write_config_and_vocabulary` has nothing to reinterpret — see
+    /// `a_migrating_save_writes_the_whole_list_to_the_file_and_blanks_config_toml`
+    /// for the execution half.
+    #[test]
+    fn the_vocabulary_save_plan_covers_every_state() {
+        let rows = [
+            PlanRow {
+                what: "no vocabulary.txt, vocabulary untouched",
+                use_file: false,
+                config_toml: &["whisrs"],
+                file: &[],
+                current: &["whisrs"],
+                expect_config_toml: &["whisrs"],
+                expect_file: None,
+            },
+            PlanRow {
+                what: "no vocabulary.txt, term added — stays in config.toml",
+                use_file: false,
+                config_toml: &["whisrs"],
+                file: &[],
+                current: &["whisrs", "NixOS"],
+                expect_config_toml: &["whisrs", "NixOS"],
+                expect_file: None,
+            },
+            PlanRow {
+                what: "no vocabulary.txt, list cleared",
+                use_file: false,
+                config_toml: &["whisrs"],
+                file: &[],
+                current: &[],
+                expect_config_toml: &[],
+                expect_file: None,
+            },
+            PlanRow {
+                what: "vocabulary.txt present, vocabulary untouched — neither store moves",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &["NixOS"],
+                current: &["whisrs", "NixOS"],
+                expect_config_toml: &["whisrs"],
+                expect_file: None,
+            },
+            PlanRow {
+                what: "term added — the whole merged list migrates to the file",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &["NixOS"],
+                current: &["whisrs", "NixOS", "Deepgram"],
+                expect_config_toml: &[],
+                expect_file: Some(&["whisrs", "NixOS", "Deepgram"]),
+            },
+            PlanRow {
+                what: "term removed — the file gets the survivors, config.toml is blanked",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &["NixOS"],
+                current: &["whisrs"],
+                expect_config_toml: &[],
+                expect_file: Some(&["whisrs"]),
+            },
+            PlanRow {
+                what: "reordered — order is part of the list (Deepgram budgets in order)",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &["NixOS"],
+                current: &["NixOS", "whisrs"],
+                expect_config_toml: &[],
+                expect_file: Some(&["NixOS", "whisrs"]),
+            },
+            PlanRow {
+                what: "case-only change — Deepgram echoes the casing configured",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &["NixOS"],
+                current: &["Whisrs", "NixOS"],
+                expect_config_toml: &[],
+                expect_file: Some(&["Whisrs", "NixOS"]),
+            },
+            PlanRow {
+                what: "everything deleted — the file is written empty, not left holding terms",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &["NixOS"],
+                current: &[],
+                expect_config_toml: &[],
+                expect_file: Some(&[]),
+            },
+            PlanRow {
+                what: "empty vocabulary.txt, nothing anywhere — its existence is not an edit",
+                use_file: true,
+                config_toml: &[],
+                file: &[],
+                current: &[],
+                expect_config_toml: &[],
+                expect_file: None,
+            },
+            PlanRow {
+                what: "empty vocabulary.txt, config.toml terms untouched — they stay put",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &[],
+                current: &["whisrs"],
+                expect_config_toml: &["whisrs"],
+                expect_file: None,
+            },
+            PlanRow {
+                what: "empty vocabulary.txt, term added — now the file is written",
+                use_file: true,
+                config_toml: &["whisrs"],
+                file: &[],
+                current: &["whisrs", "NixOS"],
+                expect_config_toml: &[],
+                expect_file: Some(&["whisrs", "NixOS"]),
+            },
+            PlanRow {
+                // The editor round-trips through `join(", ")` + `parse_csv_list`,
+                // which trims. A padded config.toml term must not read as an edit.
+                what: "padded config.toml term, editor opened and left alone",
+                use_file: true,
+                config_toml: &[" whisrs "],
+                file: &["NixOS"],
+                current: &["whisrs", "NixOS"],
+                expect_config_toml: &[" whisrs "],
+                expect_file: None,
+            },
+            PlanRow {
+                // Same, for the other half of that round trip: the editor's
+                // input format splits on commas.
+                what: "comma-containing config.toml term, editor opened and left alone",
+                use_file: true,
+                config_toml: &["Claude, Code"],
+                file: &["NixOS"],
+                current: &["Claude", "Code", "NixOS"],
+                expect_config_toml: &["Claude, Code"],
+                expect_file: None,
+            },
+        ];
+
+        for row in rows {
+            let vocab = baseline(row.use_file, row.config_toml, row.file);
+            let plan = vocabulary_save_plan(&vocab, &terms(row.current));
+            assert_eq!(
+                plan,
+                VocabularySavePlan {
+                    config_toml: terms(row.expect_config_toml),
+                    vocabulary_txt: row.expect_file.map(terms),
+                },
+                "{}",
+                row.what
+            );
+        }
+    }
+
+    /// A `whisrs config` session that only ever loaded the config: the baseline
+    /// and the in-memory list are the same raw merged list, padding and all.
+    /// Nothing may migrate.
+    #[test]
+    fn a_save_that_never_opened_the_vocabulary_editor_does_not_migrate() {
+        let vocab = baseline(true, &[" whisrs ", "Claude, Code"], &["NixOS"]);
+        let untouched = vocab.merged.clone();
+        assert_eq!(
+            vocabulary_save_plan(&vocab, &untouched).vocabulary_txt,
+            None
+        );
+    }
+
+    /// A config.toml + vocabulary.txt pair in a fresh temp dir, driven through
+    /// the real save path. Returns the two paths and what the vocabulary write
+    /// reported.
+    fn run_save(
+        vocab: &VocabularyBaseline,
+        current: &[&str],
+        vocabulary_txt: Option<&str>,
+    ) -> (tempfile::TempDir, PathBuf, PathBuf, Option<PathBuf>) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config_path = dir.path().join("config.toml");
+        let vocab_path = dir.path().join("vocabulary.txt");
+        if let Some(contents) = vocabulary_txt {
+            fs::write(&vocab_path, contents).expect("seed vocabulary.txt");
+        }
+
+        let mut config = default_config();
+        config.general.vocabulary = terms(current);
+        let written = write_config_and_vocabulary(&config, vocab, &config_path, &vocab_path)
+            .expect("save succeeds");
+
+        (dir, config_path, vocab_path, written)
+    }
+
+    fn config_toml_terms(path: &Path) -> Vec<String> {
+        let contents = fs::read_to_string(path).expect("config.toml exists");
+        let parsed: Config = toml::from_str(&contents).expect("config.toml reparses");
+        parsed.general.vocabulary
+    }
+
+    /// The composition, not the pieces: an edit must put the *whole merged
+    /// list* in vocabulary.txt and an empty list in config.toml, in that order.
+    ///
+    /// Writing the blanked config.toml list to the file, skipping the file
+    /// write, or writing the merged list into config.toml each destroy or
+    /// duplicate the user's terms, and each is a one-line slip at this call
+    /// site. All three fail here.
+    #[test]
+    fn a_migrating_save_writes_the_whole_list_to_the_file_and_blanks_config_toml() {
+        let vocab = baseline(true, &["whisrs"], &["NixOS"]);
+        let (_dir, config_path, vocab_path, written) = run_save(
+            &vocab,
+            &["whisrs", "NixOS", "Deepgram"],
+            Some("# hand-written\nNixOS\n"),
+        );
+
+        assert_eq!(written.as_deref(), Some(vocab_path.as_path()));
+        assert_eq!(
+            vocabulary::load_vocabulary_file(&vocab_path).expect("readable"),
+            Some(terms(&["whisrs", "NixOS", "Deepgram"])),
+            "vocabulary.txt must hold every term the editor showed"
+        );
+        assert!(
+            config_toml_terms(&config_path).is_empty(),
+            "config.toml must be blanked so no term is stored twice"
+        );
+    }
+
+    /// The other half of the composition: with no edit, neither store is
+    /// touched. vocabulary.txt keeps its comments byte for byte and config.toml
+    /// gets back exactly its own half of the list, not the merge.
+    #[test]
+    fn a_save_without_a_vocabulary_edit_leaves_both_stores_alone() {
+        let seeded = "# Deepgram keyterms\n\n# proper nouns\nNixOS\n";
+        let vocab = baseline(true, &["whisrs"], &["NixOS"]);
+        let (_dir, config_path, vocab_path, written) =
+            run_save(&vocab, &["whisrs", "NixOS"], Some(seeded));
+
+        assert_eq!(written, None);
+        assert_eq!(
+            fs::read_to_string(&vocab_path).expect("readable"),
+            seeded,
+            "an untouched vocabulary must not cost the user their comments"
+        );
+        assert_eq!(
+            config_toml_terms(&config_path),
+            terms(&["whisrs"]),
+            "config.toml keeps its own half; the file's terms must not leak in"
+        );
+    }
+
+    /// FIX for the editor round trip: opening "Vocabulary & prompt" to change
+    /// only the prompt and pressing Enter over the vocabulary line is not an
+    /// edit, even when config.toml's terms have padding or a comma in them.
+    /// Before this, `parse_csv_list` normalized them, the lists compared
+    /// unequal, and a migration the user never asked for flattened their
+    /// hand-maintained vocabulary.txt.
+    #[test]
+    fn an_unedited_pass_through_the_editor_does_not_migrate() {
+        let seeded = "# grouped by project\nNixOS\n\n# people\nClaude\n";
+        let vocab = baseline(true, &[" whisrs ", "Claude, Code"], &["NixOS", "Claude"]);
+        // Exactly what the editor hands back when the user accepts the default.
+        let echoed = normalized_vocabulary(&vocab.merged);
+        let echoed: Vec<&str> = echoed.iter().map(String::as_str).collect();
+
+        let (_dir, config_path, vocab_path, written) = run_save(&vocab, &echoed, Some(seeded));
+
+        assert_eq!(written, None, "an unedited pass must not write the file");
+        assert_eq!(fs::read_to_string(&vocab_path).expect("readable"), seeded);
+        assert_eq!(
+            config_toml_terms(&config_path),
+            terms(&[" whisrs ", "Claude, Code"]),
+            "config.toml must keep its terms verbatim"
+        );
+    }
+
+    /// Deleting a term is the case blanking config.toml exists for: the term
+    /// must be in neither store afterwards, so the daemon's startup merge
+    /// cannot bring it back. This is the resurrection scenario end to end —
+    /// save, then re-run the merge the daemon does.
+    #[test]
+    fn a_deleted_term_cannot_resurrect_from_config_toml() {
+        let vocab = baseline(true, &["whisrs", "ghost"], &["NixOS"]);
+        let (_dir, config_path, vocab_path, _) =
+            run_save(&vocab, &["whisrs", "NixOS"], Some("NixOS\n"));
+
+        let from_file = vocabulary::load_vocabulary_file(&vocab_path)
+            .expect("readable")
+            .expect("written");
+        let merged = vocabulary::merge_vocabulary(config_toml_terms(&config_path), from_file);
+        assert_eq!(
+            merged,
+            terms(&["whisrs", "NixOS"]),
+            "the daemon must load exactly what the editor showed after the delete"
+        );
+    }
+
+    /// A term starting with `#` survives the migration. It used to be written
+    /// as a line the parser reads as a comment, so it disappeared from
+    /// vocabulary.txt in the same save that blanked config.toml — gone from
+    /// both stores, silently.
+    #[test]
+    fn a_hash_leading_term_survives_the_migration() {
+        let vocab = baseline(true, &["#1", "NixOS"], &[]);
+        let (_dir, config_path, vocab_path, _) =
+            run_save(&vocab, &["#1", "NixOS", "Deepgram"], Some(""));
+
+        let from_file = vocabulary::load_vocabulary_file(&vocab_path)
+            .expect("readable")
+            .expect("written");
+        let merged = vocabulary::merge_vocabulary(config_toml_terms(&config_path), from_file);
+        assert_eq!(merged, terms(&["#1", "NixOS", "Deepgram"]));
     }
 
     /// A section with nothing bound is dropped, keeping the TOML clean.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,5 +3,6 @@
 pub mod edit;
 pub mod setup;
 pub mod types;
+pub mod vocabulary;
 
 pub use types::*;

--- a/src/config/setup.rs
+++ b/src/config/setup.rs
@@ -806,7 +806,11 @@ pub fn write_config(config: &Config) -> Result<PathBuf> {
 }
 
 /// Implementation of [`write_config`] against an explicit path (testable).
-fn write_config_to(config: &Config, config_path: &Path) -> Result<()> {
+///
+/// `pub(crate)` so the `whisrs config` save path can be driven end to end in a
+/// temp dir — the composition of "write vocabulary.txt, then write config.toml
+/// with the right list" is where the destructive bugs live, not in either half.
+pub(crate) fn write_config_to(config: &Config, config_path: &Path) -> Result<()> {
     let config_dir = config_path
         .parent()
         .expect("config path should have a parent directory");
@@ -1071,7 +1075,11 @@ fn atomic_write(path: &Path, contents: &str) -> std::io::Result<()> {
 
 /// Create (or truncate) `path` with mode 0600 and write `contents`, fsyncing
 /// before returning.
-fn write_private_file(path: &Path, contents: &str) -> std::io::Result<()> {
+///
+/// `pub(crate)` because every file whisrs writes next to `config.toml` gets the
+/// same treatment — `vocabulary.txt` included, since the feature moves user
+/// data out of the 0600 config into a sibling file.
+pub(crate) fn write_private_file(path: &Path, contents: &str) -> std::io::Result<()> {
     use std::io::Write as _;
 
     let mut options = fs::OpenOptions::new();

--- a/src/config/vocabulary.rs
+++ b/src/config/vocabulary.rs
@@ -1,0 +1,126 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub fn vocabulary_path() -> PathBuf {
+    crate::config_path().with_file_name("vocabulary.txt")
+}
+
+pub fn parse_vocabulary(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+        .collect()
+}
+
+pub fn load_vocabulary_file(path: &Path) -> io::Result<Option<Vec<String>>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => Ok(Some(parse_vocabulary(&contents))),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Case-sensitive: Deepgram returns each keyterm in the casing configured.
+pub fn merge_vocabulary(config_terms: Vec<String>, file_terms: Vec<String>) -> Vec<String> {
+    let mut merged = Vec::with_capacity(config_terms.len() + file_terms.len());
+    for term in config_terms.into_iter().chain(file_terms) {
+        if !merged.contains(&term) {
+            merged.push(term);
+        }
+    }
+    merged
+}
+
+pub fn write_vocabulary_file(path: &Path, terms: &[String]) -> io::Result<()> {
+    let mut contents = terms.join("\n");
+    contents.push('\n');
+    std::fs::write(path, contents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vocabulary_file_lives_next_to_config_toml() {
+        let vocab = vocabulary_path();
+        assert_eq!(vocab.file_name().unwrap(), "vocabulary.txt");
+        assert_eq!(vocab.parent(), crate::config_path().parent());
+    }
+
+    #[test]
+    fn parse_skips_blanks_and_comments_and_trims() {
+        let contents = "\
+# Deepgram nova-3 keyterms: this casing comes back.
+whisrs
+
+  Claude Code  \n\
+\t
+NixOS
+# trailing comment
+";
+        assert_eq!(
+            parse_vocabulary(contents),
+            vec!["whisrs", "Claude Code", "NixOS"]
+        );
+    }
+
+    #[test]
+    fn parse_keeps_inline_hash() {
+        assert_eq!(parse_vocabulary("C# dev\n"), vec!["C# dev"]);
+    }
+
+    #[test]
+    fn parse_empty_and_comment_only_files_yield_no_terms() {
+        assert!(parse_vocabulary("").is_empty());
+        assert!(parse_vocabulary("# only a comment\n\n").is_empty());
+    }
+
+    #[test]
+    fn merge_puts_config_first_and_drops_duplicates() {
+        let config = vec!["whisrs".to_string(), "GNOME".to_string()];
+        let file = vec![
+            "Deepgram".to_string(),
+            "whisrs".to_string(),
+            "NixOS".to_string(),
+        ];
+        assert_eq!(
+            merge_vocabulary(config, file),
+            vec!["whisrs", "GNOME", "Deepgram", "NixOS"]
+        );
+    }
+
+    #[test]
+    fn merge_is_case_sensitive() {
+        let merged = merge_vocabulary(vec!["whisrs".to_string()], vec!["Whisrs".to_string()]);
+        assert_eq!(merged, vec!["whisrs", "Whisrs"]);
+    }
+
+    #[test]
+    fn missing_file_is_not_an_error() {
+        let dir = std::env::temp_dir().join("whisrs-vocab-test-missing");
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(
+            load_vocabulary_file(&dir.join("vocabulary.txt")).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn write_then_load_round_trips() {
+        let dir = std::env::temp_dir().join("whisrs-vocab-test-roundtrip");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("vocabulary.txt");
+
+        write_vocabulary_file(&path, &[]).unwrap();
+        assert_eq!(load_vocabulary_file(&path).unwrap(), Some(Vec::new()));
+
+        let terms = vec!["whisrs".to_string(), "Claude Code".to_string()];
+        write_vocabulary_file(&path, &terms).unwrap();
+        assert_eq!(load_vocabulary_file(&path).unwrap(), Some(terms));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/config/vocabulary.rs
+++ b/src/config/vocabulary.rs
@@ -5,11 +5,30 @@ pub fn vocabulary_path() -> PathBuf {
     crate::config_path().with_file_name("vocabulary.txt")
 }
 
+/// One term per line; blank lines and `#` comment lines are skipped.
+///
+/// A leading UTF-8 BOM is stripped from the whole file, not per line, because
+/// that is the only place it can appear and because stripping it here is what
+/// makes a BOM-only file yield nothing. `str::trim` does not remove U+FEFF, so
+/// without this an editor that writes a BOM shipped `\u{feff}NixOS` to Deepgram
+/// as a keyterm that can never match, and a BOM-only file produced one bogus
+/// single-character term.
+///
+/// A single leading `\` is an escape and is stripped after the comment check,
+/// so [`write_vocabulary_file`] can store a term that begins with `#` (or with
+/// `\`) without the parser reading it back as a comment. That is the whole
+/// grammar: `\` anywhere else, and `#` anywhere but the first non-whitespace
+/// column, are literal — `C# dev` stays one term.
 pub fn parse_vocabulary(contents: &str) -> Vec<String> {
     contents
+        .strip_prefix('\u{feff}')
+        .unwrap_or(contents)
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| line.strip_prefix('\\').unwrap_or(line))
+        // A lone `\` unescapes to nothing, which is not a term.
+        .filter(|term| !term.is_empty())
         .map(str::to_string)
         .collect()
 }
@@ -33,10 +52,30 @@ pub fn merge_vocabulary(config_terms: Vec<String>, file_terms: Vec<String>) -> V
     merged
 }
 
+/// One term per line, 0600 like the config it was split out of.
+///
+/// A term whose first non-whitespace character is `#` or `\` is written with a
+/// single extra leading `\`, which [`parse_vocabulary`] strips back off. Without
+/// that escape the migration destroyed such a term outright: `#1` was written as
+/// a line the parser reads as a comment, so it vanished from `vocabulary.txt`
+/// while `[general] vocabulary` was blanked in the same save — gone from both
+/// stores, with no warning. Nothing else is escaped, so `C# dev` is written
+/// as-is.
+///
+/// The file sits next to `config.toml` and now holds vocabulary that used to
+/// live inside it, so it is written with the same private-file helper (0600)
+/// rather than through `fs::write`, which leaves it world-readable under the
+/// usual umask.
 pub fn write_vocabulary_file(path: &Path, terms: &[String]) -> io::Result<()> {
-    let mut contents = terms.join("\n");
-    contents.push('\n');
-    std::fs::write(path, contents)
+    let mut contents = String::new();
+    for term in terms {
+        if matches!(term.trim_start().chars().next(), Some('#') | Some('\\')) {
+            contents.push('\\');
+        }
+        contents.push_str(term);
+        contents.push('\n');
+    }
+    crate::config::setup::write_private_file(path, &contents)
 }
 
 #[cfg(test)]
@@ -76,6 +115,24 @@ NixOS
     fn parse_empty_and_comment_only_files_yield_no_terms() {
         assert!(parse_vocabulary("").is_empty());
         assert!(parse_vocabulary("# only a comment\n\n").is_empty());
+    }
+
+    /// `str::trim` strips `\r` but not U+FEFF, so a BOM used to ride into the
+    /// term itself and reach Deepgram as `%EF%BB%BFNixOS`.
+    #[test]
+    fn parse_strips_a_leading_utf8_bom() {
+        assert_eq!(
+            parse_vocabulary("\u{feff}NixOS\nwhisrs\n"),
+            vec!["NixOS", "whisrs"]
+        );
+    }
+
+    /// A BOM-only file is an empty file. Trimming per line would leave the BOM
+    /// standing as a one-character term.
+    #[test]
+    fn parse_bom_only_file_yields_no_terms() {
+        assert!(parse_vocabulary("\u{feff}").is_empty());
+        assert!(parse_vocabulary("\u{feff}\n").is_empty());
     }
 
     #[test]
@@ -122,5 +179,108 @@ NixOS
         assert_eq!(load_vocabulary_file(&path).unwrap(), Some(terms));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The property the migration depends on: whatever the writer puts on disk,
+    /// the parser reads back as the same list. Before the `\` escape, `#1` was
+    /// written as a comment line and dropped — and since the same save blanks
+    /// `[general] vocabulary`, the term ended up in neither store.
+    ///
+    /// The corpus is deliberately adversarial about the two characters the
+    /// format gives meaning to, plus ordinary terms that must stay untouched.
+    #[test]
+    fn write_then_parse_round_trips_every_term() {
+        let terms: Vec<String> = [
+            "#1",
+            "#rust",
+            "\\#literal",
+            "\\backslash",
+            "\\",
+            "  #padded",
+            "C# dev",
+            "Claude Code",
+            "NixOS",
+            "whisrs",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vocabulary.txt");
+        write_vocabulary_file(&path, &terms).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(
+            parse_vocabulary(&written),
+            terms,
+            "written form did not round-trip:\n{written}"
+        );
+    }
+
+    /// The two terms that do *not* survive the round trip, pinned so the gap is
+    /// deliberate rather than discovered later: an empty term and a
+    /// whitespace-only term are both dropped, because the parser trims each
+    /// line and skips blanks.
+    ///
+    /// Nothing downstream wants them either. `usable_keyterms`
+    /// (`src/transcription/deepgram.rs`) trims and drops blanks before any
+    /// counting or budgeting, so `Config::validate` and the request builder
+    /// both ignore them; the `whisrs config` editor drops them in
+    /// `parse_csv_list`. A blank entry is not a term anywhere in whisrs.
+    #[test]
+    fn empty_and_whitespace_only_terms_are_dropped_not_round_tripped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vocabulary.txt");
+        let terms = vec![
+            String::new(),
+            "   ".to_string(),
+            "\t".to_string(),
+            "NixOS".to_string(),
+        ];
+        write_vocabulary_file(&path, &terms).unwrap();
+
+        assert_eq!(
+            load_vocabulary_file(&path).unwrap(),
+            Some(vec!["NixOS".to_string()])
+        );
+    }
+
+    /// A `#` term written by the migration is a term, not a comment, and a
+    /// hand-written comment is still a comment.
+    #[test]
+    fn a_leading_hash_term_is_escaped_and_comments_still_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vocabulary.txt");
+        write_vocabulary_file(&path, &["#1".to_string(), "NixOS".to_string()]).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "\\#1\nNixOS\n");
+        assert_eq!(
+            parse_vocabulary("# a real comment\n\\#1\nNixOS\n"),
+            vec!["#1", "NixOS"]
+        );
+    }
+
+    /// The file holds vocabulary that used to live in the 0600 config.toml, so
+    /// splitting it out must not widen who can read it. `fs::write` under the
+    /// usual umask leaves 0644.
+    #[cfg(unix)]
+    #[test]
+    fn written_file_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vocabulary.txt");
+
+        write_vocabulary_file(&path, &["NixOS".to_string()]).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        // A file that already drifted to laxer permissions is tightened, not
+        // left as it was found.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        write_vocabulary_file(&path, &["NixOS".to_string(), "whisrs".to_string()]).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/src/daemon/startup.rs
+++ b/src/daemon/startup.rs
@@ -28,6 +28,38 @@ pub(crate) async fn cleanup_stale_socket(path: &std::path::Path) -> Result<()> {
 /// Returns (Config, Option<warning_message>) — the warning is set when config
 /// parsing fails and defaults are used, so the caller can notify the user.
 pub(crate) fn load_config() -> (Config, Option<String>) {
+    let (mut config, warning) = load_config_toml();
+    merge_vocabulary_file(&mut config);
+    (config, warning)
+}
+
+/// Must run before `validate_config`, so the keyterm limits count the terms
+/// the backends actually receive.
+fn merge_vocabulary_file(config: &mut Config) {
+    use whisrs::config::vocabulary::{load_vocabulary_file, merge_vocabulary, vocabulary_path};
+
+    let path = vocabulary_path();
+    match load_vocabulary_file(&path) {
+        Ok(Some(terms)) if !terms.is_empty() => {
+            let file_count = terms.len();
+            let merged = merge_vocabulary(std::mem::take(&mut config.general.vocabulary), terms);
+            info!(
+                "vocabulary: {file_count} term(s) from {}, {} effective after merging \
+                 with config.toml",
+                path.display(),
+                merged.len()
+            );
+            config.general.vocabulary = merged;
+        }
+        Ok(_) => {}
+        Err(e) => warn!(
+            "failed to read vocabulary file at {}: {e} — ignoring it",
+            path.display()
+        ),
+    }
+}
+
+fn load_config_toml() -> (Config, Option<String>) {
     let config_path = whisrs::config_path();
     if config_path.exists() {
         match std::fs::read_to_string(&config_path) {

--- a/src/daemon/startup.rs
+++ b/src/daemon/startup.rs
@@ -28,18 +28,34 @@ pub(crate) async fn cleanup_stale_socket(path: &std::path::Path) -> Result<()> {
 /// Returns (Config, Option<warning_message>) — the warning is set when config
 /// parsing fails and defaults are used, so the caller can notify the user.
 pub(crate) fn load_config() -> (Config, Option<String>) {
-    let (mut config, warning) = load_config_toml();
-    merge_vocabulary_file(&mut config);
+    load_config_from(
+        &whisrs::config_path(),
+        &whisrs::config::vocabulary::vocabulary_path(),
+    )
+}
+
+/// The body of [`load_config`] against explicit paths, so the whole load order
+/// is testable without mutating `XDG_CONFIG_HOME` (env mutation races with the
+/// parallel test runner).
+///
+/// The merge must run before `validate_config`, so the keyterm limits count the
+/// terms the backends actually receive.
+fn load_config_from(
+    config_path: &std::path::Path,
+    vocabulary_path: &std::path::Path,
+) -> (Config, Option<String>) {
+    let (mut config, warning) = load_config_toml_at(config_path);
+    merge_vocabulary_file_at(&mut config, vocabulary_path);
     (config, warning)
 }
 
-/// Must run before `validate_config`, so the keyterm limits count the terms
-/// the backends actually receive.
-fn merge_vocabulary_file(config: &mut Config) {
-    use whisrs::config::vocabulary::{load_vocabulary_file, merge_vocabulary, vocabulary_path};
+/// Merge `vocabulary.txt` into `[general] vocabulary`, config.toml's terms
+/// first. A missing file is the opt-out; an unreadable one is warned about and
+/// ignored, because the daemon still has to start.
+fn merge_vocabulary_file_at(config: &mut Config, path: &std::path::Path) {
+    use whisrs::config::vocabulary::{load_vocabulary_file, merge_vocabulary};
 
-    let path = vocabulary_path();
-    match load_vocabulary_file(&path) {
+    match load_vocabulary_file(path) {
         Ok(Some(terms)) if !terms.is_empty() => {
             let file_count = terms.len();
             let merged = merge_vocabulary(std::mem::take(&mut config.general.vocabulary), terms);
@@ -59,10 +75,9 @@ fn merge_vocabulary_file(config: &mut Config) {
     }
 }
 
-fn load_config_toml() -> (Config, Option<String>) {
-    let config_path = whisrs::config_path();
+fn load_config_toml_at(config_path: &std::path::Path) -> (Config, Option<String>) {
     if config_path.exists() {
-        match std::fs::read_to_string(&config_path) {
+        match std::fs::read_to_string(config_path) {
             Ok(contents) => match toml::from_str::<Config>(&contents) {
                 Ok(config) => {
                     info!("loaded config from {}", config_path.display());
@@ -327,5 +342,221 @@ pub(crate) fn validate_config(config: &Config) {
     }
     if !config.has_any_backend_configured() {
         warn!("No transcription backend configured. Run 'whisrs setup' to get started.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A config.toml + vocabulary.txt pair in a fresh temp dir.
+    ///
+    /// Both paths are passed explicitly, so nothing here touches
+    /// `XDG_CONFIG_HOME` — mutating the environment races with the parallel
+    /// test runner.
+    fn write_pair(config_toml: &str, vocabulary_txt: Option<&str>) -> (tempfile::TempDir, Config) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, config_toml).expect("write config.toml");
+        let vocab_path = dir.path().join("vocabulary.txt");
+        if let Some(contents) = vocabulary_txt {
+            std::fs::write(&vocab_path, contents).expect("write vocabulary.txt");
+        }
+        let (config, _) = load_config_from(&config_path, &vocab_path);
+        (dir, config)
+    }
+
+    /// The whole point of the feature: terms that live only in vocabulary.txt
+    /// end up in the config the daemon runs on. Deleting the merge call from
+    /// `load_config_from` fails here.
+    #[test]
+    fn vocabulary_file_terms_reach_the_loaded_config() {
+        let (_dir, config) = write_pair(
+            "[general]\nbackend = \"groq\"\n",
+            Some("# keyterms\nNixOS\n\nClaude Code\n"),
+        );
+        assert_eq!(config.general.vocabulary, vec!["NixOS", "Claude Code"]);
+    }
+
+    /// config.toml's terms come first and a term in both stores is kept once.
+    /// Ordering is not cosmetic: Deepgram charges keyterms against a byte and
+    /// word budget in list order, so a reshuffle changes which terms survive.
+    #[test]
+    fn config_toml_terms_come_first_and_duplicates_are_dropped() {
+        let (_dir, config) = write_pair(
+            "[general]\nbackend = \"groq\"\nvocabulary = [\"whisrs\", \"GNOME\"]\n",
+            Some("Deepgram\nwhisrs\nNixOS\n"),
+        );
+        assert_eq!(
+            config.general.vocabulary,
+            vec!["whisrs", "GNOME", "Deepgram", "NixOS"],
+            "config.toml first, then the file's new terms, each term once"
+        );
+    }
+
+    /// The feature is opt-in by creating the file, so no file means the
+    /// config.toml list is passed through untouched.
+    #[test]
+    fn a_missing_vocabulary_file_is_a_no_op() {
+        let (_dir, config) = write_pair(
+            "[general]\nbackend = \"groq\"\nvocabulary = [\"whisrs\"]\n",
+            None,
+        );
+        assert_eq!(config.general.vocabulary, vec!["whisrs"]);
+    }
+
+    /// An unreadable path is warned about and ignored, never fatal: the daemon
+    /// still has to start. A directory is the portable stand-in for a file the
+    /// process cannot read (chmod is a no-op for root in CI).
+    #[test]
+    fn an_unreadable_vocabulary_file_is_a_no_op() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let vocab_path = dir.path().join("vocabulary.txt");
+        std::fs::create_dir(&vocab_path).expect("make vocabulary.txt a directory");
+
+        let mut config: Config = toml::from_str("").expect("empty config uses defaults");
+        config.general.vocabulary = vec!["whisrs".to_string()];
+        merge_vocabulary_file_at(&mut config, &vocab_path);
+
+        assert_eq!(config.general.vocabulary, vec!["whisrs"]);
+    }
+
+    /// The end of the "user added a term" flow: `whisrs config` wrote the whole
+    /// merged list to vocabulary.txt and an empty `vocabulary` to config.toml.
+    /// The daemon must then load exactly the list the user saw in the editor.
+    /// This drives the real writer, not a hand-rolled file.
+    #[test]
+    fn a_migrated_vocabulary_round_trips_back_through_the_daemon() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[general]\nbackend = \"groq\"\nvocabulary = []\n",
+        )
+        .expect("write config.toml");
+        let vocab_path = dir.path().join("vocabulary.txt");
+        let migrated = vec![
+            "whisrs".to_string(),
+            "Hyprland".to_string(),
+            "NixOS".to_string(),
+        ];
+        whisrs::config::vocabulary::write_vocabulary_file(&vocab_path, &migrated)
+            .expect("write vocabulary.txt");
+
+        let (config, _) = load_config_from(&config_path, &vocab_path);
+        assert_eq!(config.general.vocabulary, migrated);
+    }
+
+    /// An unparseable config.toml still gets the vocabulary merge.
+    ///
+    /// `load_config_toml_at` falls back to `default_config()` on a parse or
+    /// read error, and that fallback runs *before* the merge, so a broken
+    /// config.toml does not also cost the user their vocabulary file — which is
+    /// the point, since the file exists for setups where config.toml is
+    /// generated and the user cannot fix it in place. Moving the merge above
+    /// the fallback, or into the `Ok` arm only, breaks this.
+    #[test]
+    fn a_broken_config_toml_still_gets_the_vocabulary_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "this is [ not toml").expect("write config.toml");
+        let vocab_path = dir.path().join("vocabulary.txt");
+        std::fs::write(&vocab_path, "NixOS\nClaude Code\n").expect("write vocabulary.txt");
+
+        let (config, warning) = load_config_from(&config_path, &vocab_path);
+
+        assert_eq!(config.general.vocabulary, vec!["NixOS", "Claude Code"]);
+        let warning = warning.expect("a parse failure must be reported to the user");
+        assert!(
+            warning.contains("using defaults"),
+            "the warning must say defaults were substituted: {warning}"
+        );
+
+        // The other fallback arm: a config.toml that exists but cannot be read
+        // (a directory is the portable stand-in — chmod is a no-op for root).
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::create_dir(&config_path).expect("make config.toml a directory");
+        let vocab_path = dir.path().join("vocabulary.txt");
+        std::fs::write(&vocab_path, "NixOS\n").expect("write vocabulary.txt");
+
+        let (config, warning) = load_config_from(&config_path, &vocab_path);
+        assert_eq!(config.general.vocabulary, vec!["NixOS"]);
+        assert!(warning.is_some(), "an unreadable config must be reported");
+    }
+
+    /// An empty vocabulary.txt plus an empty `[general] vocabulary` yields no
+    /// terms: the file existing is not itself a term, and the merge invents
+    /// nothing.
+    ///
+    /// This deliberately does *not* prove that a deleted term cannot come back.
+    /// That property belongs to the editor's save path, which blanks
+    /// `[general] vocabulary` in the same save that writes the file — see
+    /// `a_deleted_term_cannot_resurrect_from_config_toml` in `src/config/edit.rs`.
+    /// If config.toml still held the term, the merge below would happily
+    /// resurrect it, which is exactly why the save blanks it.
+    #[test]
+    fn an_emptied_vocabulary_file_leaves_the_daemon_with_no_terms() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[general]\nbackend = \"groq\"\nvocabulary = []\n",
+        )
+        .expect("write config.toml");
+        let vocab_path = dir.path().join("vocabulary.txt");
+        whisrs::config::vocabulary::write_vocabulary_file(&vocab_path, &[])
+            .expect("write an empty vocabulary.txt");
+
+        let (config, _) = load_config_from(&config_path, &vocab_path);
+        assert!(
+            config.general.vocabulary.is_empty(),
+            "deleted terms came back: {:?}",
+            config.general.vocabulary
+        );
+    }
+
+    /// The contract that fixes the load order: the merge runs *before*
+    /// `validate_config`, so the Deepgram keyterm warning counts the terms the
+    /// backend actually receives.
+    ///
+    /// `[general] vocabulary` is empty in config.toml, so without the merge
+    /// `deepgram_keyterm_warnings` sees zero usable terms and returns nothing
+    /// at all. The warning existing, and naming the file's term count, is only
+    /// possible if the file reached `validate`.
+    #[test]
+    fn vocabulary_file_terms_are_counted_by_config_validate() {
+        // Well past every keyterm cap, so the "N of M reach Deepgram" warning
+        // is the one that fires.
+        let terms: Vec<String> = (0..1000).map(|i| format!("term{i:04}")).collect();
+        let (_dir, config) = write_pair(
+            "[general]\n\
+             backend = \"deepgram\"\n\
+             \n\
+             [deepgram]\n\
+             api_key = \"test-key\"\n\
+             model = \"nova-3\"\n",
+            Some(&format!("{}\n", terms.join("\n"))),
+        );
+        assert_eq!(
+            config.general.vocabulary.len(),
+            terms.len(),
+            "premise: every term came from vocabulary.txt, none from config.toml"
+        );
+
+        let warnings = config.validate().expect("the config is valid");
+        let warning = warnings
+            .iter()
+            .find(|w| w.message.starts_with("[general] vocabulary: "))
+            .unwrap_or_else(|| {
+                panic!("the file's terms never reached Config::validate: {warnings:?}")
+            });
+        assert!(
+            warning
+                .message
+                .contains(&format!("of {} usable term(s) reach", terms.len())),
+            "the warning must count the file-sourced terms: {}",
+            warning.message
+        );
     }
 }


### PR DESCRIPTION

## What

Optional `vocabulary.txt` next to `config.toml`, folded into `[general] vocabulary` at load. Shape as agreed in the #133 thread: fixed path, no new config key, one term per line (blank lines and `#` lines skipped), a missing file is not an error, merged with config.toml's terms first and duplicates dropped, before `validate` so the keyterm limits count the real list.

When the file exists, `whisrs config` shows the merged list and save writes it to `vocabulary.txt`, with `config.toml` saved with an empty `vocabulary`. Keeping terms in both stores would duplicate them and make editor deletions resurrect at the next load, so the file becomes the single store once it exists.

Vocabulary only. `prompt` and everything else stay in `config.toml`. Documented in `docs/configuration.md`.

## Why

A templated `config.toml` (Nix, chezmoi) is read-only at runtime, so adding one proper noun means a rebuild. Follow-up to #131.

## Tests

534 pass (was 526); the 8 new ones are in `src/config/vocabulary.rs`.

Verified end to end on GNOME Wayland (NixOS): read-only `config.toml` with no `vocabulary` key, all 27 terms in `vocabulary.txt`, startup logs the merge and dictation returns the terms in their configured casing.
