### PR TITLE
fix(nix): give the packaged systemd unit an absolute ExecStart

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,12 @@
             substituteInPlace contrib/99-whisrs.rules \
               --replace-fail /usr/bin/setfacl ${pkgs.acl}/bin/setfacl
 
+            # systemd resolves a non-absolute ExecStart against a compile-time
+            # search path, never $PATH, and no store path is ever in it — the
+            # packaged unit would name a binary systemd cannot find.
+            substituteInPlace contrib/whisrs.service \
+              --replace-fail ExecStart=whisrsd ExecStart=$out/bin/whisrsd
+
             install -Dm644 contrib/whisrs.1 $out/share/man/man1/whisrs.1
             install -Dm644 contrib/whisrsd.1 $out/share/man/man1/whisrsd.1
             install -Dm644 contrib/99-whisrs.rules $out/lib/udev/rules.d/99-whisrs.rules


### PR DESCRIPTION
Fixes #143.

`contrib/whisrs.service` ships `ExecStart=whisrsd` and `flake.nix` installed it verbatim. systemd resolves a non-absolute `ExecStart` against a search path fixed at compile time rather than the shell's `$PATH`, and a store path is never in it — so the unit the Nix package installed named a binary systemd could not find.

#138 fixed this for `whisrs setup`, which rewrites `ExecStart=` when it *copies* the contrib unit. The Nix path never reaches that code: the unit is already installed, so `setup_user_service` takes the "Service already installed" branch and rewrites nothing.

## Change

Substitute the path at build time, mirroring the `setfacl` fix three lines above:

```nix
substituteInPlace contrib/whisrs.service \
  --replace-fail ExecStart=whisrsd ExecStart=$out/bin/whisrsd
```

`--replace-fail` rather than `--replace`, so a future edit to the contrib unit breaks the build instead of silently restoring the old behavior.

## Verification

Built and checked on NixOS (the box #143 was waiting on), with `systemd-analyze --user verify`:

| unit | result |
|---|---|
| `contrib/whisrs.service` (`ExecStart=whisrsd`) | exit 1 — `Command whisrsd is not executable: No such file or directory` |
| built package (`ExecStart=/nix/store/bzmg…-whisrs-0.1.27/bin/whisrsd`) | exit 0 |

`result/bin/whisrsd --version` prints `whisrsd 0.1.27`, so the path the unit now names is real and runnable. The neighbouring udev `setfacl` substitution still resolves correctly — no regression from the adjacent `--replace-fail`.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (582 tests) all pass; the change is Nix-only and touches no Rust.

## Note for a follow-up (pre-existing, not from this PR)

nixpkgs' fixup phase moves the unit out of where `flake.nix` installs it:

```
result/lib/systemd/user -> ../../share/systemd/user
result/share/systemd/user/whisrs.service
```

The real file lands in `share/systemd/user/`, with `lib/systemd/user` left as a relative symlink. Worth knowing for anything documenting the install path or for a NixOS module consuming this package.