### PR TITLE
fix(local-whisper): cut forced splits at silence, keep the post-cut tail (#151)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,7 +234,8 @@ model_path = "~/.local/share/whisrs/models/ggml-base.en.bin"
 # segmentation: how streaming audio is split before decoding.
 # - "silence" (default): split into phrases at natural pauses and decode each
 #   phrase exactly once. No overlap, no dedup — prevents repeated/invented
-#   text. Continuous speech is force-split at 20 s so it still emits.
+#   text. Continuous speech is force-split at the first silent moment after
+#   20 s (hard ceiling 28 s) so it still emits.
 # - "window": legacy 8s/2s overlapping sliding window with text-based dedup.
 # segmentation = "silence"
 # phrase_silence_ms: continuous silence (ms) that ends a phrase in "silence"

--- a/scripts/check-issue55.sh
+++ b/scripts/check-issue55.sh
@@ -8,9 +8,10 @@
 #                           repeated n-grams (the original issue #55 repro)
 #                           and >= 80% ground-truth word coverage, so silently
 #                           dropped words fail too.
-#   2. issue55_nopause.wav  ~28 s of continuous pause-free speech — must be
+#   2. issue55_nopause.wav  ~41 s of continuous pause-free speech — must be
 #                           transcribed in full (>= 80% ground-truth word
-#                           coverage), proving the 20 s max-segment cap emits
+#                           coverage), proving the 20 s soft cap (cutting only
+#                           at silence) and the 28 s hard ceiling both emit
 #                           instead of stalling.
 #
 # Exit code: 0 = both checks pass, 1 = at least one failed.
@@ -49,7 +50,7 @@ WHISRS_ISSUE55_MIN_COVERAGE=0.8 "$BIN" "$WAV" "$MODEL" "$TRUTH" \
     || pause_status=$?
 
 echo
-echo "=== 2/2 no-pause fixture (coverage gate, 20s cap) ==="
+echo "=== 2/2 no-pause fixture (coverage gate, 20s soft cap / 28s hard ceiling) ==="
 nopause_status=0
 WHISRS_ISSUE55_MIN_COVERAGE=0.8 "$BIN" "$NP_WAV" "$MODEL" "$NP_TRUTH" \
     || nopause_status=$?

--- a/scripts/gen-issue55-fixture.sh
+++ b/scripts/gen-issue55-fixture.sh
@@ -6,13 +6,14 @@
 # separated by 2-6 s silence gaps, including a trailing incomplete phrase
 # right before a pause (the golden repro for the repetition bug).
 #
-# Also builds a continuous no-pause fixture (~28 s of speech with no gaps)
-# used to prove that pause-free dictation still emits (20 s max-segment cap).
+# Also builds a continuous no-pause fixture (~41 s of speech with no gaps)
+# used to prove that pause-free dictation still emits past both the 20 s soft
+# cap and the 28 s hard ceiling.
 #
 # Output (gitignored, never commit the WAVs):
 #   fixtures/issue55.wav           16 kHz mono s16 test audio (~45 s, pauses)
 #   fixtures/issue55.txt           ground-truth transcript (one line)
-#   fixtures/issue55_nopause.wav   16 kHz mono s16 test audio (~28 s, no gaps)
+#   fixtures/issue55_nopause.wav   16 kHz mono s16 test audio (~41 s, no gaps)
 #   fixtures/issue55_nopause.txt   ground-truth transcript (one line)
 #
 # Requires: espeak-ng, ffmpeg
@@ -36,7 +37,7 @@ for arg in "$@"; do
     case "$arg" in
         --force) FORCE=1 ;;
         -h|--help)
-            sed -n '2,17p' "$0" | sed 's/^# \?//'
+            sed -n '2,18p' "$0" | sed 's/^# \?//'
             exit 0
             ;;
         *)
@@ -128,15 +129,20 @@ info "Wrote:" "$OUT_TXT (ground truth)"
 # ---------------------------------------------------------------------------
 # Continuous no-pause fixture: one long run-on utterance with no punctuation
 # (espeak-ng inserts pauses at clause boundaries, so the text avoids them).
-# Exercises the streaming max-segment cap: continuous speech past 20 s must
-# still be emitted in full.
+# Long enough (~41 s of speech) to exceed both the 20 s soft cap and the 28 s
+# hard ceiling, so both forced-cut paths are exercised: the soft cap only
+# cuts at a genuinely silent frame, and the hard ceiling cuts unconditionally
+# at the quietest frame if none ever appears.
 # ---------------------------------------------------------------------------
 NOPAUSE_TEXT="this recording keeps going without any pauses so the streaming \
 backend must split the audio on its own the quick brown fox jumps over the \
 lazy dog while the developer keeps talking about testing the local whisper \
-backend and the words continue to flow one after another until the very end \
-of the recording where the final words prove the whole utterance was \
-transcribed"
+streaming backend and the words continue to flow one after another until \
+the very end of the recording where the final words prove the whole \
+utterance was transcribed and even though the sentence keeps running past \
+twenty seconds the pipeline should still wait for a quiet moment before it \
+cuts the audio and falls back to the hard ceiling a little later if none \
+ever comes"
 
 NP_RAW="$WORK_DIR/nopause_raw.wav"
 NP_SEG="$WORK_DIR/nopause_seg.wav"

--- a/src/transcription/local_whisper.rs
+++ b/src/transcription/local_whisper.rs
@@ -9,6 +9,13 @@
 //! in issue #55, so the only prompt ever passed to the decoder is the static
 //! vocabulary prompt from the user's config.
 //!
+//! Pause-free speech is force-cut by the splitter before it outgrows
+//! whisper's 30 s context window (soft cap at a genuinely silent frame, hard
+//! ceiling regardless); the phrase after such a cut is decoded on its own,
+//! and its spurious leading capital — whisper capitalizes each decode
+//! independently — is lowercased (see
+//! [`Phrase::continuation`](super::phrase_split::Phrase::continuation)).
+//!
 //! The legacy sliding-window mode (`segmentation = "window"`) keeps the
 //! 8s/2s overlapping windows with text-based n-gram overlap removal
 //! (`asr_dedup::TextDedup`) for lower-latency partial output.
@@ -139,14 +146,30 @@ impl LocalWhisperBackend {
 
         while let Some(chunk) = audio_rx.recv().await {
             for phrase in splitter.feed(&chunk) {
-                state = decode_phrase(ctx, state, phrase, config, &text_tx).await?;
+                state = decode_phrase(
+                    ctx,
+                    state,
+                    phrase.samples,
+                    phrase.continuation,
+                    config,
+                    &text_tx,
+                )
+                .await?;
             }
         }
 
         // End of stream: flush the trailing in-progress phrase (if any),
         // exactly once. No rewind, no overlap re-send.
         if let Some(phrase) = splitter.flush() {
-            decode_phrase(ctx, state, phrase, config, &text_tx).await?;
+            decode_phrase(
+                ctx,
+                state,
+                phrase.samples,
+                phrase.continuation,
+                config,
+                &text_tx,
+            )
+            .await?;
         }
 
         Ok(())
@@ -289,6 +312,28 @@ fn i16_to_f32(samples: &[i16]) -> Vec<f32> {
         .collect()
 }
 
+/// Lowercase the first character of `text` if it is an uppercase letter.
+///
+/// Applied to continuation phrases (those starting at a forced mid-speech
+/// cut): whisper capitalizes each decode independently, so a continuation's
+/// leading capital is spurious mid-sentence. Char-safe for UTF-8;
+/// `char::to_lowercase` may expand to multiple chars.
+#[cfg(any(feature = "local-whisper", test))]
+fn decapitalize_first(text: &str) -> String {
+    let mut chars = text.chars();
+    match chars.next() {
+        // The standalone pronoun "I" (and contractions: "I'm", "I'll") is
+        // correctly capitalized mid-sentence; lowercasing it is visibly wrong.
+        Some('I') if !chars.clone().next().is_some_and(|c| c.is_alphabetic()) => text.to_string(),
+        Some(c) if c.is_alphabetic() && c.is_uppercase() => {
+            let mut out: String = c.to_lowercase().collect();
+            out.push_str(chars.as_str());
+            out
+        }
+        _ => text.to_string(),
+    }
+}
+
 /// Create a decoder state for a stream (or a single batch call).
 ///
 /// Creating a state allocates all of whisper.cpp's KV and compute buffers —
@@ -304,6 +349,8 @@ fn create_state(ctx: &whisper_rs::WhisperContext) -> anyhow::Result<whisper_rs::
 /// Decode a single phrase and send its trimmed text over `text_tx`.
 ///
 /// Each phrase is decoded exactly once with only the static config prompt.
+/// `continuation` marks a phrase starting at a forced mid-speech cut; its
+/// spurious leading capital is lowercased before sending.
 /// The stream's reusable `state` is taken by value (it has to move into the
 /// blocking task) and handed back on return; if the decode fails or the task
 /// panics, that state is discarded and a fresh one is created to keep the
@@ -312,6 +359,7 @@ async fn decode_phrase(
     ctx: &Arc<whisper_rs::WhisperContext>,
     mut state: whisper_rs::WhisperState,
     mut phrase: Vec<i16>,
+    continuation: bool,
     config: &TranscriptionConfig,
     text_tx: &mpsc::Sender<String>,
 ) -> anyhow::Result<whisper_rs::WhisperState> {
@@ -337,8 +385,13 @@ async fn decode_phrase(
         Ok((state, Ok(text))) => {
             let text = text.trim();
             if !text.is_empty() {
+                let text = if continuation {
+                    decapitalize_first(text)
+                } else {
+                    text.to_string()
+                };
                 debug!("phrase produced: {:?}", text);
-                text_tx.send(text.to_string()).await.ok();
+                text_tx.send(text).await.ok();
             }
             Ok(state)
         }
@@ -515,6 +568,45 @@ mod tests {
         assert_eq!(f32_samples[0], 0.0);
         assert!((f32_samples[1] - 1.0).abs() < 0.001);
         assert!((f32_samples[2] + 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn decapitalize_first_lowercases_ascii_uppercase() {
+        assert_eq!(decapitalize_first("Hello world"), "hello world");
+    }
+
+    #[test]
+    fn decapitalize_first_leaves_lowercase_unchanged() {
+        assert_eq!(decapitalize_first("hello World"), "hello World");
+    }
+
+    #[test]
+    fn decapitalize_first_leaves_digit_and_punct_unchanged() {
+        assert_eq!(decapitalize_first("42 things"), "42 things");
+        assert_eq!(decapitalize_first("...And then"), "...And then");
+    }
+
+    #[test]
+    fn decapitalize_first_handles_multibyte_uppercase() {
+        assert_eq!(decapitalize_first("École normale"), "école normale");
+    }
+
+    #[test]
+    fn decapitalize_first_handles_empty_string() {
+        assert_eq!(decapitalize_first(""), "");
+    }
+
+    #[test]
+    fn decapitalize_first_keeps_pronoun_i() {
+        assert_eq!(decapitalize_first("I think so"), "I think so");
+        assert_eq!(decapitalize_first("I'm here"), "I'm here");
+        assert_eq!(decapitalize_first("I"), "I");
+    }
+
+    #[test]
+    fn decapitalize_first_still_lowercases_i_words() {
+        assert_eq!(decapitalize_first("It works"), "it works");
+        assert_eq!(decapitalize_first("Instead of that"), "instead of that");
     }
 
     #[test]

--- a/src/transcription/phrase_split.rs
+++ b/src/transcription/phrase_split.rs
@@ -11,12 +11,22 @@
 //! - A phrase ends once `split_silence_frames` consecutive silent frames
 //!   follow speech.
 //! - Phrases with fewer than `min_speech_frames` frames containing speech are
-//!   discarded as noise.
+//!   discarded as noise — unless the phrase continues a forced cut, in which
+//!   case a single speech frame is enough to keep it (speech was flowing at
+//!   the cut, so a short tail is real speech, not a noise blip). A
+//!   continuation with zero speech frames is still discarded.
 //! - Emitted phrases include up to `pad_frames` of surrounding silence.
-//! - A phrase that reaches `max_phrase_frames` without a silence split is
-//!   force-split at the quietest recent frame boundary, so continuous
+//! - A phrase that reaches `max_phrase_frames` (the soft cap) without a
+//!   silence split is cut at the quietest *sub-threshold* frame in the recent
+//!   lookback window. If every recent frame is voiced, the cut is deferred —
+//!   the search re-runs each frame — until the first sub-threshold frame
+//!   arrives or the phrase reaches `hard_max_phrase_frames` (the hard
+//!   ceiling, sized to stay inside whisper's 30 s context window), where it
+//!   is cut at the quietest recent frame even if voiced, so continuous
 //!   pause-free speech still emits. No padding is added at a forced boundary
 //!   (the audio is contiguous, and padding would duplicate samples).
+//! - Each emitted [`Phrase`] records whether it *starts* at a forced cut
+//!   (`continuation`), so a decoder can treat it as mid-sentence text.
 //! - [`PhraseSplitter::flush`] emits the trailing in-progress phrase at end of
 //!   stream (if it carries enough speech) exactly once.
 
@@ -28,10 +38,25 @@ const FRAME_MS: usize = 100;
 const PAD_MS: usize = 100;
 /// Minimum speech (frames containing speech, ~ms) required to keep a phrase.
 const MIN_PHRASE_SPEECH_MS: usize = 250;
-/// Hard cap on phrase length before a forced split.
+/// Soft cap on phrase length: past this, cut at the first sub-threshold
+/// frame found in the lookback window.
 const MAX_PHRASE_SECS: usize = 20;
+/// Hard ceiling on phrase length: past this, cut at the quietest recent
+/// frame even if it is voiced. Sized to stay inside whisper's 30 s context
+/// window.
+const HARD_MAX_PHRASE_SECS: usize = 28;
 /// How far back to look for the quietest frame when force-splitting.
 const QUIET_SEARCH_MS: usize = 2000;
+
+/// A completed phrase of contiguous audio.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Phrase {
+    /// The phrase samples (contiguous input audio plus silence padding).
+    pub samples: Vec<i16>,
+    /// True when this phrase starts at a forced cut boundary (mid-speech),
+    /// i.e. it continues the previous phrase rather than starting fresh.
+    pub continuation: bool,
+}
 
 /// Incremental silence-delimited phrase splitter over i16 PCM samples.
 pub struct PhraseSplitter {
@@ -43,6 +68,7 @@ pub struct PhraseSplitter {
     max_phrase_frames: usize,
     pad_frames: usize,
     quiet_search_frames: usize,
+    hard_max_phrase_frames: usize,
 
     // Rolling state. `buffer` holds samples not yet consumed by an emitted or
     // discarded phrase; `energies[i]` is the RMS of frame `i` of `buffer`.
@@ -57,6 +83,8 @@ pub struct PhraseSplitter {
     speech_frames: usize,
     /// Consecutive silent frames at the current analysis position.
     trailing_silence: usize,
+    /// True while the open phrase started at a forced cut boundary.
+    continuation: bool,
 }
 
 impl PhraseSplitter {
@@ -74,10 +102,16 @@ impl PhraseSplitter {
             (MAX_PHRASE_SECS * 1000 / FRAME_MS).max(2),
             PAD_MS / FRAME_MS,
             (QUIET_SEARCH_MS / FRAME_MS).max(1),
+            (HARD_MAX_PHRASE_SECS * 1000 / FRAME_MS).max(2),
         )
     }
 
     /// Create a splitter with explicit frame-level parameters (used by tests).
+    ///
+    /// `max_phrase_frames` is the soft cap (cut only at a sub-threshold
+    /// frame); `hard_max_phrase_frames` is the hard ceiling (cut at the
+    /// quietest recent frame regardless), clamped to at least the soft cap.
+    #[allow(clippy::too_many_arguments)]
     pub fn with_params(
         frame_len: usize,
         threshold: f64,
@@ -86,15 +120,18 @@ impl PhraseSplitter {
         max_phrase_frames: usize,
         pad_frames: usize,
         quiet_search_frames: usize,
+        hard_max_phrase_frames: usize,
     ) -> Self {
+        let max_phrase_frames = max_phrase_frames.max(2);
         Self {
             frame_len: frame_len.max(1),
             threshold,
             split_silence_frames: split_silence_frames.max(1),
             min_speech_frames: min_speech_frames.max(1),
-            max_phrase_frames: max_phrase_frames.max(2),
+            max_phrase_frames,
             pad_frames,
             quiet_search_frames: quiet_search_frames.max(1),
+            hard_max_phrase_frames: hard_max_phrase_frames.max(max_phrase_frames),
             buffer: Vec::new(),
             energies: Vec::new(),
             in_phrase: false,
@@ -102,11 +139,12 @@ impl PhraseSplitter {
             phrase_start_frame: 0,
             speech_frames: 0,
             trailing_silence: 0,
+            continuation: false,
         }
     }
 
     /// Feed samples; returns zero or more completed phrases in FIFO order.
-    pub fn feed(&mut self, samples: &[i16]) -> Vec<Vec<i16>> {
+    pub fn feed(&mut self, samples: &[i16]) -> Vec<Phrase> {
         self.buffer.extend_from_slice(samples);
         let mut out = Vec::new();
         // Analyze every complete frame not yet analyzed. `process_frame` may
@@ -123,10 +161,10 @@ impl PhraseSplitter {
 
     /// End of stream: emit the trailing in-progress phrase, if it carries
     /// enough speech. Resets the splitter; subsequent calls return `None`.
-    pub fn flush(&mut self) -> Option<Vec<i16>> {
+    pub fn flush(&mut self) -> Option<Phrase> {
         // A partial (<1 frame) unanalyzed tail without an open phrase can hold
         // at most one frame of speech — below any sensible minimum. Discard.
-        if !self.in_phrase || self.speech_frames < self.min_speech_frames {
+        if !self.in_phrase || !self.keep_phrase() {
             self.clear();
             return None;
         }
@@ -139,13 +177,25 @@ impl PhraseSplitter {
         } else {
             self.buffer.len()
         };
-        let phrase = self.buffer[self.emit_start_frame * self.frame_len..end_sample].to_vec();
+        let phrase = Phrase {
+            samples: self.buffer[self.emit_start_frame * self.frame_len..end_sample].to_vec(),
+            continuation: self.continuation,
+        };
         self.clear();
         Some(phrase)
     }
 
+    /// Noise gate: keep a phrase carrying at least `min_speech_frames` of
+    /// speech — or any speech at all when it continues a forced cut, since
+    /// speech was flowing at the cut and a short tail is real speech, not a
+    /// noise blip. A continuation with zero speech frames is still discarded.
+    fn keep_phrase(&self) -> bool {
+        self.speech_frames >= self.min_speech_frames
+            || (self.continuation && self.speech_frames >= 1)
+    }
+
     /// Process the just-analyzed frame `i` (index into `energies`).
-    fn process_frame(&mut self, i: usize, energy: f64, out: &mut Vec<Vec<i16>>) {
+    fn process_frame(&mut self, i: usize, energy: f64, out: &mut Vec<Phrase>) {
         let silent = energy < self.threshold;
 
         if !self.in_phrase {
@@ -162,6 +212,8 @@ impl PhraseSplitter {
                 self.emit_start_frame = i.saturating_sub(self.pad_frames);
                 self.speech_frames = 1;
                 self.trailing_silence = 0;
+                // Natural onset: this phrase does not continue a forced cut.
+                self.continuation = false;
             }
             return;
         }
@@ -177,26 +229,35 @@ impl PhraseSplitter {
             self.trailing_silence = 0;
         }
 
-        // Forced split: phrase reached the hard cap without a silence gap.
-        if i + 1 - self.phrase_start_frame >= self.max_phrase_frames {
+        // Length caps. Past the hard ceiling, cut unconditionally at the
+        // quietest recent frame; past the soft cap, cut only at a genuinely
+        // sub-threshold frame, deferring (re-checked every frame) until one
+        // arrives.
+        let phrase_len = i + 1 - self.phrase_start_frame;
+        if phrase_len >= self.hard_max_phrase_frames {
             self.force_split(i, out);
+        } else if phrase_len >= self.max_phrase_frames {
+            self.try_soft_split(i, out);
         }
     }
 
     /// Natural end of phrase: enough consecutive silence after speech.
-    fn end_phrase(&mut self, i: usize, out: &mut Vec<Vec<i16>>) {
+    fn end_phrase(&mut self, i: usize, out: &mut Vec<Phrase>) {
         // One past the last frame that contained speech.
         let speech_end = i + 1 - self.trailing_silence;
         let end_frame = (speech_end + self.pad_frames).min(self.energies.len());
 
-        if self.speech_frames >= self.min_speech_frames {
-            out.push(
-                self.buffer[self.emit_start_frame * self.frame_len..end_frame * self.frame_len]
+        if self.keep_phrase() {
+            out.push(Phrase {
+                samples: self.buffer
+                    [self.emit_start_frame * self.frame_len..end_frame * self.frame_len]
                     .to_vec(),
-            );
+                continuation: self.continuation,
+            });
         }
 
         self.in_phrase = false;
+        self.continuation = false;
         self.speech_frames = 0;
         self.trailing_silence = 0;
         // Keep up to `pad_frames` of the gap as leading padding for the next
@@ -209,13 +270,11 @@ impl PhraseSplitter {
         self.drop_frames(keep_from);
     }
 
-    /// Forced split at the cap: cut at the quietest recent frame boundary so
-    /// we are least likely to cut mid-word. The quietest frame starts the
-    /// next phrase; no padding is duplicated across the boundary.
-    fn force_split(&mut self, i: usize, out: &mut Vec<Vec<i16>>) {
-        let search_start = (i + 1)
-            .saturating_sub(self.quiet_search_frames)
-            .max(self.phrase_start_frame + 1);
+    /// Forced split at the hard ceiling: cut at the quietest recent frame
+    /// boundary — voiced or not — so a pause-free phrase still emits before
+    /// it outgrows the decoder's context window.
+    fn force_split(&mut self, i: usize, out: &mut Vec<Phrase>) {
+        let search_start = self.split_search_start(i);
         let mut split_frame = search_start;
         let mut min_energy = f64::INFINITY;
         for j in search_start..=i {
@@ -224,16 +283,52 @@ impl PhraseSplitter {
                 split_frame = j;
             }
         }
+        self.cut_at(split_frame, out);
+    }
 
-        out.push(
-            self.buffer[self.emit_start_frame * self.frame_len..split_frame * self.frame_len]
+    /// Soft-cap split: cut at the quietest *sub-threshold* frame in the
+    /// lookback window, if any. When every recent frame is voiced this does
+    /// nothing — the search re-runs on each subsequent frame, so the first
+    /// arriving sub-threshold frame becomes the cut point.
+    fn try_soft_split(&mut self, i: usize, out: &mut Vec<Phrase>) {
+        let search_start = self.split_search_start(i);
+        let mut split_frame = None;
+        let mut min_energy = f64::INFINITY;
+        for j in search_start..=i {
+            let e = self.energies[j];
+            if e < self.threshold && e < min_energy {
+                min_energy = e;
+                split_frame = Some(j);
+            }
+        }
+        if let Some(split_frame) = split_frame {
+            self.cut_at(split_frame, out);
+        }
+    }
+
+    /// First frame eligible as a forced-cut point when processing frame `i`.
+    fn split_search_start(&self, i: usize) -> usize {
+        (i + 1)
+            .saturating_sub(self.quiet_search_frames)
+            .max(self.phrase_start_frame + 1)
+    }
+
+    /// Cut the open phrase at `split_frame`: emit everything before it; the
+    /// split frame starts the remainder, which continues as an open phrase
+    /// marked as a continuation. No padding is duplicated across the
+    /// boundary (the audio is contiguous).
+    fn cut_at(&mut self, split_frame: usize, out: &mut Vec<Phrase>) {
+        out.push(Phrase {
+            samples: self.buffer
+                [self.emit_start_frame * self.frame_len..split_frame * self.frame_len]
                 .to_vec(),
-        );
+            continuation: self.continuation,
+        });
 
-        // The remainder continues as an open phrase starting at the split.
         self.drop_frames(split_frame);
         self.phrase_start_frame = 0;
         self.emit_start_frame = 0;
+        self.continuation = true;
         self.speech_frames = self
             .energies
             .iter()
@@ -264,6 +359,7 @@ impl PhraseSplitter {
         self.phrase_start_frame = 0;
         self.speech_frames = 0;
         self.trailing_silence = 0;
+        self.continuation = false;
     }
 }
 
@@ -276,10 +372,16 @@ mod tests {
     const QUIET_SPEECH: i16 = 500; // ~0.015 — voiced but the quietest around
 
     /// frame_len=10, threshold=0.01, split after 3 silent frames, min 2 speech
-    /// frames, cap at 100 frames, 1 pad frame, search 5 frames for the
-    /// quietest split point.
+    /// frames, soft cap at 100 frames, 1 pad frame, search 5 frames for the
+    /// quietest split point, hard ceiling at 140 frames.
     fn splitter() -> PhraseSplitter {
-        PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 100, 1, 5)
+        PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 100, 1, 5, 140)
+    }
+
+    /// Splitter that hits its caps quickly: soft cap 6 frames, search 3,
+    /// hard ceiling `hard` frames.
+    fn capped_splitter(hard: usize) -> PhraseSplitter {
+        PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 6, 1, 3, hard)
     }
 
     fn frames(pattern: &[(i16, usize)]) -> Vec<i16> {
@@ -288,6 +390,14 @@ mod tests {
             out.extend(std::iter::repeat_n(value, count * FRAME));
         }
         out
+    }
+
+    /// Concatenate the emitted phrases' samples in order.
+    fn rejoin(phrases: &[Phrase]) -> Vec<i16> {
+        phrases
+            .iter()
+            .flat_map(|p| p.samples.iter().copied())
+            .collect()
     }
 
     #[test]
@@ -300,9 +410,9 @@ mod tests {
 
         assert_eq!(phrases.len(), 2);
         // Phrase 1: 1 pad + 5 speech + 1 pad frames.
-        assert_eq!(phrases[0].len(), 7 * FRAME);
+        assert_eq!(phrases[0].samples.len(), 7 * FRAME);
         // Phrase 2: 1 pad + 3 speech + 1 pad frames.
-        assert_eq!(phrases[1].len(), 5 * FRAME);
+        assert_eq!(phrases[1].samples.len(), 5 * FRAME);
     }
 
     #[test]
@@ -312,7 +422,7 @@ mod tests {
         let phrases = s.feed(&audio);
 
         assert_eq!(phrases.len(), 1);
-        let p = &phrases[0];
+        let p = &phrases[0].samples;
         assert_eq!(p.len(), 6 * FRAME);
         // Leading pad frame is silence, then speech, then trailing pad frame.
         assert!(p[..FRAME].iter().all(|&x| x == 0));
@@ -328,8 +438,8 @@ mod tests {
 
         assert_eq!(phrases.len(), 1);
         // No silence exists before the speech: 4 speech + 1 trailing pad.
-        assert_eq!(phrases[0].len(), 5 * FRAME);
-        assert_eq!(phrases[0][0], SPEECH);
+        assert_eq!(phrases[0].samples.len(), 5 * FRAME);
+        assert_eq!(phrases[0].samples[0], SPEECH);
     }
 
     #[test]
@@ -361,28 +471,74 @@ mod tests {
     }
 
     #[test]
-    fn cap_force_splits_at_quietest_frame() {
-        // Cap at 6 frames; quiet-but-voiced frame at index 4 should become
-        // the split point (start of the next phrase).
-        let mut s = PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 6, 1, 3);
-        let audio = frames(&[(SPEECH, 4), (QUIET_SPEECH, 1), (SPEECH, 3)]);
+    fn cap_split_lands_on_dip_not_quiet_voiced_frame() {
+        // The quiet-but-voiced frame at index 4 (rms ~0.015, above the 0.01
+        // threshold) is the quietest around when the soft cap fires, but it
+        // is not silence: the cut must defer past it and land on the true
+        // sub-threshold dip at index 8.
+        let mut s = capped_splitter(20);
+        let audio = frames(&[
+            (SPEECH, 4),
+            (QUIET_SPEECH, 1),
+            (SPEECH, 3),
+            (0, 1),
+            (SPEECH, 2),
+        ]);
         let mut phrases = s.feed(&audio);
         phrases.extend(s.flush());
 
         assert_eq!(phrases.len(), 2);
-        // First phrase: frames 0..4 (split before the quiet frame).
-        assert_eq!(phrases[0].len(), 4 * FRAME);
-        assert!(phrases[0].iter().all(|&x| x == SPEECH));
-        // Continuation: quiet frame + remaining speech, flushed at end.
-        assert_eq!(phrases[1].len(), 4 * FRAME);
-        assert_eq!(phrases[1][0], QUIET_SPEECH);
+        // First phrase runs through the quiet-but-voiced frame to the dip.
+        assert_eq!(phrases[0].samples.len(), 8 * FRAME);
+        assert_eq!(phrases[0].samples[4 * FRAME], QUIET_SPEECH);
+        assert!(!phrases[0].continuation);
+        // Continuation starts at the dip, flushed at end.
+        assert_eq!(phrases[1].samples[0], 0);
+        assert!(phrases[1].continuation);
+        assert_eq!(rejoin(&phrases), audio);
+    }
+
+    #[test]
+    fn soft_cap_defers_until_first_dip() {
+        // All-voiced speech past the soft cap (6): no cut until the first
+        // sub-threshold frame arrives (index 9, before the ceiling of 20),
+        // and the cut lands exactly on it.
+        let mut s = capped_splitter(20);
+        let audio = frames(&[(SPEECH, 9), (0, 1), (SPEECH, 2)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert_eq!(phrases.len(), 2);
+        assert_eq!(phrases[0].samples.len(), 9 * FRAME);
+        assert!(phrases[0].samples.iter().all(|&x| x == SPEECH));
+        assert_eq!(phrases[1].samples[0], 0, "cut must land on the dip");
+        assert_eq!(rejoin(&phrases), audio);
+    }
+
+    #[test]
+    fn hard_ceiling_forces_voiced_cut() {
+        // All-voiced speech with no dip ever: the soft cap keeps deferring,
+        // and the hard ceiling (10) forces a cut on a voiced frame via the
+        // unconditional argmin.
+        let mut s = capped_splitter(10);
+        let audio = frames(&[(SPEECH, 14)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert_eq!(phrases.len(), 2);
+        // Ceiling fired at frame 10; argmin over the 3-frame lookback of
+        // equal energies picks its start (frame 7).
+        assert_eq!(phrases[0].samples.len(), 7 * FRAME);
+        assert!(!phrases[0].continuation);
+        assert!(phrases[1].continuation);
+        assert_eq!(rejoin(&phrases), audio);
     }
 
     #[test]
     fn continuous_speech_is_emitted_without_loss_or_duplication() {
-        // 25 frames of pause-free speech with a cap of 6: every sample must be
-        // emitted exactly once across forced splits + final flush.
-        let mut s = PhraseSplitter::with_params(FRAME, 0.01, 3, 2, 6, 1, 3);
+        // 25 frames of pause-free speech with a ceiling of 8: every sample
+        // must be emitted exactly once across forced splits + final flush.
+        let mut s = capped_splitter(8);
         let audio = frames(&[(SPEECH, 25)]);
         let mut phrases = s.feed(&audio);
         phrases.extend(s.flush());
@@ -392,7 +548,94 @@ mod tests {
             "expected multiple forced splits, got {}",
             phrases.len()
         );
-        let rejoined: Vec<i16> = phrases.into_iter().flatten().collect();
+        assert!(!phrases[0].continuation);
+        assert!(phrases[1..].iter().all(|p| p.continuation));
+        let rejoined = rejoin(&phrases);
+        assert_eq!(rejoined, audio);
+    }
+
+    #[test]
+    fn continuation_flag_tracks_forced_cuts() {
+        // Natural phrases carry continuation == false.
+        let mut s = splitter();
+        let audio = frames(&[(0, 2), (SPEECH, 5), (0, 4), (SPEECH, 3), (0, 4)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+        assert_eq!(phrases.len(), 2);
+        assert!(phrases.iter().all(|p| !p.continuation));
+
+        // A forced cut marks the remainder as a continuation; the next
+        // naturally started phrase is not one.
+        let mut s = capped_splitter(10);
+        let audio = frames(&[
+            (SPEECH, 4),
+            (0, 1),
+            (SPEECH, 4),
+            (0, 4),
+            (SPEECH, 3),
+            (0, 4),
+        ]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+        assert_eq!(phrases.len(), 3);
+        assert!(!phrases[0].continuation);
+        assert!(phrases[1].continuation);
+        assert!(!phrases[2].continuation);
+    }
+
+    #[test]
+    fn short_continuation_tail_survives_natural_end() {
+        // min_speech = 3. After a forced cut, a 1-speech-frame tail followed
+        // by a natural silence end must be emitted via the continuation
+        // bypass, not dropped as a noise blip.
+        let mut s = PhraseSplitter::with_params(FRAME, 0.01, 3, 3, 6, 1, 3, 10);
+        let audio = frames(&[(SPEECH, 6), (0, 1), (SPEECH, 1), (0, 4)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert_eq!(phrases.len(), 2);
+        assert!(phrases[1].continuation);
+        // Dip frame + 1 speech frame + 1 trailing pad.
+        assert_eq!(phrases[1].samples.len(), 3 * FRAME);
+        assert!(phrases[1].samples[FRAME..2 * FRAME]
+            .iter()
+            .all(|&x| x == SPEECH));
+    }
+
+    #[test]
+    fn continuation_with_zero_speech_is_discarded() {
+        // The remainder after a forced cut holds no speech at all: the
+        // continuation bypass must not resurrect pure silence.
+        let mut s = capped_splitter(20);
+        let audio = frames(&[(SPEECH, 8), (0, 4)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert_eq!(phrases.len(), 1);
+        assert_eq!(phrases[0].samples.len(), 8 * FRAME);
+    }
+
+    #[test]
+    fn forced_cut_tail_is_not_discarded_at_flush() {
+        // Production-ratio params: frame=10, threshold 0.01, split_silence 15,
+        // min_speech 3, soft cap 200, pad 1, quiet search 20, ceiling 280.
+        let mut s = PhraseSplitter::with_params(FRAME, 0.01, 15, 3, 200, 1, 20, 280);
+        // 199 frames of speech, a genuine sub-threshold dip at frame 199,
+        // then one more speech frame. The cut lands on the dip; the
+        // 1-speech-frame tail after it must still be emitted at flush via
+        // the continuation bypass of the noise gate.
+        let audio = frames(&[(SPEECH, 199), (0, 1), (SPEECH, 1)]);
+        let mut phrases = s.feed(&audio);
+        phrases.extend(s.flush());
+
+        assert_eq!(phrases.len(), 2);
+        assert!(phrases[1].continuation);
+        let rejoined = rejoin(&phrases);
+        assert_eq!(
+            rejoined.len(),
+            audio.len(),
+            "forced-cut tail was dropped at flush (samples lost)"
+        );
         assert_eq!(rejoined, audio);
     }
 
@@ -405,7 +648,8 @@ mod tests {
 
         let phrase = s.flush().expect("trailing phrase should flush");
         // 1 pad + 4 speech + 1 trailing silence frame (<= pad, kept).
-        assert_eq!(phrase.len(), 6 * FRAME);
+        assert_eq!(phrase.samples.len(), 6 * FRAME);
+        assert!(!phrase.continuation);
         assert!(s.flush().is_none(), "flush must emit exactly once");
     }
 
@@ -418,7 +662,7 @@ mod tests {
 
         let phrase = s.flush().expect("trailing phrase should flush");
         // Trimmed to 1 pad + 4 speech + 1 pad.
-        assert_eq!(phrase.len(), 6 * FRAME);
+        assert_eq!(phrase.samples.len(), 6 * FRAME);
     }
 
     #[test]


### PR DESCRIPTION
Closes #151.

In `segmentation = "silence"`, the local-whisper force split picked the quietest frame in the 2 s lookback without checking it against the silence threshold, so pause-free speech was cut mid-word. The short tail after the cut was then zero-padded into a blind decode or silently discarded by the flush noise gate.

Prompt carry-over (the reporter's proposal) stays rejected: feeding decoded text back into the decoder is what caused the #55 repetition loops. The fix lives entirely in the splitter.

- **Cut only at silence.** The 20 s cap is now a soft cap: at the cap, cut at the quietest sub-threshold frame in the lookback if one exists, otherwise defer and cut at the first sub-threshold frame that arrives. A 28 s hard ceiling keeps the old unconditional quietest-frame cut so a truly gapless phrase still emits inside whisper's 30 s window.
- **Keep the tail.** `flush()` and `end_phrase()` no longer apply the `min_speech_frames` gate to a post-cut continuation carrying real speech, so a short tail is never dropped.
- **Heal the seam.** Phrases carry a `continuation` flag; a continuation's first word is decapitalized so a forced seam stops reading as a fresh sentence.
- The `check-issue55` no-pause fixture is lengthened to ~41 s so both the soft-cap and hard-ceiling paths stay exercised.

Verified: `check-issue55.sh` both gates green on real inference (repetition-free, 93.2% coverage), full test suite green, and manually on Hyprland with local whisper (`base.en`) — the 20 s+ seam reads coherently, the post-cut tail is preserved, and no words are lost.

The configurable cap (the reporter's secondary ask) is deliberately deferred: with cuts landing only in real silence, it is mitigation, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
